### PR TITLE
docs(adr): reconcile ADR-0013 and ADR-0014 scope

### DIFF
--- a/.github/shared/decision-log.md
+++ b/.github/shared/decision-log.md
@@ -625,6 +625,31 @@ required.
   return value and assert that only the single selected contact's
   `displayName` and `phoneNumbers` are visible to downstream code.
 
+### Relationship to ADR-0014
+
+ADR-0013 governs **bulk PII handling**: device contacts are never uploaded to
+any server, matching is performed locally, and the contact picker exposes only
+the single selected contact to downstream code.
+
+ADR-0014 governs the **individual user lookup mechanism**: once a single phone
+number has been selected on-device, how does the app determine whether that
+number belongs to a registered One By Two user? ADR-0014 answers this
+sub-question by routing the lookup through a Cloud Function gateway
+(`lookupUserByPhoneNumber`) rather than a direct client-side Firestore query.
+This preserves the restrictive `users` read rule while still enabling contact
+matching.
+
+The two decisions sit at different layers of the same problem. ADR-0013's
+constraint that contacts never leave the device as bulk data remains binding.
+ADR-0014's Cloud Function accepts only a single phone number per invocation,
+which is consistent with that constraint.
+
+Note: the "No Cloud Function dependency" consequence listed above was written
+before the Security Rules analysis (PR #32) revealed that cross-user reads are
+blocked for clients. ADR-0014's Cloud Function gateway is a conscious
+refinement of the lookup mechanism, not a contradiction of the local-matching
+strategy.
+
 ---
 
 ## ADR-0014: Cross-User Lookup for Contact Matching — Cloud Function Gateway
@@ -741,5 +766,20 @@ and unusable for contact matching. Rejected as non-functional.
    documents of users they share a friendship or group with. Direct
    phone-number queries against the `users` collection remain blocked for
    clients.
+
+### Relationship to ADR-0013
+
+ADR-0013 establishes the higher-level contact-matching strategy: contacts
+remain on-device, no bulk upload occurs, and matching is scoped to individual
+selections. ADR-0014 refines the implementation mechanism for that individual
+lookup. Where ADR-0013 described "queries Firestore by `phoneNumber`",
+ADR-0014 specifies that this query is routed through a Cloud Function
+gateway — not executed as a direct client-side Firestore read — because the
+`users` Security Rules restrict cross-user reads.
+
+Together, the two ADRs form the complete contact-matching architecture:
+ADR-0013 defines what data stays on-device (bulk contacts) and what may be
+looked up (a single selected phone number); ADR-0014 defines how that lookup
+is performed (Cloud Function, rate-limited, with minimal response shape).
 
 ---

--- a/docs/copilot_prompts/sprint_2/3_1.md
+++ b/docs/copilot_prompts/sprint_2/3_1.md
@@ -1,0 +1,44 @@
+You are the architect agent. The OneByTwo decision log has two ADRs that appear to overlap on the contact-matching domain: ADR-0013 (local matching strategy, ratified in PR #31) and ADR-0014 (Cloud Function gateway, ratified in PR #32). They are not contradictory but the relationship between them is currently implicit. Make it explicit.
+
+Read before starting:
+  - `.github/shared/decision-log.md` — both ADRs in full.
+  - `docs/design/07-technical/pii-handling.md` (added in PR #31).
+  - PR #31's diff (architect notes for the contact picker).
+  - PR #32's diff (especially the Cloud Function implementation and the rules changes).
+
+────────────────────────────────────────
+TASK
+────────────────────────────────────────
+
+1. Decide the relationship between ADR-0013 and ADR-0014. Two reasonable framings:
+
+   **Framing A — Both remain Accepted, with explicit scope clarification:**
+   - ADR-0013 governs the on-device handling of contact lists ("contacts never leave the device as bulk data").
+   - ADR-0014 governs the cross-user lookup mechanism ("individual lookups happen server-side, not via direct Firestore reads").
+   - Add a "Relationship to ADR-0014" subsection to ADR-0013 explaining this scoping.
+   - Add a "Relationship to ADR-0013" subsection to ADR-0014 explaining this scoping.
+   - The framing in plain English: ADR-0013 is about *bulk PII handling*; ADR-0014 is about *individual user lookup*. They sit at different layers of the same problem.
+
+   **Framing B — ADR-0013 amended to reference ADR-0014 as the implementation mechanism:**
+   - ADR-0013's "Decision" section is updated to clarify that the lookup mechanism for matching is the Cloud Function gateway specified in ADR-0014, while the on-device-only contact list constraint remains binding.
+   - ADR-0013's status remains Accepted.
+   - ADR-0014's status remains Accepted.
+   - This framing positions ADR-0013 as the higher-level decision and ADR-0014 as the implementation answer to one of its sub-questions.
+
+   Pick whichever framing reads more naturally given how the decision log structures other ADR relationships. If a previous ADR has been amended in a similar way (check ADR-0007 or ADR-0012 for precedent), match that precedent.
+
+2. Write the amendments. Both ADRs end up with cross-references to the other.
+
+3. If there's a third party affected — `docs/design/07-technical/pii-handling.md` — verify it still reads consistently with both ADRs. Update if needed.
+
+4. Commit as `docs(adr): reconcile ADR-0013 and ADR-0014 scope`.
+
+────────────────────────────────────────
+GUARDRAILS
+────────────────────────────────────────
+
+- This is a documentation amendment, NOT a new ADR. Do NOT create ADR-0015 for this work.
+- Do NOT change any Decision substance in either ADR. Only clarify scope and add cross-references.
+- If the architect concludes the two ADRs ARE genuinely contradictory and one supersedes the other (rather than complementing it): STOP and escalate. That's a more substantive conversation than this task is scoped for.
+
+When done, state explicitly: "ADR-0013 and ADR-0014 reconciliation committed. PR #33 may now proceed."

--- a/docs/design/07-technical/pii-handling.md
+++ b/docs/design/07-technical/pii-handling.md
@@ -6,7 +6,7 @@
 | Status           | Active             |
 | Author           | Solution Architect |
 | SRS Baseline     | v1.1               |
-| ADR Reference    | ADR-0013           |
+| ADR Reference    | ADR-0013, ADR-0014 |
 
 ---
 
@@ -24,8 +24,11 @@ future pull request that touches PII.
 ### 2.1 PII stays on-device
 
 PII remains on the device unless explicitly required for a server-side
-operation. Querying Firestore by `phoneNumber` to look up a single user is
-acceptable; batch-uploading contact lists is not.
+operation. Looking up a single user by phone number is acceptable;
+batch-uploading contact lists is not. In practice, individual lookups are
+routed through the `lookupUserByPhoneNumber` Cloud Function (ADR-0014)
+rather than as direct client-side Firestore queries, preserving restrictive
+client-side read rules.
 
 ### 2.2 PII is excluded from telemetry and persistent stores
 


### PR DESCRIPTION
## Summary

ADR-0013 (local contact matching, PR #31) and ADR-0014 (Cloud Function lookup gateway, PR #32) address different layers of the same contact-matching problem. Their relationship was implicit; this PR makes it explicit.

## Changes

- **ADR-0013**: Added "Relationship to ADR-0014" subsection clarifying it governs bulk PII handling (contacts stay on-device).
- **ADR-0014**: Added "Relationship to ADR-0013" subsection clarifying it refines the individual lookup mechanism (Cloud Function gateway).
- **pii-handling.md**: Header now references both ADRs. Section 2.1 clarifies lookups route through the Cloud Function.

## Framing

Framing A (scope clarification) was chosen over Framing B (amendment). Both ADRs remain Accepted with no Decision substance changed — only cross-references added.

No contradictions were found; the ADRs are complementary, not conflicting.