### PR TITLE
fix(auth): add +91 prefix to resend OTP phone number

### DIFF
--- a/lib/features/auth/application/otp_entry_controller.dart
+++ b/lib/features/auth/application/otp_entry_controller.dart
@@ -313,7 +313,7 @@ class OtpEntryController extends StateNotifier<OtpEntryState> {
     );
 
     await _repository.resendOtp(
-      phoneNumber: _phoneNumber,
+      phoneNumber: '+91$_phoneNumber',
       onCodeSent: (session) {
         if (!mounted) return;
         _resendToken = session.resendToken;


### PR DESCRIPTION
## Summary

The `resend()` method in `OtpEntryController` was passing the raw 10-digit phone number to `PhoneAuthRepository.resendOtp()` instead of the E.164 formatted number (`+91XXXXXXXXXX`). This caused silent failures — the resend button remained tappable without a countdown reset, and no new OTP was dispatched.

## Root Cause

`OtpEntryScreen` strips the `+91` prefix before passing the phone number to the controller (`session.phoneNumber.replaceFirst('+91', '')`). The `resend()` method then passed this raw number directly to `resendOtp()`, which expects E.164 format.

## Fix

Prepend `'+91'` to `_phoneNumber` in the `resendOtp` call, matching the format used by `PhoneEntryController.submit()`.

## Testing

- All 31 OTP controller unit tests pass
- Manual testing on iOS Simulator confirmed resend now dispatches a new OTP and resets the countdown
- Found during Sprint 1 manual QA

## Severity

S2 — Feature broken (resend OTP non-functional), no workaround.