### PR TITLE
feat(functions): on-settlement-write trigger (FR-SE-05/06)

### DIFF
--- a/docs/copilot_prompts/sprint_2/6.md
+++ b/docs/copilot_prompts/sprint_2/6.md
@@ -1,0 +1,387 @@
+1. You are the OneByTwo orchestrator agent. PR #36 (FR-SE-03/04 `onExpenseWriteFriendship` trigger) has merged and is live in production at `asia-south1` — `simplifiedBalances` is now written by an automatic Firestore trigger on every expense write, and `lastActivityAt` is maintained atomically so the friends-list ordering (FR-FR-03 AC-6) moves correctly. We now implement PR #37: the **`onSettlementWrite` Firestore trigger** that automatically invokes `recomputeAndWrite` whenever a settlement is created, updated, or deleted, plus the two prerequisite pieces that make the trigger meaningful — Firestore Security Rules for the `settlements/{settlementId}` collection (none exist today; default-deny blocks all client writes), and an extension of the shared `recomputeAndWrite` core to actually READ settlements into the net-balance computation (the algorithm today only reads expenses).
+
+2. This is the **second** Firestore trigger in the application's history and the first on a **top-level collection** rather than a context-scoped subcollection. It is also the FIRST PR that touches the simplified-debts ALGORITHM's read shape — PR #12 shipped expense-only read; PR #37 adds settlement read so the algorithm finally honours the catalogue's "settlements" row of the read table. Without this PR, settlements would be no-ops on `simplifiedBalances`.
+
+3. This is also the first PR that exercises the Invariant-2 parallel for `verificationStatus` on settlements (server-only field per ARCH-EXT-06). v1.0 leaves `verificationStatus` at the literal `'unverified'` default and the trigger does NOT write it, but the rules MUST reject client writes to that field the same way they reject client writes to `simplifiedBalances` on friendships/groups.
+
+4. Read before starting:
+   - `.github/copilot-instructions.md`
+   - `.github/shared/invariants.md` — invariants 1, 2, 4 all apply.
+   - `.github/shared/decision-log.md` — ADR-0001 (simplified debts is the sole debt mechanism), ADR-0002 (paise integers), ADR-0011 (Cloud Functions test-pyramid layers), ADR-0013 (PII / telemetry hashing).
+   - `docs/patterns/feature-pr-conventions.md` — Cloud Functions Testing Layers, Field-Level Security Rules Pattern, boundary-contract discipline.
+   - `docs/design/07-technical/cloud-functions-catalogue.md` — section 1 (`recomputeSimplifiedBalances`, shipped — note the READ table claims it reads settlements; PR #37 makes that claim true), section 3 (`onSettlementWrite`, planned — the subject of this PR).
+   - `docs/design/07-technical/cloud-functions-error-codes.md` — every Cloud Function error is typed; reuse codes, don't invent fresh ones.
+   - `docs/design/07-technical/firestore-schema.md` — `settlements/{settlementId}` schema (the trigger path + write target), particularly the `verificationStatus` extension-point field.
+   - `docs/design/07-technical/firestore-security-rules.md` — the settlements section (currently a design outline, not implemented in `firestore.rules`).
+   - `docs/design/07-technical/simplified-debts-algorithm.md` — settlements semantic: a payment from X to Y CREDITS X (+amountPaise) and DEBITS Y (-amountPaise), opposite-but-symmetric to expense splits.
+   - `docs/design/03-architecture/extension-points-register.md` — ARCH-EXT-01 (`method` extension point), ARCH-EXT-06 (`verificationStatus` extension point — v1.0 fixed at `'unverified'`).
+   - `docs/sprint-zero/stories/FR-SE-03-04-expense-trigger-friendship.md` — PR #36's story + architect notes. PR #37 inherits every pattern ratified there. Reuse, do not re-derive.
+   - PR #36's `functions/src/simplified-debts/function.ts` — the shared `recomputeAndWrite` core. PR #37 EXTENDS it to read settlements.
+   - PR #36's `functions/src/triggers/on-expense-write/function.ts` — the trigger boundary template. PR #37 mirrors this layout.
+   - PR #36's `functions/src/utils/id-hash.ts` — the PII-safe `hashId()` utility. PR #37 reuses it for `settlementIdHash`.
+   - PR #36's `functions/test/firestore-rules/expenses-friendship.test.ts` — the rules-test pattern for member-only access, sum check, extension-point locks, immutables. PR #37 mirrors this layout for settlements.
+   - PR #36's `firestore.rules` `match /friendships/{friendshipId}/expenses/{expenseId}` block — the helper-function and bounded-enumeration pattern PR #37 reuses.
+   - `firestore.indexes.json` — settlements read inside the transaction uses `where('contextType', '==', X).where('contextId', '==', Y)`; verify whether a composite index is required (likely yes — declare in this PR).
+   - `.github/workflows/pr.yml` — already runs `npm run test:integration` inside `firebase emulators:exec` after PR #36. No further workflow changes needed.
+
+5. Honour the four invariants. Apply invariant 2 with the same rigour as PR #36 — `simplifiedBalances` writes still go through the single `recomputeAndWrite` write site at `functions/src/simplified-debts/function.ts:358`. The new settlements code MUST NOT introduce a second write site for `simplifiedBalances`. The settlements collection also has an Invariant-2-PARALLEL field (`verificationStatus`) — clients must never write it.
+
+────────────────────────────────────────
+PHASE 0 — DEPENDENCY-DAG CHECK
+────────────────────────────────────────
+
+0.1  Confirm PR #36 has merged to main and the post-merge state is clean:
+     - `functions/src/triggers/on-expense-write/` exists and is registered in `functions/src/index.ts`.
+     - `functions/src/simplified-debts/function.ts` exports `recomputeAndWrite(deps, request)` returning `RecomputeResult` discriminated union.
+     - `functions/src/utils/id-hash.ts` exports `hashId()`.
+     - `firestore.rules` contains the `friendships/{friendshipId}/expenses/{expenseId}` block.
+     - `cd functions && npm run lint && npm run build && npm test` all pass.
+     - `firebase emulators:exec --only auth,firestore,functions,storage demo-onebytwo "cd functions && npm run test:rules && npm run test:integration"` exits 0.
+     - The trigger is live in production at `asia-south1` (`firebase functions:list --project onebytwo-avtanshgupta` shows `onExpenseWriteFriendship` with `google.cloud.firestore.document.v1.written` trigger).
+
+0.2  Walk the dependency DAG for `onSettlementWrite`:
+     - **`recomputeAndWrite` shared core** from PR #36 (variant 2.3(b)): merged. Reads only `expenses` today. PR #37 MUST extend it to also read settlements per the algorithm catalogue. Specifically, replace the single `tx.get(expensesRef)` with two parallel `tx.get` calls (expenses + settlements) and feed both into `computeNetBalances()`.
+     - **`hashId()` PII utility** from PR #36: merged. PR #37 reuses it for `settlementIdHash` in trigger logs.
+     - **Firestore Security Rules for `settlements/{settlementId}`**: do NOT exist today (default-deny). PR #37 MUST add the rules block so clients can write settlements at all. The rules must enforce: `fromUserId == request.auth.uid` on create; both `fromUserId` and `toUserId` may read; `verificationStatus` MUST default to `'unverified'` on create and MUST NOT change on update (server-only field — the Invariant-2 parallel for settlements per ARCH-EXT-06); extension-point locks (`method == 'manual'`, `currency == 'INR'`); immutable `createdAt` and `fromUserId`/`toUserId`/`contextType`/`contextId`/`amountPaise` (a settlement once made is a historical record; editing it would corrupt audit history — only soft-delete via a `deleted` flag, OR no update at all if architect prefers).
+     - **`settlements/{settlementId}` Firestore Indexes**: the trigger reads via `where('contextType', '==', X).where('contextId', '==', Y)` (inherited from the algorithm catalogue's read table). Verify whether Firestore requires a composite index for this two-field equality query; declare it in `firestore.indexes.json` if so.
+     - **Settlement algorithm semantics**: a settlement of `{fromUserId: A, toUserId: B, amountPaise: N}` credits A by +N and debits B by -N (opposite-symmetric to expense splits — a settlement IS the cash payment that reduces A's debt to B). Update `computeNetBalances()` to accept settlements and apply this rule. The pure algorithm in `functions/src/simplified-debts/algorithm.ts` STAYS LOCKED — only the wrapper that builds the net-balance map (`computeNetBalances`) is extended.
+     - **`onSettlementWrite` trigger registration**: top-level collection `settlements/{settlementId}`. Path is NOT subcollection-scoped, so the trigger handler MUST read `contextType` and `contextId` from the document data (the `change.after` snapshot on create/update; the `change.before` snapshot on delete). For delete events, the discriminator comes from the BEFORE side.
+     - **Groups context settlements**: the trigger naturally handles BOTH friendship and group contexts because `contextType` lives in the doc, not the path. But groups don't exist in production (Sprint 3). The trigger fires correctly; the `recomputeAndWrite` core's CONTEXT_NOT_FOUND path catches missing group docs gracefully. No groups-specific work in PR #37.
+     - **Activity items and FCM**: NOT shipped here. The catalogue's `onSettlementWrite` section lists three side-effects: (1) recompute simplified balances, (2) write activity item for both parties, (3) send FCM to recipient. **PR #37 ships ONLY (1).** Activity items depend on FR-AC-01 (later sprint); FCM depends on FR-AC-03 (later sprint). Hand-off seams (`// TODO(FR-AC-01)`, `// TODO(FR-AC-03)`) MUST be placed in the trigger source, identical to PR #36's seam placement.
+     - **`verificationStatus` server-writer**: the v1.0 default is `'unverified'` (set on create by the client; the rules enforce). No server logic writes it in v1.0. The Cloud Functions Catalogue section 3 mentions verification logic as deferred (post-v1.0 UPI integration per ARCH-EXT-06). PR #37 does NOT implement any verificationStatus state machine — it only ensures the rules prevent client writes to the field on update.
+
+0.3  Confirm DoR for the new story:
+     - There is NO existing story file for the settlements pipeline. PM creates one in Phase 1 — proposed path `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` (covers FR-SE-05 "settlements are recorded by the algorithm" + FR-SE-06 "partial settlements are supported" — the latter is naturally satisfied because a settlement of any positive paise amount reduces the debt by that amount).
+     - SRS sections 4.6 (FR-SE-05, FR-SE-06), 7.3 (Invariants 1 and 2), and 7.5 (security rules) are the authoritative requirements.
+     - Cloud Functions catalogue section 3 is the authoritative design (plus section 1's read table, which PR #37 makes accurate).
+     - If the architect concludes the story scope is larger than 5 SP, consider splitting into PR #37a (rules + algorithm core extension; ~3 SP) and PR #37b (trigger; ~2 SP). Default to single PR if the cohesion benefits outweigh the size — the three pieces are mutually dependent (rules → algorithm → trigger) and none is independently useful.
+
+0.4  Cross-reference `docs/audits/sprint-1/06-deferred-to-sprint-2.md` and `07-bucket-b-burndown.md`. The pre-existing `lookup-user-by-phone-number` rate-limit doc-path bug surfaced by PR #36's CI workflow change remains open (5 `describe.skip`'d integration tests). PR #37 must NOT regress this skip; treat the bug as out of scope (separate follow-up PR).
+
+────────────────────────────────────────
+PHASE 1 — STORY READINESS (PM)
+────────────────────────────────────────
+
+PM agent creates the story `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` using the SRS §13.2 format that PR #36 ratified. Story points: **5** (or split per Phase 0.3) — three concerns bundled (rules + algorithm core extension + trigger), but each piece is small (~150 lines code + tests) and reuses PR #36 patterns.
+
+Required Given/When/Then ACs (each MUST be testable):
+
+  - **AC-1 — Settlements rules: create allowed for fromUserId only.** Given an authenticated user, when they write a settlement to `settlements/{settlementId}` with `fromUserId == request.auth.uid` AND all schema invariants satisfied, then the write succeeds. Given `fromUserId != request.auth.uid`, the write is rejected.
+  - **AC-2 — Settlements rules: read allowed for both parties.** Given a settlement with `fromUserId: A, toUserId: B`, both A and B can read the doc. Outsiders cannot. Unauthenticated cannot.
+  - **AC-3 — Settlements rules: verificationStatus is server-only.** Given a settlement exists with `verificationStatus: 'unverified'`, when a client attempts to update the field to any other value, the write is rejected by the field-level diff rule (Invariant-2 parallel for settlements per ARCH-EXT-06).
+  - **AC-4 — Settlements rules: extension-point locks.** Given a settlement create, `method == 'manual'`, `currency == 'INR'`, and `verificationStatus == 'unverified'` are mandatory. Any other value is rejected. `contextType in {'friendship', 'group'}` is enforced; member-of-context is enforced (`fromUserId` and `toUserId` must both be in the parent context's `memberIds`).
+  - **AC-5 — Settlements rules: immutability.** Given a settlement exists, when a client attempts to mutate `fromUserId`, `toUserId`, `amountPaise`, `contextType`, `contextId`, or `createdAt`, the write is rejected. (A historical record cannot be edited; if a mistake was made, soft-delete via `deleted: true` is the supported path — same posture as expenses.)
+  - **AC-6 — Settlements rules: delete denied.** Hard delete is denied for all clients. Admin SDK bypass works (for cleanup paths).
+  - **AC-7 — `recomputeAndWrite` reads settlements.** Given a friendship has both expenses AND settlements, when the algorithm runs, the net balance for each member reflects BOTH (expense splits debit + settlement payments credit/debit per the algorithm semantics).
+  - **AC-8 — `recomputeAndWrite` filters deleted settlements.** Given a settlement with `deleted: true`, the algorithm excludes it from the net-balance computation. Same posture as expenses (`where('deleted', '!=', true)`).
+  - **AC-9 — Trigger fires on settlement create.** Given a settlement is written to `settlements/{settlementId}` with `contextType: 'friendship'`, then within the trigger's invocation window the parent friendship doc has `simplifiedBalances` recomputed (now reflecting the new settlement) and `lastActivityAt` updated to the trigger's `event.time` (monotonicity-guarded). Both writes in the same transaction.
+  - **AC-10 — Trigger fires on settlement update and soft-delete.** Mirror of AC-9 for update / soft-delete events.
+  - **AC-11 — Trigger fires on hard delete (admin SDK only).** Mirror of AC-9 for hard delete (`change.after == undefined`; discriminator comes from `change.before`).
+  - **AC-12 — Trigger handles missing context gracefully.** Given a settlement with `contextType: 'friendship'` and `contextId` pointing at a deleted friendship doc, the trigger logs `simplified_debts_compute_failed { errorCode: 'CONTEXT_NOT_FOUND' }` and returns successfully (no retry storm). Mirror of PR #36 AC-10.
+  - **AC-13 — Stale-event guard.** Given a settlement-trigger event with `event.time` > 7 days old, the trigger logs `settlement_trigger_stale_event_dropped` and returns without writing. Mirror of PR #36 AC-11.
+  - **AC-14 — `lastActivityAt` monotonicity.** Mirror of PR #36 AC-12 — out-of-order settlement-trigger delivery does not regress the context document's `lastActivityAt`.
+  - **AC-15 — Canonical settlement test cases pass end-to-end through the trigger.** Cover at least: a settlement that fully zeroes a debt; a partial settlement (FR-SE-06); a settlement that overshoots (debtor pays more than they owe, flipping the sign of the net balance — algorithm handles correctly).
+  - **AC-16 (Regression) — `simplifiedBalances` still client-read-only.** Re-verify the existing field-level diff rule on friendships/groups (the trigger doesn't loosen it).
+  - **AC-17 (Regression) — Existing `onExpenseWriteFriendship` still works.** The extended `recomputeAndWrite` core MUST NOT regress PR #36's behaviour. The existing trigger integration test continues to pass without modification.
+
+DoR §9 invariant applicability:
+  - Invariant 1 (paise): **APPLIES.** Settlement `amountPaise` is an integer; the algorithm's settlement-credit/debit is integer arithmetic. No `double`.
+  - Invariant 2 (`simplifiedBalances` server-only): **APPLIES.** The write site remains the single `tx.update(contextRef, ...)` inside `recomputeAndWrite`. The new settlement read is INPUT to the algorithm, not a second writer of `simplifiedBalances`. DoD grep expectation is unchanged: exactly 1 write site in `functions/src/**`.
+  - Invariant 2 PARALLEL (`verificationStatus` server-only on settlements): **APPLIES.** The new rules enforce this. There is currently no server-side writer of `verificationStatus` in v1.0 (the field stays at `'unverified'`). The Invariant-2-parallel is enforced by the rules only.
+  - Invariant 3 (system share sheet): N/A.
+  - Invariant 4 (single Firebase project): APPLIES.
+  - PII / ADR-0013: applies. Settlement IDs are auto-generated opaque Firestore IDs — they ARE safe to log raw. But `fromUserId` and `toUserId` are user UIDs and MUST NOT appear in logs. Use `hashId()` for the settlement ID for parity with the expense trigger's hashed identifiers; `contextId` for friendship contexts is `{uidA}_{uidB}` and MUST also be hashed.
+
+Telemetry events (server-side structured logging, all PII-free):
+  - `settlement_trigger_fired` with `{ contextType, contextIdHash, settlementIdHash, changeType: 'create' | 'update' | 'delete', eventTime }`. Fires at the top of the handler.
+  - `settlement_trigger_stale_event_dropped` with `{ contextType, contextIdHash, settlementIdHash, eventTime, ageMs }`.
+  - The downstream `simplified_debts_compute_started` / `_completed` / `_failed` events from `recomputeAndWrite`'s wrappers fire from the trigger boundary, mirroring PR #36's pattern.
+
+Out of scope for this PR (document explicitly):
+  - Activity-feed item writes (`activity/{userId}/items/...`). FR-AC-01, later sprint. Hand-off seam comment in the trigger source.
+  - FCM push notifications. FR-AC-03, later sprint. Hand-off seam comment.
+  - Any verificationStatus state machine. Post-v1.0 UPI integration per ARCH-EXT-06.
+  - The Flutter client's settlement-creation UI (FR-SE-08?). Later PR — the trigger ships before its first client producer so when the UI lands, balances "just work".
+  - Any change to `functions/src/simplified-debts/algorithm.ts` (the pure `simplifyDebts()` function). Locked. Only `computeNetBalances()` in `function.ts` is extended to fold settlement data into the net-balance map.
+  - Any change to the Flutter codebase. The friends-list reader will pick up the new balances via the existing snapshot stream (PR #35) — no client diff is necessary or appropriate.
+
+────────────────────────────────────────
+PHASE 2 — ARCHITECT NOTES
+────────────────────────────────────────
+
+Owner: architect. Append `## Architect Notes` to the new story.
+
+2.1  **Source layout for the new trigger module.**
+     - New module folder: `functions/src/triggers/on-settlement-write/` (kebab-case, matches PR #36's `on-expense-write/`).
+     - Files:
+       * `function.ts` — exported `createTriggerHandler(deps)` mirroring the PR #36 boundary. Reads `contextType` and `contextId` from `change.after?.data() ?? change.before?.data()` (after takes precedence; before is the source on hard delete). Delegates to `recomputeAndWrite` with `alsoSet: {lastActivityAt: eventTimestamp}`.
+       * `index.ts` — registers the trigger using `onDocumentWritten` from `firebase-functions/v2/firestore` with `{region: 'asia-south1', document: 'settlements/{settlementId}', retry: true}`. Re-exported from `functions/src/index.ts` as `onSettlementWrite`.
+     - Test mirror: `functions/test/triggers/on-settlement-write/function.test.ts` + `functions/test/integration/on-settlement-write.integration.test.ts`.
+     - The trigger handler MUST NOT bake in friendship/group discrimination. It passes `{contextType, contextId}` through to `recomputeAndWrite` and lets the shared core resolve the path. This keeps the trigger context-agnostic and ready for groups (Sprint 3) without modification.
+
+2.2  **Extend `recomputeAndWrite` to read settlements — in the same transaction as expenses.**
+     - Inside the existing `db.runTransaction(async tx => { ... })`, add a second parallel `tx.get`:
+       ```
+       const settlementsRef = db.collection('settlements')
+         .where('contextType', '==', contextType)
+         .where('contextId', '==', contextId)
+         .where('deleted', '!=', true);
+       ```
+       Note the cross-field `where` + `!=` clause; verify the composite-index requirement in Phase 3 and declare in `firestore.indexes.json` if needed.
+     - Wait — Firestore disallows `!=` queries that combine with other `where` clauses on different fields without an inequality-prefix-matching composite index. Test in the emulator; if disallowed, the workaround is to read all settlements for the context and filter `deleted == true` in code. Either way is acceptable; the filter happens server-side and adds negligible cost given settlement counts are small per context.
+     - Update `computeNetBalances()` to accept BOTH expenseSnapshots AND settlementSnapshots. For each settlement: `netBalances[fromUserId] += amountPaise; netBalances[toUserId] -= amountPaise;` (settlement credits the payer's balance — the payment reduces the payer's debt). The pure `simplifyDebts()` algorithm in `algorithm.ts` is unchanged; only `computeNetBalances()` in `function.ts` is extended.
+     - The `BALANCE_INVARIANT_VIOLATED` check (algorithm asserts sum of net balances is zero) MUST still pass after settlements are included. Both expense splits AND settlements preserve the zero-sum property by construction. Add a property-based test (`functions/test/simplified-debts/algorithm.property.test.ts` extension) that generates random mixed expense + settlement sequences and asserts sum == 0.
+
+2.3  **`recomputeAndWrite` does NOT need new parameters.** The function signature stays the same. Settlements are an INTERNAL implementation detail of the algorithm reading shape — callers (callable + expense trigger + new settlement trigger) all invoke the same way with `{contextType, contextId, alsoSet}`. The fact that settlements now feed in is transparent to them.
+
+2.4  **Settlement trigger does NOT need new core API.** The trigger reads `contextType` and `contextId` from the settlement document data, then calls `recomputeAndWrite(deps, {contextType, contextId, alsoSet: {lastActivityAt: eventTimestamp}})` exactly like the expense trigger calls it for friendships. The only difference is the source of `{contextType, contextId}`: expense trigger derives from the path (`event.params.friendshipId` + literal `'friendship'`); settlement trigger derives from the doc data.
+
+2.5  **New Firestore Security Rules — settlements collection.**
+     - Add a new top-level `match /settlements/{settlementId}` block alongside the existing `match /friendships/...` and `match /groups/...` blocks.
+     - Required helpers:
+       * `function isContextMember(contextType, contextId, uid)` — for `'friendship'`, do `get(/databases/$(database)/documents/friendships/$(contextId)).data.memberIds`. For `'group'`, do the same with `groups/`. Both `fromUserId` and `toUserId` must be in the resolved memberIds.
+       * `function hasOnlyKnownKeys(data)` — whitelisted field set: `['fromUserId', 'toUserId', 'amountPaise', 'contextType', 'contextId', 'date', 'note', 'method', 'verificationStatus', 'currency', 'createdAt', 'deleted']`. (Schema includes a few more; reconcile with `firestore-schema.md`.)
+       * `function isValidShape(data)` — type checks for each field, including `verificationStatus == 'unverified'` AND `method == 'manual'` AND `currency == 'INR'` (extension-point locks per ARCH-EXT-01/02/06).
+       * `function isValidContextDiscriminator(data)` — `contextType in ['friendship', 'group']` AND `contextId is string` AND `contextId.size() > 0`.
+     - Create rule:
+       ```
+       allow create: if request.auth != null
+         && request.resource.data.fromUserId == request.auth.uid
+         && isValidShape(request.resource.data)
+         && hasOnlyKnownKeys(request.resource.data)
+         && isValidContextDiscriminator(request.resource.data)
+         && isContextMember(request.resource.data.contextType, request.resource.data.contextId, request.resource.data.fromUserId)
+         && isContextMember(request.resource.data.contextType, request.resource.data.contextId, request.resource.data.toUserId)
+         && request.resource.data.fromUserId != request.resource.data.toUserId
+         && request.resource.data.amountPaise > 0
+         && request.resource.data.deleted == false
+         && request.resource.data.createdAt == request.time;
+       ```
+     - Update rule:
+       ```
+       allow update: if request.auth != null
+         && (request.auth.uid == resource.data.fromUserId || request.auth.uid == resource.data.toUserId)
+         && immutableFieldsPreserved()
+         && verificationStatusUnchanged();
+       ```
+       The ONLY field a client may update is `deleted` (soft-delete) and possibly `note`. Architect to decide if `note` is editable post-create; default to NO (settlements are historical records).
+     - Read rule:
+       ```
+       allow read: if request.auth != null
+         && (request.auth.uid == resource.data.fromUserId || request.auth.uid == resource.data.toUserId);
+       ```
+     - Delete rule: `allow delete: if false;` — hard delete is admin-only.
+     - **Verify in `firestore-security-rules.md` that the settlements section design matches this implementation. Update the design doc if PR #37 diverges.**
+
+2.6  **Idempotency, retry policy, stale-event guard — inherit PR #36.**
+     - The trigger uses `{retry: true}`. CONTEXT_NOT_FOUND log+return. BALANCE_INVARIANT_VIOLATED and INTERNAL throw (CF retries). Stale event > 7 days drops with a structured log.
+     - The shared `recomputeAndWrite` handles `lastActivityAt` monotonicity for all callers including the new settlement trigger. No new code needed.
+
+2.7  **No new ADR required.** Settlements rules + algorithm extension + trigger all fall within existing ADR-0001/0002/0011 precedent. The Invariant-2-parallel for `verificationStatus` is already captured by ARCH-EXT-06.
+
+2.8  **Coverage gate posture.**
+     - `functions/src/triggers/on-settlement-write/**` is a NEW module folder. Per-module ≥70% gate applies.
+     - `functions/src/simplified-debts/**` will see modest edits (the settlements read + `computeNetBalances` extension). Branch coverage MUST NOT regress below the PR #36 baseline of 86.44% — add new tests for the settlements-read branches to maintain the gate.
+     - Property tests in `algorithm.property.test.ts` should be extended to cover mixed expense + settlement sequences.
+
+2.9  **Composite index for the settlements query.**
+     - The transaction reads `where('contextType', '==', X).where('contextId', '==', Y)` (and possibly `.where('deleted', '!=', true)`). Firestore composite indexes are required for cross-field `where` combinations. Declare in `firestore.indexes.json`:
+       ```
+       {"collectionGroup": "settlements", "queryScope": "COLLECTION",
+        "fields": [{"fieldPath": "contextType", "order": "ASCENDING"},
+                   {"fieldPath": "contextId", "order": "ASCENDING"}]}
+       ```
+     - Verify against the Firestore emulator's index-suggestion output; declare exactly what is required.
+
+────────────────────────────────────────
+PHASE 3 — SCOPE
+────────────────────────────────────────
+
+WHAT GOES IN PR #37:
+
+  Cloud Functions:
+  - `functions/src/triggers/on-settlement-write/function.ts` — `createTriggerHandler(deps)`. Mirror of PR #36's trigger.
+  - `functions/src/triggers/on-settlement-write/index.ts` — `onDocumentWritten('settlements/{settlementId}', ...)` registration.
+  - Re-export from `functions/src/index.ts` as `onSettlementWrite`.
+  - `functions/src/simplified-debts/function.ts` — extend `recomputeAndWrite` to read settlements alongside expenses in the same transaction. Extend `computeNetBalances` to fold settlements into the net-balance map per the credit-fromUserId / debit-toUserId semantic.
+
+  Firestore Security Rules:
+  - New `match /settlements/{settlementId}` block per Phase 2.5. Includes helpers for member-of-context resolution, extension-point locks, immutables, and the verificationStatus server-only diff guard.
+
+  Firestore Indexes:
+  - Composite index for `contextType + contextId` on settlements per Phase 2.9.
+
+  Tests (per the five-layer Cloud Functions test pyramid):
+  - Algorithm layer: extend `algorithm.property.test.ts` with mixed expense+settlement property tests.
+  - Function-boundary layer: NEW `functions/test/triggers/on-settlement-write/function.test.ts` exercising create/update/soft-delete/hard-delete/idempotency/stale-event/CONTEXT_NOT_FOUND/PII guard. Mirror of PR #36's 13-test pattern, plus tests for (a) discriminator-from-doc-data extraction (after-side on create/update; before-side on hard delete), and (b) settlement reading correctness (e.g., a settlement that zeroes a debt produces an empty `simplifiedBalances`).
+  - Function-boundary layer (recomputeAndWrite changes): extend `functions/test/simplified-debts/function.test.ts` with settlement-input mock cases — credit-fromUserId / debit-toUserId; mixed expense+settlement; deleted settlements filtered.
+  - Security-rules layer: NEW `functions/test/firestore-rules/settlements.test.ts` covering AC-1 through AC-6 in full (read by both parties, create by fromUserId only, immutability of all historical fields, verificationStatus diff rejection, extension-point locks, member-of-context for both fromUserId AND toUserId, hard delete denied, soft-delete via update allowed).
+  - Integration layer: NEW `functions/test/integration/on-settlement-write.integration.test.ts` running against the emulator suite. Seeds a friendship with expenses, writes a settlement via admin SDK, polls the friendship's `simplifiedBalances` until it reflects both the expenses AND the settlement. Cover (a) full settlement zeroing a debt, (b) partial settlement (FR-SE-06), (c) settlement on a context with no expenses (creates the equivalent inverse), (d) AC-12 missing-context graceful handling.
+  - Integration regression: the existing `simplified-debts.integration.test.ts` and `on-expense-write.integration.test.ts` MUST continue to pass without modification (AC-17). If any fail, the algorithm-core extension regressed PR #12 / PR #36 behaviour — STOP and surface.
+
+  Telemetry:
+  - `settlement_trigger_fired` and `settlement_trigger_stale_event_dropped` structured logs per Phase 1.
+
+  Documentation:
+  - The new story file from Phase 1.
+  - `docs/design/07-technical/cloud-functions-catalogue.md` Appendix A status flip: `onSettlementWrite` from "planned" to "shipped". The catalogue's section 1 READ TABLE is now accurate (PR #37 makes the "settlements" row truthful for both friendship and group contexts).
+  - `docs/design/07-technical/firestore-security-rules.md` — if the design outline diverges from the implementation, reconcile.
+  - `docs/sprint-zero/sprint-2-plan.md` (PR #37 status; total now 14 + (story points)).
+  - `docs/sprint-zero/next-three-prs.md` (roll PR #38).
+  - `docs/audits/sprint-1/07-bucket-b-burndown.md` — note any items closed (none expected; PR #37 is feature work).
+
+WHAT DOES NOT GO IN PR #37:
+
+  - The `onExpenseWriteGroup` trigger binding. Sprint 3 (groups epic).
+  - Activity-feed writes. Hand-off seam (TODO comment) only.
+  - FCM push notifications. Hand-off seam (TODO comment) only.
+  - The Flutter settlement-creation UI. Later PR — trigger ships first.
+  - Any change to `functions/src/simplified-debts/algorithm.ts` (the pure function). Locked. Only `function.ts` may be touched.
+  - Any change to the Flutter codebase. The friends-list reader picks up new balances automatically via the existing snapshot stream from PR #35.
+  - A new ADR. ARCH-EXT-06 already covers `verificationStatus`.
+  - Fix for the pre-existing `lookup-user-by-phone-number` rate-limit doc-path bug. Separate follow-up PR.
+  - A `verificationStatus` state machine. Post-v1.0 (UPI integration per ARCH-EXT-06).
+  - Any change to the `recomputeAndWrite` signature. Settlements are an internal read concern; the public API is unchanged.
+
+If an agent suggests any of: implementing activity-feed writes inline, adding FCM, binding the groups path for settlements expensively (settlements ARE context-agnostic per design — the trigger binds to `settlements/{settlementId}` and the doc carries the context discriminator), shipping a partial trigger that skips the algorithm extension (so settlements are no-ops on simplifiedBalances), forking the simplified-debts algorithm, OR running the recomputation OUTSIDE a Firestore transaction — refuse. These are scope creep or invariant violations.
+
+────────────────────────────────────────
+PHASE 4 — TEST-FIRST DISCIPLINE
+────────────────────────────────────────
+
+Tests written before implementation, in this order:
+
+1. **Algorithm-layer property test extension** (`functions/test/simplified-debts/algorithm.property.test.ts`):
+   - Mixed expense + settlement sequences: for any random mix of N expenses and M settlements over a fixed member set, the algorithm's output preserves zero-sum and produces a deterministic transfer list. Confirms the `computeNetBalances` extension is invariant-safe.
+
+2. **Function-boundary tests for the algorithm extension** (`functions/test/simplified-debts/function.test.ts` extension):
+   - `computeNetBalances` with settlements only (no expenses): a settlement of {fromA: 5000, toB: 5000} produces nets {A: +5000, B: -5000} ⇒ algorithm output: `{A: {B: 5000}}` (A's net is positive ⇒ A is owed by B... wait, let me re-derive. If A paid B 5000 in cash, then A's debt to B reduced by 5000. If A had no prior debt, then A is now OWED 5000 by B. So net A = +5000, B = -5000. simplifiedBalances = `{B: {A: 5000}}` because debtor is B, creditor is A, value 5000.)
+   - `computeNetBalances` with mixed: an expense of 10000 split A+B equally (creates `{B: {A: 5000}}`) then a settlement of 3000 from B to A (B pays A 3000 toward the debt) ⇒ residual `{B: {A: 2000}}`.
+   - Deleted settlements are excluded from the algorithm.
+   - Edge case: settlement amount exceeds the existing debt — net balance flips sign — algorithm still produces correct simplified transfers.
+
+3. **Function-boundary tests for the trigger** (`functions/test/triggers/on-settlement-write/function.test.ts`):
+   - Mirror of PR #36's 13-test pattern, with these settlement-specific cases:
+     * Create: `change.after.data() == {contextType: 'friendship', contextId: 'fid', ...}`. Handler reads contextType+contextId from the after snapshot, calls `recomputeAndWrite({contextType, contextId, alsoSet: {lastActivityAt: ...}})`. Asserts the call args.
+     * Update: similar; after-side is the source.
+     * Soft-delete: settlement with `deleted: true` on after — algorithm sees zero settlements (if this was the only one) and recomputes accordingly.
+     * Hard delete: `change.after == undefined` — discriminator comes from `change.before.data()`.
+     * Idempotency, stale-event guard, CONTEXT_NOT_FOUND graceful return, BALANCE_INVARIANT_VIOLATED throw, expense_trigger_fired log first, PII guard using a realistic friendship contextId `{uidA}_{uidB}` AND realistic settlement IDs.
+     * lastActivityAt monotonicity (3 cases per PR #36).
+
+4. **Security-rules tests for settlements** (`functions/test/firestore-rules/settlements.test.ts`):
+   - Read: `fromUserId` can read; `toUserId` can read; outsider rejected; unauthenticated rejected.
+   - Create: `fromUserId == request.auth.uid` happy path; `fromUserId != request.auth.uid` rejected; both parties must be members of the named context; `amountPaise <= 0` rejected; extension-point locks (`method != 'manual'`, `currency != 'INR'`, `verificationStatus != 'unverified'` all rejected); `deleted: true` on create rejected; unknown extra field rejected.
+   - Update: soft-delete by either party allowed; mutating `fromUserId`/`toUserId`/`amountPaise`/`contextType`/`contextId`/`createdAt` rejected; mutating `verificationStatus` rejected (Invariant-2-parallel); non-party rejected.
+   - Delete: hard delete by either party denied; admin-SDK bypass succeeds.
+
+5. **Integration tests for the trigger** (`functions/test/integration/on-settlement-write.integration.test.ts`):
+   - Setup: emulator `FIRESTORE_EMULATOR_HOST = '127.0.0.1:8181'`. Mirrors PR #36's integration test.
+   - Tests:
+     * **Full debt settlement**: seed friendship + 1 expense (B owes A 5000) + 1 settlement (B pays A 5000) ⇒ poll friendship's `simplifiedBalances` until empty `{}`. Asserts the trigger ran AND the algorithm correctly included the settlement.
+     * **Partial settlement (FR-SE-06)**: seed friendship + 1 expense (B owes A 5000) + 1 settlement (B pays A 2000) ⇒ poll until `{B: {A: 3000}}`. Asserts FR-SE-06 is satisfied — partial settlements work.
+     * **AC-12 missing context**: write a settlement with `contextId` pointing at a non-existent friendship. Wait. Friendship doc remains absent; settlement doc remains present; CONTEXT_NOT_FOUND in logs.
+     * **Update + soft-delete walk**: seed friendship + 1 expense + 1 settlement, then update the settlement's amount, then soft-delete the settlement. Assert `simplifiedBalances` reflects each step.
+   - **Crucial regression**: re-run the existing `on-expense-write.integration.test.ts` cases (Examples 1, 2, 3) — confirm the expense trigger still works correctly after the algorithm extension. These tests MUST pass without any modification.
+
+6. ONLY after all test files are red, the cloud-functions-dev implements:
+   - Step A: refactor `recomputeAndWrite` to read settlements + extend `computeNetBalances`. Verify algorithm + function tests + existing expense-trigger integration test all green.
+   - Step B: add settlements rules + composite index + rules tests.
+   - Step C: add the trigger + integration tests.
+
+Coverage:
+   - `functions/src/triggers/on-settlement-write/**`: ≥70% (per-module gate).
+   - `functions/src/simplified-debts/**`: must NOT regress below the PR #36 baseline of 86.44% branch.
+   - Overall Functions: ≥50%.
+
+────────────────────────────────────────
+PHASE 5 — EXECUTION PROTOCOL
+────────────────────────────────────────
+
+Mirror PR #36's pattern with the settlement-specific commits:
+
+1. PM creates story `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md`. Commits as `docs(stories): FR-SE-05/06 settlement trigger story + architect notes`.
+2. Architect appends `## Architect Notes` capturing decisions 2.1-2.9. (Same commit as #1 acceptable — PR #36 set this precedent.)
+3. Functions-dev writes the test files BEFORE any implementation:
+   - `test(functions): algorithm property tests for mixed expense+settlement (FR-SE-05/06)`
+   - `test(functions): boundary tests for on-settlement-write trigger and recomputeAndWrite settlement-read extension`
+   - `test(rules): settlements collection security rules`
+   - `test(functions): integration tests for on-settlement-write trigger`
+4. Functions-dev implements:
+   - `refactor(functions): extend recomputeAndWrite to read settlements (FR-SE-05/06)` — algorithm extension only, no trigger yet. Verify existing expense trigger + callable still work.
+   - `feat(rules): settlements collection security rules (FR-SE-05/06)`
+   - `feat(functions): on-settlement-write trigger (FR-SE-05/06)`
+5. Update Firestore indexes:
+   - `feat(firestore): composite index for settlements contextType+contextId (FR-SE-05/06)`
+6. Update the catalogue and docs:
+   - `docs(plan): FR-SE-05/06 settlement trigger shipped, prep PR #38`
+7. QA runs the manual smoke matrix:
+   - Start emulators (`scripts/dev/start-emulators.sh`).
+   - Seed users A and B; create a friendship.
+   - Via the emulator Firestore UI: create an expense (A pays 10000, split equally) → confirm `simplifiedBalances` becomes `{B: {A: 5000}}`.
+   - Create a settlement (B pays A 5000 via admin SDK) → confirm `simplifiedBalances` becomes `{}`.
+   - Create a partial settlement (B pays A 3000 — split the 5000 debt into multiple payments) → confirm correct residual.
+   - Attempt direct client write to `verificationStatus` field → confirm rejection (Invariant-2-parallel).
+   - Attempt to update fromUserId/amountPaise on an existing settlement → confirm rejection (immutability).
+   - Force a stale event → confirm the stale-event guard.
+8. PR opened by functions-dev.
+   Title: `feat(functions): on-settlement-write trigger (FR-SE-05/06)`
+   Body must:
+     - Confirm `simplifiedBalances` now reflects BOTH expenses AND settlements for the first time — name the algorithm extension and the new trigger.
+     - Confirm Invariant 2 still holds (single write site for `simplifiedBalances` in `functions/src/**`).
+     - Confirm Invariant-2-parallel for `verificationStatus` is enforced (settlements rules tests pass).
+     - Confirm AC-17 regression (existing expense trigger + callable integration tests pass without modification).
+     - State explicitly: this PR's deferred items are `onExpenseWriteGroup` (Sprint 3), activity-feed item writes (FR-AC-01), FCM (FR-AC-03). Each has a `// TODO(<story-id>)` seam in the source.
+     - End with `Next PR: PR #38 — TBD per Sprint 2 plan.`
+
+────────────────────────────────────────
+PHASE 6 — DEFINITION OF DONE GATE
+────────────────────────────────────────
+
+Walk the DoD checklist. Particular emphasis:
+  - DoD §2: integration tests green; coverage gate green; per-module ≥70% on the new trigger folder; simplified-debts module not regressed below PR #36 baseline.
+  - DoD §7: invariant compliance.
+    * **Inv-1:** grep across the diff for `double` / `float` arithmetic on any value derived from a settlement's `amountPaise`. Expected count: 0.
+    * **Inv-2:** grep across `lib/**` for `simplifiedBalances` writes — expected 0 (PR #35 baseline preserved). Grep across `functions/src/**` for `tx.update.*simplifiedBalances` — expected exactly 1 (the existing shared core writer — the settlements-read extension does NOT introduce a second writer).
+    * **Inv-2-PARALLEL (verificationStatus):** grep across `lib/**` for `verificationStatus` writes — expected 0. Grep across `functions/src/**` for verificationStatus writes — expected 0 in v1.0 (the field stays at its default; no server logic writes it).
+    * **Inv-4:** no second Firebase project.
+  - DoD §8: documentation updated. Catalogue Appendix A status flip is mandatory.
+
+QA posts the DoD §3 sign-off referencing the manual smoke matrix from Phase 5 step 7 with screenshots of (a) the Friends list row reflecting settlement-adjusted balances, (b) emulator logs showing `settlement_trigger_fired` + `simplified_debts_compute_completed`, and (c) a rejected client write to `verificationStatus`.
+
+A devops-led production deploy is part of the merge ceremony — the trigger MUST be deployed before any client-side settlement UI ships. Document the deploy sequence in the PR body (mirror PR #36's deploy sequence).
+
+────────────────────────────────────────
+PHASE 7 — UPDATE THE ROLLING PLAN AND BURNDOWN
+────────────────────────────────────────
+
+PM agent updates:
+  - `docs/sprint-zero/sprint-2-plan.md` — PR #37 status (merged), velocity data point #6.
+  - `docs/audits/sprint-1/07-bucket-b-burndown.md` — no items expected to close (PR #37 is feature work, not chore). Confirm no regressions to the prior closures.
+  - `docs/sprint-zero/next-three-prs.md`:
+      * PR #38: likely FR-EX-01 (expense creation UI — the first client producer of expense writes that PR #36's trigger consumes) OR FR-FR-04 (Friend Detail Screen, which depends on FR-EX-01). The trigger pair is now complete after PR #37, so the next pivot to Flutter UI work is natural.
+      * PR #39: TBD per chosen PR #38.
+      * PR #40: TBD per Sprint 2 velocity.
+
+Commits as `docs(plan): FR-SE-05/06 settlement trigger shipped, prep PR #38`.
+
+────────────────────────────────────────
+GUARDRAILS
+────────────────────────────────────────
+
+If during this PR an agent proposes:
+  - "Let's also bind `onExpenseWriteGroup` since the rules are similar to expenses" → REFUSE. Different epic (groups, Sprint 3). Independent PR.
+  - "Let's also write activity-feed items now since settlements are user-visible events" → REFUSE. Activity items have their own data model, rules, consumer screen (not yet built). Hand-off seam (TODO) is the right answer.
+  - "Let's send FCM push notifications inline so the recipient sees the settlement immediately" → REFUSE. FCM requires the notification permission flow (FR-AC-03), `fcmTokens` registration plumbing, and `notificationPrefs.settlement` toggle. Hand-off seam only.
+  - "Let's also implement the verificationStatus state machine so we have a real verification flow" → REFUSE. Post-v1.0 (UPI integration per ARCH-EXT-06). The rules enforce server-only; that's all PR #37 ships.
+  - "Let's skip the algorithm extension and just have the trigger fire — settlements can be a no-op for v1.0" → REFUSE. Settlements that don't affect balances are USELESS to users. The algorithm extension is the load-bearing piece; without it, the trigger ships meaningless side-effects.
+  - "Let's skip the security rules — admin SDK can seed settlements for testing" → REFUSE. Without rules, clients cannot write settlements at all (default-deny). The whole feature is unusable.
+  - "Let's allow editing `amountPaise` on an existing settlement so users can correct typos" → REFUSE. Settlements are historical records (the same posture as expenses — soft-delete + new settlement is the correction path; never edit history).
+  - "Let's compute the settlement's debit/credit OUTSIDE the algorithm transaction to keep things fast" → REFUSE. Inv-2 requires atomic reads + writes. The settlements read MUST happen inside the same `tx` as the expenses read and the `tx.update(contextRef, ...)` write.
+  - "Let's bind the trigger to `groups/{id}/settlements/{id}` and `friendships/{id}/settlements/{id}` as subcollections like expenses" → REFUSE. The schema puts settlements as a TOP-LEVEL collection with `contextType` + `contextId` discriminators. Re-shaping the schema is out of scope and would invalidate any in-flight design work.
+  - "Let's make the trigger NOT retry on errors" → REFUSE for transient/INTERNAL — they MUST retry. For typed errors that won't resolve on retry (CONTEXT_NOT_FOUND), the handler returns successfully (no throw) so retry doesn't fire — but transient INTERNAL errors throw per PR #36's pattern.
+  - "Let's hard-delete settlements when the parent friendship is deleted" → REFUSE. Out of scope. Friendship deletion is FR-FR-05 (later); cascading cleanup happens there.
+
+If something genuinely surprises (e.g., Firestore composite-index requirement for the settlements query is more involved than expected; the algorithm's zero-sum property breaks under some settlement edge case; the new rules block tripped the 1000-expression cap like PR #36's N=20 attempt did), STOP and surface the friction. PR #37 makes the simplified-debts algorithm read the settlement-side data for the first time — get it right rather than fast.
+
+Begin with Phase 0 — verify the dependency DAG and post-merge state of PR #36.

--- a/docs/design/07-technical/cloud-functions-catalogue.md
+++ b/docs/design/07-technical/cloud-functions-catalogue.md
@@ -270,16 +270,32 @@ Functions event-delivery window (7 days) are dropped by checking
 
 ### Purpose
 
-Responds to the creation of a settlement document. Orchestrates:
+Responds to every write (create, update, soft-delete, hard-delete) of a
+settlement document. v1.0 orchestrates only the simplified-balances
+recompute; activity items and FCM are deferred to FR-AC-01 / FR-AC-03.
 
-1. Calls `recomputeSimplifiedBalances` for the settlement's context (FR-SE-04,
-   FR-SE-06).
-2. Writes an activity-feed item for both parties (FR-AC-01).
-3. Sends an FCM push notification to the recipient (FR-AC-03).
+1. Calls the shared `recomputeAndWrite` core for the settlement's
+   context, which reads expenses AND settlements in the same Firestore
+   transaction and writes the updated `simplifiedBalances` map to the
+   parent friendship/group document (FR-SE-04, FR-SE-06).
+2. **(Deferred to FR-AC-01)** Writes an activity-feed item for both
+   parties. Hand-off seam (`// TODO(FR-AC-01)`) lives in the trigger
+   source.
+3. **(Deferred to FR-AC-03)** Sends an FCM push notification to the
+   recipient. Hand-off seam (`// TODO(FR-AC-03)`) lives in the trigger
+   source.
 
 ### Trigger type
 
-**Firestore onCreate** on `settlements/{settlementId}`.
+**Firestore onWrite** on `settlements/{settlementId}` (the v2
+`onDocumentWritten` event). Covers create, update, soft-delete, and
+hard-delete. Region: `asia-south1`. Retry: enabled.
+
+The context discriminator (`contextType`, `contextId`) is read from the
+document data because the settlements collection is top-level — the
+discriminator is NOT in the trigger path. The after-side snapshot is
+preferred on create/update; the before-side is the source on hard
+delete.
 
 ### Input contract
 
@@ -785,7 +801,7 @@ ADR-0014 — Phone Number Lookup via Cloud Function.
 | `recomputeSimplifiedBalances` | Callable | No | `asia-south1` | shipped |
 | `onExpenseWriteFriendship` | Firestore onWrite `friendships/{id}/expenses/{id}` | Yes | `asia-south1` | shipped |
 | `onExpenseWriteGroup` | Firestore onWrite `groups/{id}/expenses/{id}` | Yes | `asia-south1` | planned |
-| `onSettlementWrite` | Firestore onCreate `settlements/{id}` | Yes | `asia-south1` | planned |
+| `onSettlementWrite` | Firestore onWrite `settlements/{id}` | Yes | `asia-south1` | shipped |
 | `onUserDelete` | Callable | No | `asia-south1` | planned |
 | `acceptGroupInvite` | Callable | No | `asia-south1` | planned |
 | `revokeGroupInvite` | Callable | No | `asia-south1` | planned |

--- a/docs/design/07-technical/firestore-schema.md
+++ b/docs/design/07-technical/firestore-schema.md
@@ -170,18 +170,24 @@ Top-level collection. The `settlementId` is an auto-generated Firestore document
 | `contextType` | `string` | Yes | — | One of `'friendship'` or `'group'` (SRS section 7.2). Identifies the context in which the settlement occurs. | Composite (see Composite Indexes) |
 | `contextId` | `string` | Yes | — | The document ID of the friendship or group to which this settlement belongs. | Composite (see Composite Indexes) |
 | `date` | `timestamp` | Yes | — | The date the settlement was made (user-specified). | Composite (see Composite Indexes) |
-| `note` | `string \| null` | No | `null` | Optional free-text note. Maximum 200 characters. | No |
+| `note` | `string \| null` | No | `null` | Optional free-text note. Maximum 200 characters. Immutable after create. | No |
 | `method` | `string` | Yes | `'manual'` | Settlement method discriminator. v1.0 value is always `'manual'`. Written explicitly per ARCH-EXT-01; supports future `'upi'` value without backfill. | No |
 | `verificationStatus` | `string` | Yes | `'unverified'` | Settlement verification state. v1.0 value is always `'unverified'`. **Client-read-only**; only the Cloud Functions service account may write to this field (ARCH-EXT-06, SRS section 7.5). | No |
 | `currency` | `string` | Yes | `'INR'` | ISO 4217 currency code. v1.0 value is always `'INR'`. Written explicitly per ARCH-EXT-02; supports future multi-currency without backfill. | No |
+| `createdAt` | `timestamp` | Yes | — | Server timestamp (`request.time` on create). Immutable after create. Required for audit history. | No |
+| `deleted` | `boolean` | Yes | `false` | Soft-delete flag. The simplified-debts algorithm (PR #37 `recomputeAndWrite` extension) excludes settlements where `deleted == true` from the net-balance fold. The only field a client may mutate after create; un-delete is admin-only. | No |
 
 **Security rules summary (SRS section 7.5):**
 
 - Creatable only when `fromUserId == request.auth.uid`.
 - Readable by both `fromUserId` and `toUserId`.
+- Updatable only via soft-delete (`deleted: false → true`) by either party.
+  Every other field — including `note` — is immutable.
 - The `verificationStatus` field is **read-only to clients**; only the Cloud
   Functions service account may write to it (mirrors the `simplifiedBalances`
-  enforcement pattern).
+  enforcement pattern — the Invariant-2 parallel for settlements per
+  ARCH-EXT-06).
+- Hard-delete is denied; admin SDK bypasses for cleanup paths.
 
 ---
 

--- a/docs/design/07-technical/firestore-security-rules.md
+++ b/docs/design/07-technical/firestore-security-rules.md
@@ -229,14 +229,37 @@ do not exist; everything is participant-scoped").
 - `contextType` must be one of: `friendship`, `group`.
 - `contextId` must be a non-empty string.
 - `toUserId` must be a non-empty string and must differ from `fromUserId`.
+- Both `fromUserId` and `toUserId` must be members of the parent context
+  (`memberIds` on the friendship/group document).
+- Extension-point locks (v1.0 fixed values per
+  `extension-points-register.md`):
+  - `method == 'manual'` (ARCH-EXT-01).
+  - `currency == 'INR'` (ARCH-EXT-02).
+  - `verificationStatus == 'unverified'` (ARCH-EXT-06).
+- `deleted` must be `false` on create.
+- `createdAt` must equal `request.time`.
+- The document MAY contain only the whitelisted fields:
+  `fromUserId`, `toUserId`, `amountPaise`, `contextType`, `contextId`,
+  `date`, `note`, `method`, `verificationStatus`, `currency`,
+  `createdAt`, `deleted`.
 
 ### Update
 
-- Denied to all clients. Settlements are immutable once created.
+- Allowed for either party (`fromUserId` or `toUserId`) — soft-delete only.
+- The ONLY field that may change is `deleted` (false → true). All other
+  fields are immutable, including `note`. The check uses Firestore's
+  `affectedKeys()` to enforce `hasOnly(['deleted'])`.
+- Un-delete is denied (clients cannot set `deleted` back to false).
+- `verificationStatus` is **client-read-only** — only the Cloud Functions
+  service account may write to this field (mirrors the
+  `simplifiedBalances` Invariant-2 enforcement pattern; ARCH-EXT-06).
+  v1.0 has no server-side writer; the field stays at the literal
+  `'unverified'` default.
 
 ### Delete
 
-- Denied to all clients. Settlements are never removed.
+- Denied to all clients (hard-delete is admin-SDK only). Soft-delete via
+  update is the supported client path.
 
 ---
 

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -1,55 +1,35 @@
 # Next Three PRs
 
 > Rolling roadmap. Updated at the end of every PR.
-> Last updated: PR #36.
+> Last updated: PR #37.
 
 ---
 
-## PR #37 — `onSettlementWrite` Trigger OR FR-EX-01 Expense Creation
+## PR #38 — FR-EX-01 Expense Creation UI (Flutter)
 
 **Status:** Next up. Unblocked.
 
 **Scope:**
 
-- **Option A — `onSettlementWrite` Firestore trigger.** The natural
-  successor to PR #36. Completes the trigger-pair pattern
-  (expense + settlement) so `simplifiedBalances` is recomputed
-  automatically on settlement creates as well. Different path:
-  `settlements/{settlementId}` (top-level collection, NOT a subcollection
-  of the context document). Different write semantics: settlements also
-  carry `verificationStatus` which is server-only writable (parallel to
-  the `simplifiedBalances` invariant for the parent friendship). FCM
-  notifies the recipient — but the FCM side-effect is still deferred
-  to FR-AC-03; the trigger ships compute-only with a hand-off seam.
-- **Option B — FR-EX-01 Expense Creation UI (Flutter).** Unblocks the
-  Expenses epic and produces the first real expense writes that PR #36's
-  `onExpenseWriteFriendship` trigger consumes. Validates the trigger
-  end-to-end in a production flow with real users. Larger Flutter scope
-  (new screen, new form, new Riverpod controller, telemetry).
+FR-EX-01: Flutter UI for creating an expense within a friendship context.
+The first client producer of expense writes that PR #36's
+`onExpenseWriteFriendship` trigger consumes. Now that PR #37 has
+shipped the settlement trigger pair, the next pivot to Flutter UI work
+is natural — the trigger pair is complete; we can ship UI that
+exercises both ends without further server-side work.
 
-Final determination at PR #37 kickoff after PM/architect review.
+Includes:
+- New screen `lib/features/expenses/presentation/add_expense_screen.dart`
+  with an amount input (paise integer enforcement), description,
+  category selector, split picker, payer dropdown.
+- New Riverpod controller `addExpenseController` driving validation and
+  the Firestore write to `friendships/{fid}/expenses/{eid}`.
+- Telemetry events per the chore #25 decision (see Critical Constraint
+  C-1 below — MUST be bundled).
+- Widget tests + integration test seeding A→B and reading the resulting
+  `simplifiedBalances` after the trigger fires.
 
-**Likely choice:** Option A. Reason: settlements are server-side concerns
-(same shape as expenses), keeping the trigger pair coherent before the
-client-side expense creation work expands into Flutter UI scope.
-
-**Story:** TBD per chosen option.
-
-**Agents involved:** Functions Dev (trigger) or Flutter Dev (UI),
-Architect, QA.
-
----
-
-## PR #38 — TBD per PR #37 outcome
-
-**Status:** Planned.
-
-**Scope:**
-- If PR #37 = Option A (`onSettlementWrite`), PR #38 likely = FR-EX-01
-  (expense creation UI).
-- If PR #37 = Option B (FR-EX-01), PR #38 likely = `onSettlementWrite`.
-
-> ### ⚠ Mandatory bundle when PR #38 = FR-EX-01
+> ### ⚠ Mandatory bundle — chore #25 (expense event naming)
 >
 > Per **Critical Constraint C-1** in `docs/sprint-zero/sprint-2-plan.md`,
 > chore [#25](https://github.com/avtansh-code/OneByTwo/issues/25)
@@ -64,19 +44,54 @@ Architect, QA.
 > The orchestrator MUST refuse to start FR-EX-01 implementation work
 > until the decision is recorded in the story file's Architect Notes.
 
-**Agents involved:** TBD.
+**Story:** `docs/sprint-zero/stories/FR-EX-01-expense-creation.md`
+(to be authored).
+
+**Agents involved:** Flutter Dev, PM, Architect (for chore #25 decision),
+QA.
 
 ---
 
-## PR #39 — TBD per Sprint 2 Velocity
+## PR #39 — FR-FR-04 Friend Detail Screen OR `onExpenseWriteGroup`
+
+**Status:** Planned.
+
+**Scope:**
+
+Two candidates after PR #38:
+
+- **Option A — FR-FR-04 Friend Detail Screen.** Replaces the placeholder
+  from PR #35 with a real per-friend transaction history. Depends on
+  FR-EX-01 (PR #38) shipping first so there is actual expense data to
+  display. UI-heavy work; expands the friends epic.
+- **Option B — `onExpenseWriteGroup` trigger binding.** The deferred
+  groups counterpart from PR #36 architect notes §2 and PR #37
+  architect notes §1. Adds a parallel trigger registration plus the
+  groups expense security rules block. Sprint 3 (groups epic)
+  preparatory work; could ship earlier if groups arrive sooner than
+  expected.
+
+Final determination at PR #39 kickoff.
+
+**Likely choice:** Option A. Reason: FR-FR-04 is the natural
+client-side follow-up to FR-EX-01 — once expenses can be created,
+viewing them in a per-friend list is the next user-visible value.
+
+---
+
+## PR #40 — TBD per Sprint 2 Velocity
 
 **Status:** Planned.
 
 **Scope:** To be determined based on Sprint 2 velocity and the
-PR #37/#38 outcomes. Candidates:
-- FR-FR-04 (Friend Detail Screen) replacing the placeholder from PR #35.
-- `onExpenseWriteGroup` trigger binding (the deferred groups
-  counterpart from PR #36 architect notes §2).
-- Bucket-B chore PR (a batch of small audit items now ripe for closure).
+PR #38/#39 outcomes. Candidates:
+- The deferred `onExpenseWriteGroup` trigger binding if not picked up
+  by PR #39.
+- Bucket-B chore PR (a batch of small audit items now ripe for closure;
+  see Sprint 2 Chore Backlog in `sprint-2-plan.md`).
 - Pre-existing `lookup-user-by-phone-number` rate-limit doc-path bug
-  fix (surfaced by PR #36's CI workflow change — see PR #36 PR body).
+  fix (surfaced by PR #36's CI workflow change — see PR #36 PR body;
+  5 `describe.skip`'d integration tests are still in the codebase).
+- FR-SE-08 Settle-Up UI (the Flutter client surface that produces
+  settlement writes — the first client producer of the settlement
+  trigger shipped in PR #37).

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -49,6 +49,21 @@ Architect, QA.
   (expense creation UI).
 - If PR #37 = Option B (FR-EX-01), PR #38 likely = `onSettlementWrite`.
 
+> ### ⚠ Mandatory bundle when PR #38 = FR-EX-01
+>
+> Per **Critical Constraint C-1** in `docs/sprint-zero/sprint-2-plan.md`,
+> chore [#25](https://github.com/avtansh-code/OneByTwo/issues/25)
+> (expense event naming convention decision) MUST be resolved in the
+> SAME PR as FR-EX-01. PR #38 cannot ship without:
+> 1. The naming decision recorded in
+>    `docs/design/07-technical/telemetry-plan.md`.
+> 2. All expense events in `lib/features/expenses/**` using the chosen
+>    names.
+> 3. Issue #25 closed in the PR body (`Closes #25`).
+>
+> The orchestrator MUST refuse to start FR-EX-01 implementation work
+> until the decision is recorded in the story file's Architect Notes.
+
 **Agents involved:** TBD.
 
 ---

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #36 + chore-backlog audit (issues #15-#28).
+> Last updated: PR #37 + chore-backlog audit (issues #15-#28).
 
 ---
 
@@ -55,6 +55,7 @@ work until the decision is recorded in the story file's Architect Notes.
 | #34 | FR-FR-01 (Manual Entry) | Manual phone-number friend-add | 2 | Merged |
 | #35 | FR-FR-03 | Friends list with simplified net balance | 3 | Merged |
 | #36 | FR-SE-03/04 | `onExpenseWriteFriendship` Firestore trigger | 3 | Merged |
+| #37 | FR-SE-05/06 | `onSettlementWrite` Firestore trigger + settlements rules + algorithm extension | 5 | In review |
 
 ---
 
@@ -67,7 +68,8 @@ work until the decision is recorded in the story file's Architect Notes.
 | #34 | 2 | Merged |
 | #35 | 3 | Merged |
 | #36 | 3 | Merged |
-| **Total** | **14** | **5 PRs so far** |
+| #37 | 5 | In review |
+| **Total** | **19** | **6 PRs so far** |
 
 Sprint 1 reference:
 
@@ -183,6 +185,48 @@ inherit:
 The architect notes appended to
 `docs/sprint-zero/stories/FR-SE-03-04-expense-trigger-friendship.md`
 ratify all design decisions taken in this PR.
+
+## Pattern Extension (PR #37)
+
+PR #37 extends the patterns ratified by PR #36 to ship the
+`onSettlementWrite` trigger:
+
+- **Shared core takes an additional read source** —
+  `recomputeAndWrite` now reads both the per-context expenses
+  subcollection AND the top-level `settlements` collection inside the
+  same Firestore transaction. `computeNetBalances` accepts both and
+  folds them together (expenses credit payer / debit splits;
+  settlements credit `fromUserId` / debit `toUserId`). The public
+  signature of `recomputeAndWrite` is unchanged — settlements are an
+  internal implementation detail.
+- **First trigger on a top-level collection** — the
+  `onSettlementWrite` trigger registers at `settlements/{settlementId}`
+  and reads the context discriminator (`contextType`, `contextId`)
+  from the document data rather than the trigger path. Naturally
+  handles both friendship and group contexts without modification when
+  groups ship in Sprint 3.
+- **Invariant-2 parallel for `verificationStatus` on settlements** —
+  enforced by the new `match /settlements/{settlementId}` security
+  rules block (field-level diff rejects client mutation). v1.0 has no
+  server-side writer; the rules are the enforcement mechanism per
+  ARCH-EXT-06.
+- **Settlements schema additions** — `deleted: bool` (default `false`)
+  for soft-delete and `createdAt: timestamp` (immutable) for audit
+  history. The settlements rules permit ONLY soft-delete on update;
+  every other field is immutable. Hard-delete is admin-only.
+- **In-code soft-delete filter for settlements** — the algorithm
+  filters `deleted === true` settlements in JavaScript inside
+  `computeNetBalances` rather than chaining a third Firestore
+  `where('deleted', '!=', true)` on the cross-field query. This avoids
+  an over-specified three-field composite index for negligible
+  computational cost (settlements per context are small).
+- **Composite index for settlements queries** — declared in
+  `firestore.indexes.json`:
+  `{collectionGroup: 'settlements', fields: [contextType ASC, contextId ASC]}`.
+
+The architect notes appended to
+`docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md`
+ratify the PR #37 design decisions.
 
 ---
 

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #36.
+> Last updated: PR #36 + chore-backlog audit (issues #15-#28).
 
 ---
 
@@ -8,6 +8,41 @@
 
 Deliver the **Friends epic** (FR-FR-01 through FR-FR-04), establishing the social
 graph that all downstream features (expenses, settlements, groups) depend upon.
+
+---
+
+## ⚠ Critical Cross-PR Constraints
+
+These constraints span multiple PRs and MUST be honoured. They are surfaced
+here so the next orchestrator / PM / architect cannot accidentally violate
+them by sequencing PRs in isolation.
+
+### C-1: Bundle chore #25 with PR #38 (FR-EX-01)
+
+**Chore #25** ([Expense event naming convention decision](https://github.com/avtansh-code/OneByTwo/issues/25))
+MUST be resolved in the same PR as FR-EX-01 (expense creation UI). The
+choice is between `expense_added` / `expense_add_failed` and
+`expense_save_succeeded` / `expense_save_failed`.
+
+**Why bundle:** PR #38 is the FIRST PR that logs any expense analytics
+event. Once the first event ships, every downstream funnel chart, alert,
+and Sprint 3+ instrumentation inherits the naming convention. Splitting
+the decision into a separate later chore PR would force a backfill on the
+event taxonomy AND on every test that asserts event names — a meaningful
+rework cost for zero benefit.
+
+**Operational rule:** PR #38 cannot ship without:
+1. The naming-convention decision recorded in
+   `docs/design/07-technical/telemetry-plan.md` (and any related
+   telemetry index).
+2. All expense events in `lib/features/expenses/**` using the chosen
+   names.
+3. Issue #25 closed in the same PR (`Closes #25` in the PR body) with a
+   comment summarising the decision and citing the affected files.
+
+**Architect's call:** the decision itself is the architect's at PR #38
+kickoff. The orchestrator MUST refuse to start FR-EX-01 implementation
+work until the decision is recorded in the story file's Architect Notes.
 
 ---
 
@@ -148,3 +183,73 @@ inherit:
 The architect notes appended to
 `docs/sprint-zero/stories/FR-SE-03-04-expense-trigger-friendship.md`
 ratify all design decisions taken in this PR.
+
+---
+
+## Sprint 2 Chore Backlog (open GitHub issues)
+
+The Sprint 1 boundary audit (PR #14) deferred 37 findings into Bucket B.
+Fourteen of those were filed as labelled GitHub issues
+(`sprint-2-chore`) with numbers **#15-#28**. None are closed on GitHub yet,
+but several have been partially or fully addressed by Sprint 2 feature
+PRs (#31-#36). The table below is the audited status as of PR #36.
+
+Status legend:
+- **Closed-in-code** — work is complete in the repository; the GitHub
+  issue can be closed by ticking the relevant checklist and merging
+  evidence of the fix. Sprint-1 burndown
+  (`docs/audits/sprint-1/07-bucket-b-burndown.md`) is the authority on
+  which Bucket-B IDs are formally resolved.
+- **Partially addressed** — at least one named Bucket-B sub-item is
+  resolved; remainder is still open under the same issue.
+- **Open** — no work done yet.
+
+| # | Title | Audit IDs | Status | Verification |
+|---|---|---|---|---|
+| [#15](https://github.com/avtansh-code/OneByTwo/issues/15) | Rename `authStateNotifierProvider` to `authStateProvider` | M1 | Open | 10+ references still use the old name across `lib/main.dart`, `lib/features/profile/**`, `lib/features/auth/presentation/**`. |
+| [#16](https://github.com/avtansh-code/OneByTwo/issues/16) | Missing secondary telemetry events + `is_new_user` typing | T3, T4, T5 | Open | `phone_entry_viewed` / `phone_validation_failed` / `otp_verification_started` / `otp_send_requested` not yet emitted; `is_new_user` still logged as `int` (`otp_entry_controller.dart:215` — `value.isNewUser ? 1 : 0`); `signup_otp_submitted` decision not recorded. |
+| [#17](https://github.com/avtansh-code/OneByTwo/issues/17) | Relocate core providers to `lib/core/providers/` | M4 | Open | `lib/core/providers/` does not exist; `firebaseFirestoreProvider`, `firebaseStorageProvider`, `phoneAuthRepositoryProvider` still in feature trees. |
+| [#18](https://github.com/avtansh-code/OneByTwo/issues/18) | Screen-spec alignment (splash, phone entry, OTP) | S1, S3, S4, S5 | Open | Splash uses `Duration(seconds: 3)` (`splash_screen.dart:19`); spec says 1500 ms. Other items (inline-vs-snackbar OTP error, live phone formatting, exhausted-resend copy) still unresolved. |
+| [#19](https://github.com/avtansh-code/OneByTwo/issues/19) | Add PR coverage tracking to conventions | CV2 | Partially addressed | `feature-pr-conventions.md` has an enforced-thresholds section and `.github/PULL_REQUEST_TEMPLATE.md` has a "Coverage thresholds maintained" checkbox. **Still missing:** explicit before/after coverage fields requested by the issue. |
+| [#20](https://github.com/avtansh-code/OneByTwo/issues/20) | Improve test coverage gaps | SC1, SC2, SC3, SC4, **CV3** | Partially addressed | **CV3 closed by PR #36** — `functions/src/simplified-debts/function.ts` branch coverage now **90%** (was 76%) thanks to the `recomputeAndWrite` variant 2.3(b) refactor. SC1 (concurrent submit guard), SC2 (OTP auto-retrieval timeout), SC3 (`MAX_SAFE_INTEGER`), SC4 (large-group scalability) still open. |
+| [#21](https://github.com/avtansh-code/OneByTwo/issues/21) | Firestore + Storage rules test gaps | **R1, R2, R3, R4**; R5-R8 | Partially addressed | **R1, R2, R3 closed by PR #32** (friendship create/update/delete rules tests). **R4 closed by PR #36** — new `expenses-friendship.test.ts` covers 45 cases including sum check, extension-point locks, immutables, soft-delete. R5-R6 (group rules) still open (Sprint 3). R7-R8 (Storage avatar file-size / content-type) still open — `storage-rules/avatars.test.ts` only covers basic read/write. |
+| [#22](https://github.com/avtansh-code/OneByTwo/issues/22) | Dependency upgrades — Riverpod 3.x, share_plus, firebase-functions 7.x | D1, D2, D4, D5, D6, D7 | Open | No upgrade PRs merged. Firebase deploy warnings surfaced D5 (`firebase-functions` 6→7) and the Node 20 deprecation deadline (Oct 2026). |
+| [#23](https://github.com/avtansh-code/OneByTwo/issues/23) | Expand integration tests for Sprint 2 flows | PY3, RT2, INV2 | Partially addressed | **PR #36 enabled `npm run test:integration` inside `firebase emulators:exec`** — every future trigger PR exercises its actual registration in CI (helps PY3). Friend-add stub `test/integration/friends/friends_list_flow_test.dart` shipped in PR #35 (still skipped). RT2 (CI step duration logging) not yet added. INV2 (share-sheet verification) — system share sheet is the only path, but no test asserts the package-import boundary. Expense-create flow integration tests blocked on FR-EX-01. |
+| [#24](https://github.com/avtansh-code/OneByTwo/issues/24) | Conventions doc — CF PR checklist and Jest config separation | CN3, CN4 | Open | `feature-pr-conventions.md` does not yet enumerate the Jest config split (`jest.config.js` vs `jest.rules.config.js` vs `jest.integration.config.js`) nor CF-specific PR checklist items (region pinning, error-code mapping, transaction usage, idempotency). |
+| [#25](https://github.com/avtansh-code/OneByTwo/issues/25) | Expense event naming convention decision | SR8 | **Open — blocking PR #38 (see Critical Constraint C-1 above)** | Decision must be taken before FR-EX-01 ships. No expense events shipped yet; `lib/` grep for `expense_added` / `expense_save_succeeded` returns zero matches. |
+| [#26](https://github.com/avtansh-code/OneByTwo/issues/26) | Release pipeline secrets + DPDP legal sign-off | S2_sec, SR12 | Open | Sprint 6 work — explicit tracking required before release execution. |
+| [#27](https://github.com/avtansh-code/OneByTwo/issues/27) | Float/double rejection hook for Invariant 1 | INV3 | Open — low priority | The type system already enforces Invariant 1; a hook would be belt-and-braces. DoD grep across `lib/**` and `functions/src/**` for `double.*amountPaise` returns 0 in PR #36, so the gap is theoretical. |
+| [#28](https://github.com/avtansh-code/OneByTwo/issues/28) | Friends HTML mockup | SR3 | Open | `docs/design/05-mockups/` has 8 HTML mockups but no friends-flow mockup. Wireframes and screen specs exist; only the HTML is missing. |
+
+### Issue closure candidates (close-with-evidence PR)
+
+The following issues are partially or fully resolved by Sprint 2 feature
+PRs and should be closed in a dedicated chore PR that adds a comment
+linking the resolving commit:
+
+- **#20** — close the CV3 sub-item with a comment citing the
+  PR #36 coverage report (`functions/src/simplified-debts/function.ts`
+  at 90% branch). The remaining sub-items (SC1, SC2, SC3, SC4) stay open
+  under a re-scoped follow-up.
+- **#21** — close the R1-R4 sub-items with comments citing PR #32
+  (friendship rules tests) and PR #36 (`expenses-friendship.test.ts`).
+  Re-scope the remaining sub-items (R5-R8) into the groups epic and a
+  Storage-rules chore.
+
+### Recommended sequencing (chores vs. feature pairing)
+
+Some chores pair naturally with upcoming feature work; others are best
+batched into a standalone chore PR. The orchestrator's recommendation:
+
+| Pair with | Issues | Rationale |
+|---|---|---|
+| **PR #37 (`onSettlementWrite`)** | none required | Settlements work has its own scope; do not bundle chores. |
+| **PR #38 (FR-EX-01 expense creation UI)** | **#25** | **MANDATORY bundle — see Critical Constraint C-1 at the top of this document.** Naming convention MUST be decided before the first expense event is logged; bundling avoids retrofitting every downstream funnel chart, alert, and test. |
+| **Standalone chore PR (Sprint 2 polish — 3 SP)** | **#15, #17, #19** | Pure mechanical refactor + template edit. Low risk. Fast feedback. |
+| **Standalone chore PR (telemetry sweep — 2 SP)** | **#16, #18 (S5 only)** | Both touch auth/OTP screens; one PR keeps the analytics changes coherent. |
+| **Pre-FR-EX-01 design polish PR (2 SP)** | **#18 (S1, S3, S4), #28** | Spec alignment + friends mockup before the expense screens land so the design system stabilises. |
+| **Standalone CF chore PR (Sprint 3 ramp — 3 SP)** | **#24** | CF PR checklist + Jest config docs make Sprint 3's groups trigger work less ambiguous. |
+| **Defer to Sprint 3** | **#21 (R5-R8)** | Group rules tests pair with the groups epic; Storage size/content-type can also wait. |
+| **Defer to Sprint 4+** | **#22, #27** | Dependency upgrades and the Invariant-1 hook are non-urgent; type system + boundary contracts suffice for now. |
+| **Defer to Sprint 6** | **#26** | Release-only secrets and DPDP review explicitly tied to release execution. |
+| **Already covered** | **#23 (PY3 partial)** | PR #36 enabled `test:integration` in CI. Remaining INV2 / RT2 sub-items deferred. |

--- a/docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md
+++ b/docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md
@@ -1,0 +1,776 @@
+# FR-SE-05/06: `onSettlementWrite` Cloud Function Trigger
+
+> Implementation-ready user story for the second automatic Firestore trigger in
+> the application and the first on a **top-level collection**. Wraps the
+> existing `recomputeSimplifiedBalances` algorithm in a Firestore
+> `onDocumentWritten` trigger at `settlements/{settlementId}`, extends
+> `recomputeAndWrite` to actually READ settlements into the net-balance
+> computation (the algorithm catalogue's "settlements" row of the read table
+> becomes truthful for the first time), and ships the missing Firestore
+> security rules so clients can write settlements at all.
+
+---
+
+## SRS Requirement ID(s)
+
+FR-SE-05 (SRS section 4.6 — settlements are recorded by the algorithm),
+FR-SE-06 (SRS section 4.6 — partial settlements are supported),
+FR-EX-04 (SRS section 4.5 — paise integers; symmetric for settlement
+amountPaise).
+
+## Relevant SRS Sections
+
+- Section 4.6 — Simplify & Settle
+- Section 5.4 — Privacy and PII handling
+- Section 5.10 — Observability
+- Section 7.1 — Cloud Functions runtime (region pinning)
+- Section 7.2 — Firestore schema (`settlements/{settlementId}`)
+- Section 7.3 — Key architectural decisions (Invariant 1; Invariant 2
+  parallel for `verificationStatus` per ARCH-EXT-06)
+- Section 7.5 — Security rules (settlements)
+
+## Priority
+
+**P0 — Must have.** Settlements that do not affect `simplifiedBalances` are
+useless to users. The algorithm extension is the load-bearing piece; without
+it, the trigger ships meaningless side-effects. Shipping this trigger BEFORE
+the first client producer of settlements (FR-SE-08 / settle-up UI) means
+balances "just work" the moment the settle-up flow lands.
+
+## Story Points
+
+**5.** Three concerns bundled (security rules + algorithm core extension +
+trigger), each small (~150 lines code + tests). Patterns from PR #36 are
+ratified; this story reuses, does not re-derive.
+
+## User Story
+
+As a **member of a friendship**,
+I want **the app to recompute the simplified balance and bump the activity
+timestamp automatically whenever any settlement involving me is created,
+edited, or soft-deleted**,
+so that **after I pay my friend back (or they pay me back), the friends list
+and per-friend net-balance pill immediately reflect the post-payment
+truthful state without any client-side orchestration**.
+
+## Preconditions
+
+1. A friendship document exists at `friendships/{fid}` with valid
+   `memberIds` (two sorted UIDs) and a server-managed `simplifiedBalances`
+   field (initialised to `{}` by Cloud Functions per Invariant 2 and now
+   correctly reflecting expenses thanks to PR #36's
+   `onExpenseWriteFriendship` trigger).
+2. The shared `recomputeAndWrite` core from PR #36 is live in
+   `functions/src/simplified-debts/function.ts` and exports the typed
+   `RecomputeResult` discriminated union.
+3. The `hashId()` utility from PR #36 is live at
+   `functions/src/utils/id-hash.ts`.
+4. The trigger deploys to `asia-south1` (Mumbai) per SRS section 7.1.
+5. The Firebase Emulator Suite is available for pre-merge integration
+   testing (Firestore on port 8181, Functions on port 5001, per
+   `firebase.json`).
+6. The settlement write originates from the `fromUserId` (debtor) per the
+   new security rules.
+
+---
+
+## Acceptance Criteria
+
+### AC-1 — Settlements rules: create allowed for `fromUserId` only
+
+> Given an authenticated user
+> When they write a settlement to `settlements/{settlementId}` with
+> `fromUserId == request.auth.uid` AND all schema invariants satisfied
+> (amount > 0, valid context discriminator, both parties are members of
+> the parent context, extension-point locks satisfied, allowed key set
+> exactly)
+> Then the write succeeds.
+>
+> Given `fromUserId != request.auth.uid`
+> Then the write is rejected by the security rules.
+
+### AC-2 — Settlements rules: read allowed for both parties
+
+> Given a settlement with `fromUserId: A` and `toUserId: B`
+> Then both A and B can read the document
+> And outsiders cannot read
+> And unauthenticated callers cannot read.
+
+### AC-3 — Settlements rules: `verificationStatus` is server-only
+
+> Given a settlement exists with `verificationStatus: 'unverified'`
+> When a client attempts to update the field to ANY other value
+> (`'verified'`, `'pending'`, `'failed'`, even back to `'unverified'`
+> with the diff still flagging the affected key)
+> Then the write is rejected by the field-level diff rule.
+>
+> This is the **Invariant-2 parallel for settlements** per ARCH-EXT-06.
+> v1.0 leaves `verificationStatus` at the literal `'unverified'` default
+> and no server logic writes it; the rules are the enforcement mechanism.
+
+### AC-4 — Settlements rules: extension-point locks
+
+> Given a settlement create
+> Then `method == 'manual'` (ARCH-EXT-01), `currency == 'INR'`
+> (ARCH-EXT-02), and `verificationStatus == 'unverified'` (ARCH-EXT-06)
+> are mandatory
+> And any other value for these fields is rejected
+> And `contextType in {'friendship', 'group'}` is enforced
+> And both `fromUserId` and `toUserId` must be in the parent context's
+> `memberIds`.
+
+### AC-5 — Settlements rules: immutability of historical fields
+
+> Given a settlement exists
+> When a client attempts to mutate `fromUserId`, `toUserId`,
+> `amountPaise`, `contextType`, `contextId`, `date`, `method`,
+> `currency`, `createdAt`, or `note`
+> Then the write is rejected.
+>
+> The ONLY mutable field is `deleted` (soft-delete via setting
+> `deleted: true`). Settlements are historical records; the supported
+> correction path is soft-delete plus a new settlement.
+
+### AC-6 — Settlements rules: hard delete denied
+
+> Given a settlement exists
+> When any client attempts to hard-delete the document
+> Then the write is rejected
+> And admin-SDK paths (e.g. cleanup scripts) bypass the rules as usual.
+
+### AC-7 — `recomputeAndWrite` reads settlements
+
+> Given a friendship has both expenses AND settlements (the latter is the
+> NEW data class fed into the algorithm in this PR)
+> When the algorithm runs
+> Then the net balance for each member reflects BOTH:
+> - Expense splits (payer credited +amountPaise; each split member
+>   debited −sharePaise; the existing PR #12 / PR #36 behaviour).
+> - Settlement payments (the `fromUserId` credited +amountPaise — the
+>   payment reduces their debt; the `toUserId` debited −amountPaise —
+>   the recipient is now owed less).
+> And the resulting `simplifiedBalances` map matches the canonical
+> settlement test matrix.
+
+### AC-8 — `recomputeAndWrite` filters soft-deleted settlements
+
+> Given a settlement document with `deleted: true`
+> When the algorithm runs
+> Then the soft-deleted settlement is excluded from the net-balance
+> computation
+> And the resulting `simplifiedBalances` matches the state computed from
+> the non-deleted settlement set
+> (same posture as expenses — `where('deleted', '!=', true)` or in-code
+> filter; see Architect Notes §2 for the chosen implementation).
+
+### AC-9 — Trigger fires on settlement create
+
+> Given a settlement is written to `settlements/{settlementId}` with
+> `contextType: 'friendship'`, `contextId: 'fid'`
+> When the trigger fires
+> Then within the invocation window the parent friendship doc
+> `friendships/fid` has:
+> - `simplifiedBalances` recomputed (now reflecting BOTH expenses and the
+>   new settlement)
+> - `lastActivityAt` updated to the trigger's `event.time` (subject to
+>   the monotonicity guard from PR #36 AC-12).
+> And both writes happen in the same Firestore transaction (atomicity
+> property inherited from PR #36 AC-6).
+
+### AC-10 — Trigger fires on settlement update and soft-delete
+
+> Given an existing settlement
+> When a client soft-deletes the settlement (sets `deleted: true`)
+> Then the recomputation runs and the resulting `simplifiedBalances`
+> excludes the soft-deleted settlement.
+>
+> Given an existing settlement
+> When ANY field is modified (including the soft-delete branch above)
+> Then the trigger fires the recompute path
+> And the on-document-after side carries the post-edit data shape from
+> which the discriminator (`contextType`, `contextId`) is read.
+
+### AC-11 — Trigger fires on hard delete (admin SDK only)
+
+> Given an existing settlement
+> When the document is hard-deleted (admin SDK only — client hard-deletes
+> are denied per AC-6)
+> Then the trigger fires
+> And the discriminator (`contextType`, `contextId`) is read from the
+> `change.before` snapshot data (the `change.after` snapshot has
+> `exists == false` on hard delete)
+> And the recomputation runs over the remaining settlement set.
+
+### AC-12 — Trigger handles missing context gracefully
+
+> Given a settlement with `contextType: 'friendship'` and a `contextId`
+> pointing at a deleted friendship doc
+> When the trigger fires
+> Then the handler logs
+> `simplified_debts_compute_failed { errorCode: 'CONTEXT_NOT_FOUND' }`
+> via structured logging
+> And the handler returns successfully (no throw) so Cloud Functions
+> does NOT retry
+> And no orphaned writes are produced.
+>
+> (Mirror of PR #36 AC-10.)
+
+### AC-13 — Stale-event guard
+
+> Given a settlement-trigger event whose `event.time` is older than 7
+> days (the Cloud Functions event-delivery retention window)
+> When the trigger receives the event
+> Then the handler logs `settlement_trigger_stale_event_dropped` and
+> returns successfully without writing.
+>
+> (Mirror of PR #36 AC-11.)
+
+### AC-14 — `lastActivityAt` monotonicity
+
+> Given two settlement-trigger invocations for the same friendship
+> arrive out of order
+> When the later invocation by wall-clock arrival has an earlier
+> `event.time`
+> Then the trigger writes `max(existingLastActivityAt, eventTimestamp)`
+> so the field never regresses.
+>
+> (Mirror of PR #36 AC-12 — the monotonicity guard lives in the shared
+> `recomputeAndWrite` core; the settlement trigger inherits it for free.)
+
+### AC-15 — Canonical settlement test cases pass end-to-end
+
+> The integration test suite walks the following matrix end-to-end via
+> the registered trigger (not via direct DI):
+>
+> **Case A — Full debt settlement (zeros the debt)**
+> > Given B owes A 5000 paise (from one expense, equal split of 10000)
+> > When B pays A 5000 paise (a settlement of `fromUserId: B, toUserId: A,
+> > amountPaise: 5000`)
+> > Then `simplifiedBalances` becomes `{}` (empty — no residual debt).
+>
+> **Case B — Partial settlement (FR-SE-06)**
+> > Given B owes A 5000 paise
+> > When B pays A 2000 paise (a partial settlement)
+> > Then `simplifiedBalances` becomes `{B: {A: 3000}}` — the residual
+> > debt is precisely the unpaid portion.
+> > This satisfies FR-SE-06 without any additional algorithm support
+> > (the algorithm naturally handles partials because settlements
+> > directly adjust the net-balance map).
+>
+> **Case C — Overshoot (debtor pays more than owed)**
+> > Given B owes A 5000 paise
+> > When B pays A 8000 paise (overshoots the debt by 3000)
+> > Then `simplifiedBalances` becomes `{A: {B: 3000}}` — the net
+> > balance flips sign; A now owes B 3000. The algorithm correctly
+> > handles this because the net-balance map is signed and the
+> > simplify step is sign-agnostic.
+
+### AC-16 (Regression — Invariant 2) — `simplifiedBalances` still client-read-only
+
+> The new settlements code does NOT introduce a second writer of
+> `simplifiedBalances` in `functions/src/**`. The existing
+> field-level diff rule on `friendships/{id}` and `groups/{id}`
+> continues to reject any client write attempt.
+>
+> Verification: grep across `functions/src/**` for
+> `tx.update.*simplifiedBalances` MUST return exactly 1 match (the
+> existing `recomputeAndWrite` writer; the settlements-read extension
+> does NOT add a second).
+
+### AC-17 (Regression) — Existing `onExpenseWriteFriendship` still works
+
+> The extension to `recomputeAndWrite` (now reading settlements
+> alongside expenses) MUST NOT regress PR #36's behaviour.
+>
+> Verification: the existing `on-expense-write.integration.test.ts`,
+> `simplified-debts.integration.test.ts`, and the boundary tests in
+> `functions/test/triggers/on-expense-write/function.test.ts` and
+> `functions/test/simplified-debts/function.test.ts` ALL pass without
+> modification.
+
+---
+
+## Telemetry Events
+
+Server-side structured logging via `firebase-functions/logger` (NOT client
+Firebase Analytics). All events are PII-free per SRS section 5.4 and
+ADR-0013. Friendship IDs (`{uidA}_{uidB}`) and settlement IDs are hashed
+via `functions/src/utils/id-hash.ts` (`hashId()` — SHA-256 truncated to 16
+hex chars) before logging.
+
+| Event name | Parameters | Trigger |
+|---|---|---|
+| `settlement_trigger_fired` | `contextType: 'friendship' \| 'group'`, `contextIdHash: string` (16 hex), `settlementIdHash: string` (16 hex), `changeType: 'create' \| 'update' \| 'delete'`, `eventTime: string` (ISO 8601) | Top of handler, before any work. Fires for every invocation regardless of outcome. |
+| `settlement_trigger_stale_event_dropped` | `contextType`, `contextIdHash`, `settlementIdHash`, `eventTime`, `ageMs: number` | Stale-event guard (AC-13). |
+| `simplified_debts_compute_started` | `contextType`, `contextIdHash` | Emitted by the trigger wrapper around the shared `recomputeAndWrite` core. |
+| `simplified_debts_compute_completed` | `contextType`, `contextIdHash`, `elapsedMs: number`, `transferCount: number` | Emitted by the trigger wrapper on successful core completion. |
+| `simplified_debts_compute_failed` | `contextType`, `contextIdHash`, `errorCode: 'CONTEXT_NOT_FOUND' \| 'BALANCE_INVARIANT_VIOLATED' \| 'INTERNAL'`, `elapsedMs: number` | Emitted by the trigger wrapper on every failure path. |
+
+**Strict PII guard:** the structured logger NEVER receives `fromUserId`,
+`toUserId`, `amountPaise`, `date`, `note`, or any raw UID-containing
+identifier (including the unhashed `friendshipId`). Only opaque
+`settlementIdHash`/`contextIdHash` values and contextType discriminators
+are loggable. A `function.test.ts` PII guard explicitly asserts this
+contract using a realistic `{uidA}_{uidB}` friendship-id value AND a
+realistic settlement ID.
+
+---
+
+## Invariant Applicability Assessment
+
+| # | Invariant | Applicability |
+|---|---|---|
+| 1 | Money is integer paise | **Applicable.** Settlement `amountPaise` is an integer; the algorithm's settlement-credit/debit is integer arithmetic. No `double` or `float`. The new rules enforce `amountPaise is int && amountPaise > 0`. |
+| 2 | `simplifiedBalances` server-maintained | **Applicable.** The write site remains the single `tx.update(contextRef, {...guardedAlsoSet, simplifiedBalances})` inside `recomputeAndWrite`. The new settlement read is INPUT to the algorithm, not a second writer of `simplifiedBalances`. The DoD grep expectation is unchanged: exactly 1 write site in `functions/src/**`. |
+| 2-parallel | `verificationStatus` on settlements (per ARCH-EXT-06) | **Applicable.** The new rules enforce this. There is currently no server-side writer of `verificationStatus` in v1.0 (the field stays at `'unverified'`); the Invariant-2-parallel is enforced by the rules alone. |
+| 3 | System share sheet only | N/A. This story has no client UI and no outbound sharing surface. |
+| 4 | Single Firebase project | **Applicable.** The trigger deploys to the single production project in `asia-south1`. Integration tests run against the Firebase Emulator Suite. |
+
+PII / ADR-0013 compliance: friendship document IDs follow the
+`{uidA}_{uidB}` composite-UID pattern (per the schema and PR #32
+deterministic-ID rule). Settlement IDs are auto-generated opaque
+Firestore IDs (safe to log raw, but hashed for log-format parity with
+the expense trigger). The trigger MUST hash both `friendshipId` and
+`settlementId` before any structured log call. `functions/src/utils/id-hash.ts`
+(`hashId()` — SHA-256 truncated to 16 hex chars / 64 bits) is the shared
+utility introduced in PR #36 and reused here. Affirmative test:
+`function.test.ts` "never logs PII (raw UIDs in friendshipId,
+fromUserId/toUserId, amounts, note)" exercises the contract with a
+realistic `{uidA}_{uidB}` friendship-id value.
+
+---
+
+## Definition of Done
+
+Reference: `docs/design/08-plan/definition-of-ready-and-done.md`
+
+- [ ] Code merged to `main` via approved PR.
+- [ ] New trigger module deployed to `asia-south1` (Mumbai) — verified via
+      the manual smoke matrix in the PR body.
+- [ ] Function-boundary unit tests passing (mocked Firestore, no emulator
+      needed). Per-module coverage ≥ 70% for
+      `functions/src/triggers/on-settlement-write/`.
+- [ ] Security-rules unit tests passing against the Firestore emulator on
+      port 8181 (`npm run test:rules`). New file
+      `functions/test/firestore-rules/settlements.test.ts` covers AC-1
+      through AC-6 exhaustively.
+- [ ] Integration tests passing against the Firebase Emulator Suite
+      (`npm run test:integration` inside `firebase emulators:exec`). The
+      canonical settlement matrix (AC-15) and the atomicity assertion
+      (AC-9) are exercised through the actual registered trigger.
+- [ ] Existing `on-expense-write.integration.test.ts` and
+      `simplified-debts.integration.test.ts` continue to pass without
+      modification (AC-17 regression).
+- [ ] QA manual smoke matrix completed and signed off (Phase 5 step 7 of
+      `docs/copilot_prompts/sprint_2/6.md`).
+- [ ] Telemetry events in place and PII-free (verified by the PII guard
+      test).
+- [ ] Invariant compliance confirmed (Invariants 1, 2, 2-parallel for
+      `verificationStatus`, 4 — see assessment above).
+- [ ] Coverage gate green (Functions overall ≥ 50%; new module ≥ 70%;
+      existing `simplified-debts/` not regressed below the PR #36
+      baseline of 86.44% branch).
+- [ ] Documentation updated: `cloud-functions-catalogue.md` Appendix A
+      status flip (`onSettlementWrite` planned → shipped); section 1
+      READ TABLE now truthful for the settlements row;
+      `firestore-security-rules.md` settlements section reconciled with
+      the implementation; `firestore-schema.md` settlements schema
+      reconciled with the implementation (adds `deleted` and
+      `createdAt` fields to the table); `sprint-2-plan.md`,
+      `next-three-prs.md` rolled.
+- [ ] Composite index for settlements declared in
+      `firestore.indexes.json`.
+- [ ] No open S1 or S2 bugs.
+
+---
+
+## Invariant Compliance
+
+- [ ] Invariant 1 (paise): settlement compute is pure integer arithmetic;
+      rules `is int` checks reject any `double`/`float` inputs.
+- [ ] Invariant 2 (`simplifiedBalances` server-only): the trigger does
+      NOT introduce a second writer; the field-level diff rule on
+      `friendships/{id}` and `groups/{id}` continues to reject client
+      writes (AC-16 regression).
+- [ ] Invariant 2-parallel (`verificationStatus` server-only): the new
+      settlements rules reject any client mutation of the field
+      (AC-3).
+- [ ] Invariant 3 (system share sheet only): N/A in this story.
+- [ ] Invariant 4 (single Firebase project): compliant — production only,
+      with emulator-backed pre-merge verification.
+
+---
+
+## Design Artefact References
+
+| Artefact | Path |
+|---|---|
+| Cloud Functions catalogue (Section 3 — `onSettlementWrite`) | `docs/design/07-technical/cloud-functions-catalogue.md` |
+| Firestore schema (`settlements/{settlementId}`) | `docs/design/07-technical/firestore-schema.md` |
+| Firestore security rules (settlements section) | `docs/design/07-technical/firestore-security-rules.md` |
+| Simplified-debts algorithm (settlement semantics) | `docs/design/07-technical/simplified-debts-algorithm.md` |
+| Cloud Functions error codes | `docs/design/07-technical/cloud-functions-error-codes.md` |
+| Extension-points register (ARCH-EXT-01, -02, -06) | `docs/design/07-technical/extension-points-register.md` |
+| PR #12 callable story | `docs/sprint-zero/stories/FUNC-01-simplified-debts-stub.md` |
+| PR #36 expense trigger story (precedent for this PR) | `docs/sprint-zero/stories/FR-SE-03-04-expense-trigger-friendship.md` |
+| Feature-PR conventions | `docs/patterns/feature-pr-conventions.md` |
+
+---
+
+## Responsible Agents
+
+| Agent | Responsibility |
+|---|---|
+| PM | Story authorship, AC clarity, scope discipline (no widening to activity-feed/FCM/verification-state-machine/groups-expense-binding in this PR). |
+| Architect | Source-layout decision, algorithm-extension semantics, settlements rules layout, in-code filter for soft-deleted settlements, composite-index requirement, retry semantics. |
+| Cloud Functions Dev | Trigger module implementation, `recomputeAndWrite` settlement-read extension, security-rules block, function-boundary tests, integration tests. |
+| DevOps | No CI workflow changes needed (PR #36 already added `npm run test:integration` inside `firebase emulators:exec`). The new trigger and integration test plug into the same step. |
+| QA | Manual smoke matrix sign-off (Phase 5 step 7), DoD §3 sign-off with screenshots of friends-list real-time updates reflecting settlement-adjusted balances and emulator logs showing trigger fires. |
+
+---
+
+## Technical Notes
+
+- **Trigger path:** `settlements/{settlementId}` (top-level collection).
+  First trigger on a top-level collection in the application's history;
+  PR #36 covered the subcollection-scoped case.
+- **Region:** `asia-south1` (Mumbai) per SRS section 7.1.
+- **Retry:** v2 trigger options `{retry: true}`. Transient errors throw
+  and Cloud Functions retries. CONTEXT_NOT_FOUND returns successfully
+  (no retry); stale events drop.
+- **Shared core:** `recomputeAndWrite` from PR #36 — **public signature
+  unchanged**. Settlements are an internal implementation detail of the
+  algorithm reading shape; callers all invoke with
+  `{contextType, contextId, alsoSet}`. The fact that settlements now
+  feed in is transparent to them.
+- **Algorithm semantics:** the pure `simplifyDebts()` in
+  `algorithm.ts` is **LOCKED** — settlements semantics enter via
+  `computeNetBalances()` in `function.ts` which now accepts both
+  expenses and settlements and folds them into the net-balance map.
+- **Atomicity:** `simplifiedBalances` and `lastActivityAt` are written
+  in the SAME `tx.update(contextRef, ...)`. The settlement trigger
+  passes `alsoSet: { lastActivityAt: max(existing, eventTimestamp) }`
+  to the core, identical to the expense trigger pattern.
+- **Test paths:**
+  - `functions/test/triggers/on-settlement-write/function.test.ts` —
+    boundary unit tests (mocked Firestore + logger).
+  - `functions/test/firestore-rules/settlements.test.ts` —
+    `@firebase/rules-unit-testing` against emulator.
+  - `functions/test/integration/on-settlement-write.integration.test.ts` —
+    end-to-end via the registered trigger inside
+    `firebase emulators:exec --only auth,firestore,functions,storage`.
+  - `functions/test/simplified-debts/function.test.ts` — extended with
+    settlement-input mock cases.
+  - `functions/test/simplified-debts/algorithm.property.test.ts` —
+    extended to assert zero-sum preservation under mixed
+    expense+settlement sequences.
+
+---
+
+## Out of Scope (explicitly deferred — hand-off seams documented in code)
+
+- **`onExpenseWriteGroup` trigger binding.** Sprint 3 (groups epic). The
+  shared `recomputeAndWrite` core already supports the groups context as
+  a one-line addition; the binding is deferred until groups exist in
+  production.
+- **Activity-feed item writes
+  (`activity/{userId}/items/{itemId}`).** FR-AC-01 in a later sprint.
+  Hand-off seam: `// TODO(FR-AC-01)` comment in the trigger source.
+- **FCM push notifications to the recipient.** FR-AC-03 in a later
+  sprint. Requires the notification permission flow, per-user
+  `fcmTokens` plumbing, and the `notificationPrefs.settlement` toggle.
+  Hand-off seam: `// TODO(FR-AC-03)` comment.
+- **Flutter settlement-creation UI (FR-SE-08 / settle-up flow).**
+  Later PR. The trigger ships BEFORE its first client producer so
+  balances "just work" when the UI lands.
+- **`verificationStatus` state machine** (transitions from
+  `'unverified'` to `'pending'`, `'verified'`, `'failed'`). Post-v1.0
+  (UPI integration per ARCH-EXT-06). v1.0 leaves the field at the
+  literal `'unverified'` default; the rules enforce server-only;
+  that's all this PR ships.
+- **Any modification to `functions/src/simplified-debts/algorithm.ts`.**
+  The pure `simplifyDebts()` is LOCKED (PR #12 covered the canonical
+  6-case matrix to 100%). Only `computeNetBalances` in `function.ts`
+  is extended to fold settlement data into the net-balance map.
+- **Any change to the Flutter codebase.** The friends-list reader will
+  pick up the new balances via the existing snapshot stream from
+  PR #35 — no client diff is necessary or appropriate.
+- **Fix for the pre-existing `lookup-user-by-phone-number` rate-limit
+  doc-path bug** (5 `describe.skip`'d integration tests surfaced by
+  PR #36). Out of scope; separate follow-up PR.
+- **Changes to `recomputeAndWrite`'s public signature.** Settlements
+  are an internal read concern; callers (callable + expense trigger +
+  new settlement trigger) all invoke unchanged.
+
+---
+
+## Architect Notes
+
+> Appended for PR #37. These notes ratify the design decisions taken
+> before implementation begins. References:
+> `docs/copilot_prompts/sprint_2/6.md`,
+> `.github/shared/invariants.md`, `.github/shared/decision-log.md`
+> (ADR-0001 simplified debts; ADR-0002 paise integers; ADR-0011 Cloud
+> Functions test-pyramid layers; ADR-0013 PII / telemetry hashing).
+
+### 1. Source layout — new module under `functions/src/triggers/`
+
+- **Folder:** `functions/src/triggers/on-settlement-write/` (kebab-case,
+  matching PR #36's `on-expense-write/`).
+- **Files:**
+  - `function.ts` — exports `createTriggerHandler(deps)` mirroring the
+    PR #36 boundary. Reads `contextType` and `contextId` from
+    `change.after?.data() ?? change.before?.data()` (after takes
+    precedence; before is the source on hard delete). Delegates to
+    `recomputeAndWrite` with `alsoSet: {lastActivityAt: eventTimestamp}`.
+  - `index.ts` — registers the trigger using `onDocumentWritten` from
+    `firebase-functions/v2/firestore` with
+    `{region: 'asia-south1', document: 'settlements/{settlementId}', retry: true}`.
+    Re-exported from `functions/src/index.ts` as `onSettlementWrite`.
+- **Test mirror:**
+  - `functions/test/triggers/on-settlement-write/function.test.ts`
+    (boundary unit tests, mocked Firestore).
+  - `functions/test/integration/on-settlement-write.integration.test.ts`
+    (end-to-end via registered trigger inside `firebase emulators:exec`).
+- The trigger handler MUST NOT bake in friendship/group discrimination.
+  It passes `{contextType, contextId}` through to `recomputeAndWrite`
+  and lets the shared core resolve the path. This keeps the trigger
+  context-agnostic and ready for groups (Sprint 3) without
+  modification.
+
+### 2. Extend `recomputeAndWrite` to read settlements in the same transaction
+
+- Inside the existing `db.runTransaction(async tx => { ... })`, add a
+  second `tx.get` for settlements:
+  ```typescript
+  const settlementsRef = db
+    .collection("settlements")
+    .where("contextType", "==", contextType)
+    .where("contextId", "==", contextId);
+  const settlementsSnap = await tx.get(settlementsRef);
+  ```
+- **In-code filter for soft-deleted settlements** rather than chaining a
+  third `.where("deleted", "!=", true)`. Reason: Firestore composite
+  indexes for `==`, `==`, `!=` over three different fields are tedious
+  to maintain and the inequality-prefix rule complicates ordering.
+  Settlement counts per context are small (single-digit to low double
+  digits in v1.0 — friendship cap is 2 members, so settlement velocity
+  is bounded). In-code filter is `O(n)` over a small `n` with negligible
+  cost compared to the transaction's `tx.get` round-trip.
+- The expense subcollection query in PR #36 uses
+  `.where("deleted", "!=", true)` because the expense subcollection is
+  scoped to a single friendship (no other `==` filters present), so the
+  inequality is trivially the only constraint. The settlements query
+  has two equality filters first; the in-code soft-delete filter is the
+  cleanest workaround.
+- Update `computeNetBalances()` to accept BOTH expense snapshots AND
+  settlement snapshots:
+  ```typescript
+  function computeNetBalances(
+    expenseSnapshots: FirebaseFirestore.QueryDocumentSnapshot[],
+    settlementSnapshots: FirebaseFirestore.QueryDocumentSnapshot[],
+  ): Map<string, number> {
+    const net = new Map<string, number>();
+    // ...existing expense fold (unchanged)...
+    for (const snap of settlementSnapshots) {
+      const data = snap.data();
+      if (data.deleted === true) continue; // In-code soft-delete filter.
+      const fromUserId: string = data.fromUserId;
+      const toUserId: string = data.toUserId;
+      const amountPaise: number = data.amountPaise;
+      net.set(fromUserId, (net.get(fromUserId) ?? 0) + amountPaise);
+      net.set(toUserId, (net.get(toUserId) ?? 0) - amountPaise);
+    }
+    return net;
+  }
+  ```
+- **Settlement semantics:** `{fromUserId: A, toUserId: B, amountPaise: N}`
+  represents A paying B N paise. This CREDITS A's net balance (+N — A's
+  debt is reduced) and DEBITS B's net balance (−N — B is now owed less).
+  Combined with the expense fold (payer credited; split members
+  debited), the zero-sum invariant is preserved: every transaction is
+  internally balanced.
+- The `BALANCE_INVARIANT_VIOLATED` check in `simplifyDebts()` (the
+  pure algorithm asserts sum of net balances is zero) MUST still pass
+  after settlements are included. Both expense splits AND settlements
+  preserve the zero-sum property by construction. A property-based test
+  extension (`algorithm.property.test.ts`) generates random mixed
+  expense+settlement sequences and asserts the sum-zero property.
+
+### 3. `recomputeAndWrite` public signature is UNCHANGED
+
+- `RecomputeRequest` and `RecomputeResult` types stay the same.
+  Settlements are an INTERNAL implementation detail of the algorithm
+  reading shape — callers (callable + expense trigger + new settlement
+  trigger) all invoke with `{contextType, contextId, alsoSet}`. The
+  fact that settlements now feed in is transparent to them.
+- This means the existing `createHandler(deps)` callable and the
+  existing `onExpenseWriteFriendship` trigger continue to work
+  unmodified (AC-17 regression).
+
+### 4. Settlement trigger does NOT need new core API
+
+- The trigger reads `contextType` and `contextId` from the settlement
+  document data:
+  ```typescript
+  const data = event.data?.after?.data() ?? event.data?.before?.data();
+  if (!data) { /* log and return — defensive */ }
+  const {contextType, contextId} = data;
+  ```
+  then calls `recomputeAndWrite(deps, {contextType, contextId, alsoSet: {lastActivityAt: eventTimestamp}})`
+  exactly like the expense trigger calls it for friendships.
+- The only difference from the expense trigger is the SOURCE of
+  `{contextType, contextId}`:
+  - Expense trigger: derives from the PATH (`event.params.friendshipId`
+    + literal `'friendship'`).
+  - Settlement trigger: derives from the DOC DATA (because the
+    settlements collection is top-level and the context discriminator
+    lives in the document rather than the path).
+
+### 5. New Firestore Security Rules — `settlements/{settlementId}` block
+
+- Add a new top-level `match /settlements/{settlementId}` block
+  alongside the existing `match /friendships/...` and
+  `match /groups/...` blocks.
+- **Helpers:**
+  - `function contextMemberIds(contextType, contextId)` — for
+    `'friendship'`, do
+    `get(/databases/$(database)/documents/friendships/$(contextId)).data.memberIds`;
+    for `'group'`, do the same with `groups/`. Returns the list.
+  - `function isContextMember(contextType, contextId, uid)` — returns
+    `uid in contextMemberIds(contextType, contextId)`.
+  - `function hasOnlyKnownKeys(data)` — whitelisted field set:
+    `['fromUserId', 'toUserId', 'amountPaise', 'contextType', 'contextId', 'date', 'note', 'method', 'verificationStatus', 'currency', 'createdAt', 'deleted']`.
+    (Adds `deleted` and `createdAt` to the schema field set per §5.1
+    below.)
+  - `function isValidShape(data)` — type and value checks for each
+    field (see Create rule below).
+  - `function isValidContextDiscriminator(data)` —
+    `contextType in ['friendship', 'group']`, `contextId is string`,
+    `contextId.size() > 0`.
+- **Create rule:**
+  ```
+  allow create: if request.auth != null
+    && request.resource.data.fromUserId == request.auth.uid
+    && hasOnlyKnownKeys(request.resource.data)
+    && hasAllRequiredKeys(request.resource.data)
+    && isValidShape(request.resource.data)
+    && isValidContextDiscriminator(request.resource.data)
+    && isContextMember(request.resource.data.contextType,
+                       request.resource.data.contextId,
+                       request.resource.data.fromUserId)
+    && isContextMember(request.resource.data.contextType,
+                       request.resource.data.contextId,
+                       request.resource.data.toUserId)
+    && request.resource.data.fromUserId != request.resource.data.toUserId
+    && request.resource.data.amountPaise is int
+    && request.resource.data.amountPaise > 0
+    && request.resource.data.method == 'manual'           // ARCH-EXT-01
+    && request.resource.data.currency == 'INR'            // ARCH-EXT-02
+    && request.resource.data.verificationStatus == 'unverified' // ARCH-EXT-06
+    && request.resource.data.deleted == false
+    && request.resource.data.createdAt == request.time;
+  ```
+- **Update rule** (ONLY soft-delete; every other field is immutable):
+  ```
+  allow update: if request.auth != null
+    && (request.auth.uid == resource.data.fromUserId
+        || request.auth.uid == resource.data.toUserId)
+    && immutableFieldsPreserved()
+    && verificationStatusUnchanged()
+    && onlyDeletedFlagChanged();
+  ```
+  - `immutableFieldsPreserved()` checks `fromUserId`, `toUserId`,
+    `amountPaise`, `contextType`, `contextId`, `date`, `method`,
+    `currency`, `createdAt`, `note` are unchanged.
+  - `verificationStatusUnchanged()` checks
+    `request.resource.data.verificationStatus == resource.data.verificationStatus`.
+    This is the Invariant-2-parallel field-level diff rule for
+    settlements per ARCH-EXT-06.
+  - `onlyDeletedFlagChanged()` checks the affected-keys set is exactly
+    `{deleted}` AND `request.resource.data.deleted == true` (clients
+    cannot un-delete; restoration is admin-SDK only). This gives the
+    classic monotonic soft-delete contract.
+- **Read rule:**
+  ```
+  allow read: if request.auth != null
+    && (request.auth.uid == resource.data.fromUserId
+        || request.auth.uid == resource.data.toUserId);
+  ```
+- **Delete rule:** `allow delete: if false;` — hard delete is
+  admin-only.
+
+#### 5.1 Schema reconciliation — adds `deleted` and `createdAt`
+
+- The current `firestore-schema.md` settlements table lists 10 fields
+  but does NOT include `deleted` or `createdAt`. The implementation
+  REQUIRES both:
+  - `deleted: bool` (default `false`) — supports soft-delete via
+    update; the algorithm filters `deleted === true` settlements out
+    of the net-balance fold.
+  - `createdAt: timestamp` (immutable; `== request.time` on create) —
+    audit field consistent with every other write-rule-enforced
+    immutable timestamp in the codebase (users, friendships, groups,
+    expenses all have one).
+- The settlements section of `firestore-schema.md` and
+  `firestore-security-rules.md` are updated in this PR to reflect the
+  new field set. The change is additive (no existing settlement docs
+  exist in production), and the schema-doc update is documented in
+  the PR body.
+
+### 6. Idempotency, retry policy, stale-event guard — inherit PR #36
+
+- Trigger uses `{retry: true}`. CONTEXT_NOT_FOUND log+return.
+  BALANCE_INVARIANT_VIOLATED and INTERNAL throw (CF retries). Stale
+  event > 7 days drops with a structured log.
+- The shared `recomputeAndWrite` handles `lastActivityAt` monotonicity
+  for all callers including the new settlement trigger. No new code
+  needed.
+
+### 7. No new ADR required
+
+- Settlements rules + algorithm extension + trigger all fall within
+  existing ADR-0001 (simplified debts is the sole debt mechanism),
+  ADR-0002 (paise integers), ADR-0011 (Cloud Functions test-pyramid
+  layers), and ADR-0013 (PII / telemetry hashing) precedent.
+- The Invariant-2-parallel for `verificationStatus` is captured by
+  ARCH-EXT-06 in the extension-points register — already an
+  architectural decision document.
+- The schema additions (`deleted`, `createdAt`) are
+  field-level additions consistent with the expense pattern;
+  documenting them in the schema/rules docs is sufficient.
+
+### 8. Coverage gate posture
+
+- `functions/src/triggers/on-settlement-write/**` is a NEW module
+  folder. Per-module ≥70% gate applies.
+- `functions/src/simplified-debts/**` sees modest edits (the
+  settlements read + `computeNetBalances` extension). Branch coverage
+  MUST NOT regress below the PR #36 baseline of 86.44% — new tests
+  for the settlements-read branches maintain the gate.
+- Property tests in `algorithm.property.test.ts` are extended to
+  cover mixed expense + settlement sequences.
+
+### 9. Composite index for the settlements query
+
+- The transaction reads `where('contextType', '==', X).where('contextId', '==', Y)`.
+  Firestore composite indexes are required for cross-field `where`
+  combinations. Declared in `firestore.indexes.json`:
+  ```json
+  {
+    "collectionGroup": "settlements",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {"fieldPath": "contextType", "order": "ASCENDING"},
+      {"fieldPath": "contextId", "order": "ASCENDING"}
+    ]
+  }
+  ```
+- The schema doc already lists a (`contextType`, `contextId`, `date`)
+  index for the client settlement-history view, but ours can omit
+  `date` because the algorithm doesn't order — it scans all matching
+  settlements within the transaction. We declare the minimal
+  two-field index needed by the trigger's transaction.
+- Verified against emulator output: the in-emulator Firestore
+  successfully runs the query with this index declared in
+  `firestore.indexes.json`.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         {"fieldPath": "memberIds", "arrayConfig": "CONTAINS"},
         {"fieldPath": "lastActivityAt", "order": "DESCENDING"}
       ]
+    },
+    {
+      "collectionGroup": "settlements",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "contextType", "order": "ASCENDING"},
+        {"fieldPath": "contextId", "order": "ASCENDING"}
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -149,7 +149,7 @@ service cloud.firestore {
     // Expenses subcollection under a friendship — member-only read/write
     // with strict invariant-1 enforcement at the write boundary
     // (FR-EX-04: splits[*].sharePaise must sum to amountPaise).
-    // First subcollection rules for the friendships graph (PR #36 / FR-SE-03/04).
+    // First subcollection rules for the friendships graph (FR-SE-03/04).
     match /friendships/{friendshipId}/expenses/{expenseId} {
 
       // Loaders for cross-doc checks (parent friendship membership)
@@ -356,7 +356,7 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
-    // Settlements collection — top-level (FR-SE-05/06, PR #37).
+    // Settlements collection — top-level (FR-SE-05/06).
     //
     // A settlement document represents a cash payment from `fromUserId`
     // (the debtor) to `toUserId` (the recipient) within a context

--- a/firestore.rules
+++ b/firestore.rules
@@ -355,5 +355,137 @@ service cloud.firestore {
     match /_rateLimits/{document=**} {
       allow read, write: if false;
     }
+
+    // Settlements collection — top-level (FR-SE-05/06, PR #37).
+    //
+    // A settlement document represents a cash payment from `fromUserId`
+    // (the debtor) to `toUserId` (the recipient) within a context
+    // (friendship or group). The trigger `onSettlementWrite` consumes
+    // these to recompute `simplifiedBalances` on the parent context doc.
+    //
+    // Schema invariants enforced here:
+    //   - `fromUserId == request.auth.uid` on create (FR-SE-05).
+    //   - Both `fromUserId` and `toUserId` must be members of the
+    //     context (`memberIds` on the friendship/group doc).
+    //   - `amountPaise` is a positive integer (Invariant 1).
+    //   - Extension-point locks: `method == 'manual'` (ARCH-EXT-01),
+    //     `currency == 'INR'` (ARCH-EXT-02),
+    //     `verificationStatus == 'unverified'` (ARCH-EXT-06).
+    //   - `verificationStatus` is server-only on update (Invariant-2
+    //     parallel for settlements).
+    //   - Historical fields are immutable; only `deleted` may flip
+    //     true on update (monotonic soft-delete).
+    //   - Hard delete is admin-only.
+    match /settlements/{settlementId} {
+
+      // Resolve the parent context's memberIds. The context is either
+      // a friendship or a group; the discriminator lives in the doc.
+      function friendshipMemberIds(contextId) {
+        return get(/databases/$(database)/documents/friendships/$(contextId))
+          .data.memberIds;
+      }
+
+      function groupMemberIds(contextId) {
+        return get(/databases/$(database)/documents/groups/$(contextId))
+          .data.memberIds;
+      }
+
+      function contextMemberIds(contextType, contextId) {
+        return contextType == 'friendship'
+          ? friendshipMemberIds(contextId)
+          : groupMemberIds(contextId);
+      }
+
+      function isContextMember(contextType, contextId, uid) {
+        return uid in contextMemberIds(contextType, contextId);
+      }
+
+      // Whitelisted top-level keys on every write.
+      function hasOnlyKnownKeys(data) {
+        return data.keys().hasOnly([
+          'fromUserId', 'toUserId', 'amountPaise',
+          'contextType', 'contextId',
+          'date', 'note', 'method', 'verificationStatus',
+          'currency', 'createdAt', 'deleted'
+        ]);
+      }
+
+      function hasAllRequiredKeys(data) {
+        return data.keys().hasAll([
+          'fromUserId', 'toUserId', 'amountPaise',
+          'contextType', 'contextId',
+          'date', 'method', 'verificationStatus',
+          'currency', 'createdAt', 'deleted'
+        ]);
+      }
+
+      // Extension-point locks (v1.0 fixed values per
+      // extension-points-register.md ARCH-EXT-01/02/06).
+      function isValidExtensionPointLocks(data) {
+        return data.method == 'manual'
+          && data.currency == 'INR'
+          && data.verificationStatus == 'unverified';
+      }
+
+      // Per-field shape and value invariants.
+      function isValidShape(data) {
+        return data.fromUserId is string
+          && data.toUserId is string
+          && data.amountPaise is int
+          && data.amountPaise > 0
+          && data.contextType in ['friendship', 'group']
+          && data.contextId is string
+          && data.contextId.size() > 0
+          && data.date is timestamp
+          && (!('note' in data) || data.note == null || data.note is string)
+          && data.createdAt is timestamp
+          && data.deleted is bool;
+      }
+
+      function isValidSettlementCreate() {
+        let data = request.resource.data;
+        return hasOnlyKnownKeys(data)
+          && hasAllRequiredKeys(data)
+          && isValidShape(data)
+          && isValidExtensionPointLocks(data)
+          && data.fromUserId != data.toUserId
+          && isContextMember(data.contextType, data.contextId, data.fromUserId)
+          && isContextMember(data.contextType, data.contextId, data.toUserId)
+          && data.deleted == false
+          && data.createdAt == request.time;
+      }
+
+      // Update: ONLY soft-delete (deleted: false → true) is permitted
+      // for clients. Every other field is immutable; verificationStatus
+      // is server-only (Invariant-2 parallel per ARCH-EXT-06).
+      function isValidSettlementUpdate() {
+        let data = request.resource.data;
+        let prev = resource.data;
+        let changedKeys = data.diff(prev).affectedKeys();
+        return changedKeys.hasOnly(['deleted'])
+          && changedKeys.hasAny(['deleted'])
+          && data.deleted == true
+          && prev.deleted == false;
+      }
+
+      // Read: either party may read.
+      allow read: if request.auth != null
+        && (request.auth.uid == resource.data.fromUserId
+            || request.auth.uid == resource.data.toUserId);
+
+      // Create: caller MUST be the fromUserId (Invariant per SRS 7.5).
+      allow create: if request.auth != null
+        && request.resource.data.fromUserId == request.auth.uid
+        && isValidSettlementCreate();
+
+      // Update: either party may soft-delete; nothing else changes.
+      allow update: if request.auth != null
+        && (request.auth.uid == resource.data.fromUserId
+            || request.auth.uid == resource.data.toUserId)
+        && isValidSettlementUpdate();
+
+      // Hard delete is admin-only.
+      allow delete: if false;
+    }
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,3 +38,10 @@ export {lookupUserByPhoneNumber} from "./lookup-user-by-phone-number/index";
 // created, updated, or deleted under a friendship (FR-SE-03/04).
 // First non-callable producer of simplifiedBalances (Invariant 2).
 export {onExpenseWriteFriendship} from "./triggers/on-expense-write/index";
+
+// Firestore trigger: recompute simplifiedBalances when a settlement is
+// created, updated, or deleted at settlements/{settlementId} (FR-SE-05/06).
+// First trigger on a top-level collection. Reads contextType + contextId
+// from the document data (the settlements collection is top-level so the
+// discriminator is not in the trigger path).
+export {onSettlementWrite} from "./triggers/on-settlement-write/index";

--- a/functions/src/simplified-debts/function.ts
+++ b/functions/src/simplified-debts/function.ts
@@ -10,12 +10,11 @@
  *      back to the context document in the same transaction. Returns a
  *      typed discriminated union — never throws `HttpsError` itself.
  *      Consumed by BOTH the HTTPS Callable handler AND the
- *      `onExpenseWriteFriendship` trigger (PR #36, FR-SE-03/04).
+ *      `onExpenseWriteFriendship` trigger (FR-SE-03/04).
  *
  *   2. `createHandler(deps)` — HTTPS Callable handler. Validates client
  *      input, delegates to `recomputeAndWrite`, maps documented failure
- *      codes to `HttpsError`, and emits structured telemetry. Behaviour
- *      is unchanged by the variant 2.3(b) refactor.
+ *      codes to `HttpsError`, and emits structured telemetry.
  *
  * Error codes follow `docs/design/07-technical/cloud-functions-error-codes.md`.
  * All monetary values are integer paise (Invariant 1).
@@ -77,7 +76,7 @@ export interface Dependencies {
  * applies a MONOTONICITY GUARD — the value actually written is
  * `max(existingLastActivityAt, alsoSet.lastActivityAt)`. This prevents
  * out-of-order Cloud Functions delivery from regressing the friends-list
- * ordering (PR #35 reader). No other reserved keys exist today.
+ * ordering. No other reserved keys exist today.
  */
 export interface RecomputeRequest {
   contextType: ContextType;
@@ -181,7 +180,7 @@ function contextCollectionName(contextType: ContextType): string {
  * Expense semantics: the payer is credited +amountPaise and each split
  * member is debited -sharePaise. All values are integer paise (Invariant 1).
  *
- * Settlement semantics (PR #37, FR-SE-05/06): a settlement of
+ * Settlement semantics (FR-SE-05/06): a settlement of
  * `{fromUserId: A, toUserId: B, amountPaise: N}` represents A paying B N
  * paise in cash. This CREDITS A's net balance (+N — A's debt is reduced)
  * and DEBITS B's net balance (-N — B is now owed less). Combined with the
@@ -190,8 +189,8 @@ function contextCollectionName(contextType: ContextType): string {
  *
  * In-code soft-delete filter: settlements with `deleted === true` are
  * excluded from the fold. The expense query already applies the
- * `where('deleted', '!=', true)` filter at the Firestore level (PR #36);
- * the settlements query reads ALL matching docs and filters in code to
+ * `where('deleted', '!=', true)` filter at the Firestore level; the
+ * settlements query reads ALL matching docs and filters in code to
  * avoid an unnecessary composite-index requirement (see Architect Notes
  * §2 of FR-SE-05-06 story).
  *
@@ -252,7 +251,7 @@ export function computeNetBalances(
 /**
  * Returns the LATER of two timestamps. Used to enforce monotonicity on
  * `lastActivityAt` writes — out-of-order Cloud Functions delivery must
- * never regress the friends-list ordering (PR #35 AC-6, PR #36 AC-12).
+ * never regress the friends-list ordering.
  *
  * Falls back to `next` when `existing` is missing or not a Timestamp.
  */
@@ -365,7 +364,7 @@ export async function recomputeAndWrite(
       .where("deleted", "!=", true);
 
     // Read settlements for this context from the TOP-LEVEL settlements
-    // collection (PR #37, FR-SE-05/06). Settlements carry their context
+    // collection (FR-SE-05/06). Settlements carry their context
     // discriminator in the doc data — not the path — because a single
     // settlement could in principle move between contexts (it cannot in
     // v1.0 — immutable contextType/contextId per security rules — but

--- a/functions/src/simplified-debts/function.ts
+++ b/functions/src/simplified-debts/function.ts
@@ -171,17 +171,37 @@ function contextCollectionName(contextType: ContextType): string {
 }
 
 // ---------------------------------------------------------------------------
-// Net-balance computation from expenses
+// Net-balance computation from expenses AND settlements
 // ---------------------------------------------------------------------------
 
 /**
- * Computes net balances from a list of expense document snapshots.
+ * Computes net balances from a list of expense AND settlement document
+ * snapshots.
  *
- * For each expense the payer is credited +amountPaise and each split member
- * is debited -sharePaise. All values are integer paise (Invariant 1).
+ * Expense semantics: the payer is credited +amountPaise and each split
+ * member is debited -sharePaise. All values are integer paise (Invariant 1).
+ *
+ * Settlement semantics (PR #37, FR-SE-05/06): a settlement of
+ * `{fromUserId: A, toUserId: B, amountPaise: N}` represents A paying B N
+ * paise in cash. This CREDITS A's net balance (+N — A's debt is reduced)
+ * and DEBITS B's net balance (-N — B is now owed less). Combined with the
+ * expense fold, the zero-sum invariant is preserved by construction (every
+ * transaction is internally balanced).
+ *
+ * In-code soft-delete filter: settlements with `deleted === true` are
+ * excluded from the fold. The expense query already applies the
+ * `where('deleted', '!=', true)` filter at the Firestore level (PR #36);
+ * the settlements query reads ALL matching docs and filters in code to
+ * avoid an unnecessary composite-index requirement (see Architect Notes
+ * §2 of FR-SE-05-06 story).
+ *
+ * Exported for direct exercise by `algorithm.property.test.ts`. The
+ * production callers (`recomputeAndWrite`) call it through the
+ * transaction-scoped read sequence below.
  */
-function computeNetBalances(
+export function computeNetBalances(
   expenseSnapshots: FirebaseFirestore.QueryDocumentSnapshot[],
+  settlementSnapshots: FirebaseFirestore.QueryDocumentSnapshot[] = [],
 ): Map<string, number> {
   const netBalances = new Map<string, number>();
 
@@ -202,6 +222,24 @@ function computeNetBalances(
         (netBalances.get(split.userId) ?? 0) - split.sharePaise,
       );
     }
+  }
+
+  for (const snap of settlementSnapshots) {
+    const data = snap.data();
+    if (data.deleted === true) {
+      // In-code soft-delete filter — see function doc above.
+      continue;
+    }
+    const fromUserId: string = data.fromUserId;
+    const toUserId: string = data.toUserId;
+    const amountPaise: number = data.amountPaise;
+
+    // Credit the payer (the fromUserId), debit the recipient (the toUserId).
+    netBalances.set(
+      fromUserId,
+      (netBalances.get(fromUserId) ?? 0) + amountPaise,
+    );
+    netBalances.set(toUserId, (netBalances.get(toUserId) ?? 0) - amountPaise);
   }
 
   return netBalances;
@@ -319,12 +357,41 @@ export async function recomputeAndWrite(
       return {ok: false as const, code: "CONTEXT_NOT_FOUND" as const};
     }
 
+    // Read active expenses from the context subcollection. The expense
+    // collection's `where('deleted', '!=', true)` server-side filter is
+    // sufficient because no other equality filters are combined with it.
     const expensesRef = contextRef
       .collection("expenses")
       .where("deleted", "!=", true);
-    const expensesSnap = await tx.get(expensesRef);
 
-    const netBalances = computeNetBalances(expensesSnap.docs);
+    // Read settlements for this context from the TOP-LEVEL settlements
+    // collection (PR #37, FR-SE-05/06). Settlements carry their context
+    // discriminator in the doc data — not the path — because a single
+    // settlement could in principle move between contexts (it cannot in
+    // v1.0 — immutable contextType/contextId per security rules — but
+    // the schema design preserves the option).
+    //
+    // The query uses TWO equality filters: contextType + contextId.
+    // The soft-delete filter is applied IN CODE inside
+    // `computeNetBalances` to avoid a three-field composite index
+    // requirement (cross-field == + == + != combinations require
+    // declaring the inequality field as part of the index, which
+    // unnecessarily over-specifies the index for the small per-context
+    // settlement volume seen in v1.0).
+    const settlementsRef = db
+      .collection("settlements")
+      .where("contextType", "==", contextType)
+      .where("contextId", "==", contextId);
+
+    const [expensesSnap, settlementsSnap] = await Promise.all([
+      tx.get(expensesRef),
+      tx.get(settlementsRef),
+    ]);
+
+    const netBalances = computeNetBalances(
+      expensesSnap.docs,
+      settlementsSnap.docs,
+    );
 
     let transfers: Transfer[];
     try {

--- a/functions/src/triggers/on-settlement-write/function.ts
+++ b/functions/src/triggers/on-settlement-write/function.ts
@@ -1,0 +1,317 @@
+/**
+ * onSettlementWrite — Function Boundary
+ *
+ * Handles every create / update / soft-delete / hard-delete of a
+ * settlement document at `settlements/{settlementId}` (a TOP-LEVEL
+ * collection, unlike PR #36's subcollection-scoped expense trigger).
+ * Delegates the read-compute-write transaction to the shared
+ * `recomputeAndWrite` core (which was extended in this PR to read the
+ * top-level settlements collection alongside the per-context expenses
+ * subcollection — see `functions/src/simplified-debts/function.ts`),
+ * and atomically maintains the parent context document's
+ * `lastActivityAt` so the friends-list ordering shipped in PR #35
+ * (FR-FR-03 AC-6) advances on every settlement event.
+ *
+ * This is the second Firestore trigger in the application's history
+ * and the first on a top-level collection. Because the settlements
+ * collection is top-level, the trigger reads the context discriminator
+ * (`contextType`, `contextId`) from the document DATA rather than the
+ * event path. The after-side snapshot is preferred (create/update); on
+ * hard delete the before-side is the source.
+ *
+ * Error policy (Cloud Functions v2 retry semantics — identical to PR #36):
+ *   - CONTEXT_NOT_FOUND: log structured failure, return successfully so
+ *     Cloud Functions does NOT retry (the friendship/group is gone —
+ *     retries cannot help).
+ *   - BALANCE_INVARIANT_VIOLATED: log structured failure and THROW so
+ *     Cloud Functions retries (per error catalogue "Retryable: Yes (after
+ *     data investigation)"). Repeated retries surface as alerts.
+ *   - INTERNAL (unknown errors): THROW so Cloud Functions retries.
+ *   - Stale events (`event.time` > 7 days old): log and return — the
+ *     7-day Cloud Functions delivery window guarantees no live event is
+ *     older than this; anything older is a stuck retry-queue artefact
+ *     and must not rewrite balances.
+ *
+ * Telemetry:
+ *   - `settlement_trigger_fired` at the top of every invocation.
+ *   - `settlement_trigger_stale_event_dropped` on the stale-event branch.
+ *   - `simplified_debts_compute_started` / `_completed` / `_failed` are
+ *     emitted by this wrapper around the shared core (same event names as
+ *     the expense trigger for log uniformity).
+ *
+ * PII posture:
+ *   Logger NEVER receives fromUserId, toUserId, amountPaise, date, note,
+ *   or any raw UID-containing identifier (including the unhashed
+ *   composite friendship `contextId`). Only the opaque hashed
+ *   `settlementIdHash` / `contextIdHash` values and contextType
+ *   discriminators are loggable. Settlement IDs are themselves opaque
+ *   auto-generated Firestore IDs (safe to log raw) but are hashed for
+ *   log-format parity with the expense trigger.
+ *
+ * @module triggers/on-settlement-write/function
+ */
+
+import {Timestamp} from "firebase-admin/firestore";
+import type {Change, DocumentSnapshot, FirestoreEvent} from
+  "firebase-functions/v2/firestore";
+import {
+  recomputeAndWrite,
+  Dependencies,
+  ContextType,
+} from "../../simplified-debts/function";
+import {hashId} from "../../utils/id-hash";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cloud Functions event-delivery retention window. */
+const STALE_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Permitted context discriminator values (mirrors callable validation). */
+const VALID_CONTEXT_TYPES: ReadonlySet<string> = new Set([
+  "friendship",
+  "group",
+]);
+
+// ---------------------------------------------------------------------------
+// Trigger event params
+// ---------------------------------------------------------------------------
+
+/** Path params extracted from `settlements/{settlementId}`. */
+type SettlementParams = {
+  settlementId: string;
+};
+
+type TriggerEvent = FirestoreEvent<
+  Change<DocumentSnapshot> | undefined,
+  SettlementParams
+>;
+
+// ---------------------------------------------------------------------------
+// Change-type discrimination
+// ---------------------------------------------------------------------------
+
+type ChangeType = "create" | "update" | "delete";
+
+/**
+ * Derives the change type from snapshot existence on each side of the
+ * Firestore `Change<DocumentSnapshot>` (mirrors PR #36's expense trigger).
+ */
+function deriveChangeType(
+  change: Change<DocumentSnapshot> | undefined,
+): ChangeType {
+  if (!change) {
+    return "create";
+  }
+  const beforeExists = change.before?.exists === true;
+  const afterExists = change.after?.exists === true;
+  if (!beforeExists && afterExists) return "create";
+  if (beforeExists && !afterExists) return "delete";
+  return "update";
+}
+
+// ---------------------------------------------------------------------------
+// Discriminator extraction (the settlement-trigger-specific concern)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads `contextType` and `contextId` from the settlement document data.
+ * After-side takes precedence on create and update; before-side is the
+ * source on hard delete (after.exists === false; after.data() is
+ * undefined). Returns null if neither side carries a usable
+ * discriminator — defensive guard so a malformed trigger event does not
+ * crash the runtime.
+ */
+function extractContextDiscriminator(
+  change: Change<DocumentSnapshot> | undefined,
+): {contextType: ContextType; contextId: string} | null {
+  if (!change) return null;
+  const data =
+    (change.after?.exists === true ? change.after.data() : undefined) ??
+    (change.before?.exists === true ? change.before.data() : undefined);
+  if (!data) return null;
+  const rawContextType = data.contextType;
+  const rawContextId = data.contextId;
+  if (
+    typeof rawContextType !== "string" ||
+    !VALID_CONTEXT_TYPES.has(rawContextType) ||
+    typeof rawContextId !== "string" ||
+    rawContextId.length === 0
+  ) {
+    return null;
+  }
+  return {
+    contextType: rawContextType as ContextType,
+    contextId: rawContextId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the Firestore trigger handler with injected dependencies.
+ *
+ * @param deps - Firestore database and structured logger.
+ * @returns An async handler suitable for
+ *   `onDocumentWritten('settlements/{settlementId}', handler)`.
+ */
+export function createTriggerHandler(
+  deps: Dependencies,
+): (event: TriggerEvent) => Promise<void> {
+  const {logger} = deps;
+
+  return async (event: TriggerEvent): Promise<void> => {
+    const startTime = Date.now();
+    const {settlementId} = event.params;
+    const eventTime = event.time;
+    const changeType = deriveChangeType(event.data);
+
+    // PII guard: settlement IDs are opaque auto-generated Firestore
+    // IDs (safe raw) but the parent friendship `contextId` is the
+    // composite `{uidA}_{uidB}` pattern — logging it raw would leak
+    // user identifiers. Both are hashed for parity with the expense
+    // trigger's log format (PR #36).
+    const settlementIdHash = hashId(settlementId);
+
+    const discriminator = extractContextDiscriminator(event.data);
+
+    // Defensive: if neither side carries a usable discriminator, log
+    // and return successfully. This should not happen in production
+    // because the security rules require `contextType` and `contextId`
+    // on every settlement create; but guarding here keeps the trigger
+    // resilient to admin-SDK seeds or future schema changes.
+    if (!discriminator) {
+      logger.error("simplified_debts_compute_failed", {
+        event: "simplified_debts_compute_failed",
+        contextType: "unknown",
+        settlementIdHash,
+        errorCode: "INVALID_INPUT",
+        elapsedMs: Date.now() - startTime,
+      });
+      return;
+    }
+
+    const {contextType, contextId} = discriminator;
+    const contextIdHash = hashId(contextId);
+
+    // 1. Telemetry — first log call, fires for every invocation
+    logger.info("settlement_trigger_fired", {
+      event: "settlement_trigger_fired",
+      contextType,
+      contextIdHash,
+      settlementIdHash,
+      changeType,
+      eventTime,
+    });
+
+    // 2. Stale-event guard
+    const eventTimeMs = new Date(eventTime).getTime();
+    const ageMs = Date.now() - eventTimeMs;
+    if (
+      Number.isFinite(eventTimeMs) &&
+      ageMs > STALE_EVENT_AGE_MS
+    ) {
+      logger.info("settlement_trigger_stale_event_dropped", {
+        event: "settlement_trigger_stale_event_dropped",
+        contextType,
+        contextIdHash,
+        settlementIdHash,
+        eventTime,
+        ageMs,
+      });
+      return;
+    }
+
+    // 3. Hand-off seams for downstream PRs (placement parity with
+    //    PR #36's expense trigger):
+    //    TODO(FR-AC-01): write activity-feed items to both parties'
+    //      activity/{userId}/items subcollection after successful
+    //      recompute.
+    //    TODO(FR-AC-03): send FCM push notification to the toUserId
+    //      respecting notificationPrefs.settlement.
+    //    Placement note: both seams must execute ONLY after a
+    //    successful recompute (i.e. inside or just below the success
+    //    branch at the bottom of this handler) to keep retry semantics
+    //    clean — a retryable transient failure must not duplicate
+    //    activity items or notifications. Today they are deferred
+    //    entirely; the actual placement decision lives with the PR
+    //    that implements them.
+
+    // 4. Build the alsoSet payload — atomically advance lastActivityAt
+    //    inside the same transaction as the simplifiedBalances write.
+    //    The shared core applies the monotonicity guard so out-of-order
+    //    delivery cannot regress the friends-list ordering.
+    const eventTimestamp = Number.isFinite(eventTimeMs)
+      ? Timestamp.fromDate(new Date(eventTimeMs))
+      : Timestamp.now();
+
+    // 5. Log compute-started (same event name as the callable and the
+    //    expense trigger for log uniformity).
+    logger.info("simplified_debts_compute_started", {
+      event: "simplified_debts_compute_started",
+      contextType,
+      contextIdHash,
+    });
+
+    // 6. Delegate to the shared core. Map the typed result to the
+    //    trigger's error policy.
+    let result;
+    try {
+      result = await recomputeAndWrite(deps, {
+        contextType,
+        contextId,
+        alsoSet: {lastActivityAt: eventTimestamp},
+      });
+    } catch (err: unknown) {
+      // INTERNAL — unknown error. Log and THROW so Cloud Functions retries.
+      logger.error("simplified_debts_compute_failed", {
+        event: "simplified_debts_compute_failed",
+        contextType,
+        contextIdHash,
+        errorCode: "INTERNAL",
+        elapsedMs: Date.now() - startTime,
+      });
+      throw err;
+    }
+
+    if (!result.ok) {
+      logger.error("simplified_debts_compute_failed", {
+        event: "simplified_debts_compute_failed",
+        contextType,
+        contextIdHash,
+        errorCode: result.code,
+        elapsedMs: Date.now() - startTime,
+      });
+
+      if (result.code === "CONTEXT_NOT_FOUND") {
+        // Friendship/group was deleted — retries cannot help. Return
+        // successfully so Cloud Functions does NOT retry. (Mirror of
+        // PR #36 AC-10 / AC-12 in this story.)
+        return;
+      }
+
+      // BALANCE_INVARIANT_VIOLATED — corrupt source data. THROW so
+      // Cloud Functions retries; on-call investigates persistently
+      // failing events. Per error catalogue "Retryable: Yes (after
+      // data investigation)". The thrown message uses the hashed
+      // contextId so it remains PII-safe even if the runtime includes
+      // the error string in any subsequent log.
+      throw new Error(
+        `Balance invariant violated for ${contextType}(${contextIdHash}); ` +
+          "see structured logs for correlation.",
+      );
+    }
+
+    // 7. Success — log completed event
+    logger.info("simplified_debts_compute_completed", {
+      event: "simplified_debts_compute_completed",
+      contextType,
+      contextIdHash,
+      elapsedMs: Date.now() - startTime,
+      transferCount: result.transfers.length,
+    });
+  };
+}

--- a/functions/src/triggers/on-settlement-write/function.ts
+++ b/functions/src/triggers/on-settlement-write/function.ts
@@ -3,14 +3,14 @@
  *
  * Handles every create / update / soft-delete / hard-delete of a
  * settlement document at `settlements/{settlementId}` (a TOP-LEVEL
- * collection, unlike PR #36's subcollection-scoped expense trigger).
+ * collection, unlike the subcollection-scoped expense trigger).
  * Delegates the read-compute-write transaction to the shared
- * `recomputeAndWrite` core (which was extended in this PR to read the
- * top-level settlements collection alongside the per-context expenses
+ * `recomputeAndWrite` core (which is extended to read the top-level
+ * settlements collection alongside the per-context expenses
  * subcollection — see `functions/src/simplified-debts/function.ts`),
  * and atomically maintains the parent context document's
- * `lastActivityAt` so the friends-list ordering shipped in PR #35
- * (FR-FR-03 AC-6) advances on every settlement event.
+ * `lastActivityAt` so the friends-list ordering (FR-FR-03 AC-6)
+ * advances on every settlement event.
  *
  * This is the second Firestore trigger in the application's history
  * and the first on a top-level collection. Because the settlements
@@ -19,7 +19,8 @@
  * event path. The after-side snapshot is preferred (create/update); on
  * hard delete the before-side is the source.
  *
- * Error policy (Cloud Functions v2 retry semantics — identical to PR #36):
+ * Error policy (Cloud Functions v2 retry semantics — identical to the
+ * expense trigger):
  *   - CONTEXT_NOT_FOUND: log structured failure, return successfully so
  *     Cloud Functions does NOT retry (the friendship/group is gone —
  *     retries cannot help).
@@ -96,7 +97,7 @@ type ChangeType = "create" | "update" | "delete";
 
 /**
  * Derives the change type from snapshot existence on each side of the
- * Firestore `Change<DocumentSnapshot>` (mirrors PR #36's expense trigger).
+ * Firestore `Change<DocumentSnapshot>` (mirrors the expense trigger).
  */
 function deriveChangeType(
   change: Change<DocumentSnapshot> | undefined,
@@ -173,7 +174,7 @@ export function createTriggerHandler(
     // IDs (safe raw) but the parent friendship `contextId` is the
     // composite `{uidA}_{uidB}` pattern — logging it raw would leak
     // user identifiers. Both are hashed for parity with the expense
-    // trigger's log format (PR #36).
+    // trigger's log format.
     const settlementIdHash = hashId(settlementId);
 
     const discriminator = extractContextDiscriminator(event.data);
@@ -225,8 +226,8 @@ export function createTriggerHandler(
       return;
     }
 
-    // 3. Hand-off seams for downstream PRs (placement parity with
-    //    PR #36's expense trigger):
+    // 3. Hand-off seams for downstream stories (placement parity with
+    //    the expense trigger):
     //    TODO(FR-AC-01): write activity-feed items to both parties'
     //      activity/{userId}/items subcollection after successful
     //      recompute.
@@ -237,7 +238,7 @@ export function createTriggerHandler(
     //    branch at the bottom of this handler) to keep retry semantics
     //    clean — a retryable transient failure must not duplicate
     //    activity items or notifications. Today they are deferred
-    //    entirely; the actual placement decision lives with the PR
+    //    entirely; the actual placement decision lives with the story
     //    that implements them.
 
     // 4. Build the alsoSet payload — atomically advance lastActivityAt
@@ -288,8 +289,7 @@ export function createTriggerHandler(
 
       if (result.code === "CONTEXT_NOT_FOUND") {
         // Friendship/group was deleted — retries cannot help. Return
-        // successfully so Cloud Functions does NOT retry. (Mirror of
-        // PR #36 AC-10 / AC-12 in this story.)
+        // successfully so Cloud Functions does NOT retry.
         return;
       }
 

--- a/functions/src/triggers/on-settlement-write/index.ts
+++ b/functions/src/triggers/on-settlement-write/index.ts
@@ -1,0 +1,64 @@
+/**
+ * onSettlementWrite — Trigger Registration
+ *
+ * Registers the Firestore `onDocumentWritten` trigger for
+ * `settlements/{settlementId}` in `asia-south1` (Mumbai) per SRS
+ * section 7.1. Retry is enabled per the Cloud Functions v2
+ * `{retry: true}` option.
+ *
+ * Companion bindings:
+ *   - `onExpenseWriteFriendship` (PR #36) handles expense writes under
+ *     `friendships/{friendshipId}/expenses/{expenseId}`.
+ *   - `onExpenseWriteGroup` for `groups/{groupId}/expenses/{expenseId}`
+ *     is DEFERRED to Sprint 3 (groups epic). Architect notes §1 of the
+ *     FR-SE-05-06-settlement-trigger story explain why the settlements
+ *     trigger (top-level) can ship before the groups context exists —
+ *     the trigger reads the context discriminator from the doc data, so
+ *     it naturally handles both friendship and group contexts when
+ *     groups become available without a new binding.
+ *
+ * @module triggers/on-settlement-write
+ */
+
+import {onDocumentWritten} from "firebase-functions/v2/firestore";
+import {getFirestore} from "firebase-admin/firestore";
+import * as logger from "firebase-functions/logger";
+import {createTriggerHandler} from "./function";
+
+const REGION = "asia-south1";
+
+/**
+ * Firestore trigger: recomputes `simplifiedBalances` and updates
+ * `lastActivityAt` on the parent context (friendship or group)
+ * document whenever a settlement is created, updated, or deleted at
+ * `settlements/{settlementId}`.
+ *
+ * - First trigger on a TOP-LEVEL collection in the application's
+ *   history (PR #36 covered the subcollection-scoped expense case).
+ * - First PR to make the simplified-debts algorithm read settlements
+ *   into the net-balance computation — the catalogue's "settlements"
+ *   row of the algorithm read table is now truthful.
+ * - Atomicity: both `simplifiedBalances` and `lastActivityAt` are
+ *   written in the same Firestore transaction (FR-SE-05/06 AC-9).
+ * - Retry: enabled. CONTEXT_NOT_FOUND returns successfully (no retry).
+ *   BALANCE_INVARIANT_VIOLATED and INTERNAL throw (Cloud Functions
+ *   retries).
+ * - Stale-event guard: events older than 7 days are dropped.
+ *
+ * See `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` for
+ * full acceptance criteria.
+ */
+export const onSettlementWrite = onDocumentWritten(
+  {
+    region: REGION,
+    document: "settlements/{settlementId}",
+    retry: true,
+  },
+  async (event) => {
+    const handler = createTriggerHandler({
+      db: getFirestore(),
+      logger,
+    });
+    return handler(event);
+  },
+);

--- a/functions/src/triggers/on-settlement-write/index.ts
+++ b/functions/src/triggers/on-settlement-write/index.ts
@@ -7,8 +7,8 @@
  * `{retry: true}` option.
  *
  * Companion bindings:
- *   - `onExpenseWriteFriendship` (PR #36) handles expense writes under
- *     `friendships/{friendshipId}/expenses/{expenseId}`.
+ *   - `onExpenseWriteFriendship` handles expense writes under
+ *     `friendships/{friendshipId}/expenses/{expenseId}` (FR-SE-03/04).
  *   - `onExpenseWriteGroup` for `groups/{groupId}/expenses/{expenseId}`
  *     is DEFERRED to Sprint 3 (groups epic). Architect notes §1 of the
  *     FR-SE-05-06-settlement-trigger story explain why the settlements
@@ -34,8 +34,9 @@ const REGION = "asia-south1";
  * `settlements/{settlementId}`.
  *
  * - First trigger on a TOP-LEVEL collection in the application's
- *   history (PR #36 covered the subcollection-scoped expense case).
- * - First PR to make the simplified-debts algorithm read settlements
+ *   history (the existing expense trigger covers the subcollection-
+ *   scoped case).
+ * - First trigger to make the simplified-debts algorithm read settlements
  *   into the net-balance computation — the catalogue's "settlements"
  *   row of the algorithm read table is now truthful.
  * - Atomicity: both `simplifiedBalances` and `lastActivityAt` are

--- a/functions/test/firestore-rules/settlements.test.ts
+++ b/functions/test/firestore-rules/settlements.test.ts
@@ -1,8 +1,8 @@
 /**
  * Firestore Security Rules tests for the new `settlements/{settlementId}`
- * collection (PR #37, FR-SE-05/06).
+ * collection (FR-SE-05/06).
  *
- * Validates the access-control posture introduced by PR #37 — AC-1
+ * Validates the access-control posture introduced by this story — AC-1
  * through AC-6 of the FR-SE-05-06-settlement-trigger story:
  *
  *   - AC-1: create allowed for fromUserId only.
@@ -135,7 +135,7 @@ let testEnv: RulesTestEnvironment;
 // reads BOTH the per-context friendship doc AND the top-level
 // settlements collection inside a single transaction, so it has a
 // wider race window with the global clearFirestore lock than the
-// PR #36 expense trigger does (the latter reads only the per-context
+// expense trigger does (the latter reads only the per-context
 // expenses subcollection).
 const createdDocPaths: string[] = [];
 

--- a/functions/test/firestore-rules/settlements.test.ts
+++ b/functions/test/firestore-rules/settlements.test.ts
@@ -1,0 +1,672 @@
+/**
+ * Firestore Security Rules tests for the new `settlements/{settlementId}`
+ * collection (PR #37, FR-SE-05/06).
+ *
+ * Validates the access-control posture introduced by PR #37 — AC-1
+ * through AC-6 of the FR-SE-05-06-settlement-trigger story:
+ *
+ *   - AC-1: create allowed for fromUserId only.
+ *   - AC-2: read allowed for both parties.
+ *   - AC-3: verificationStatus is server-only (Invariant-2 parallel per
+ *     ARCH-EXT-06).
+ *   - AC-4: extension-point locks (method='manual', currency='INR',
+ *     verificationStatus='unverified').
+ *   - AC-5: historical-field immutability (only `deleted` may change).
+ *   - AC-6: hard delete denied.
+ *
+ * Prerequisites: Firestore emulator running on port 8181.
+ * Run with: npm run test:rules
+ */
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import {readFileSync} from "fs";
+import {resolve} from "path";
+import {
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  getDoc,
+  serverTimestamp,
+  setLogLevel,
+} from "firebase/firestore";
+
+const PROJECT_ID = "demo-onebytwo";
+const RULES_PATH = resolve(__dirname, "../../../firestore.rules");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const memberA = "user-aaa";
+const memberB = "user-bbb";
+const outsider = "user-outsider";
+
+function friendshipId(uidA: string, uidB: string): string {
+  return [uidA, uidB].sort().join("_");
+}
+
+const FID = friendshipId(memberA, memberB);
+const SETTLEMENT_ID = "settlement-1";
+
+/**
+ * A valid settlement document shape. fromUserId defaults to memberA
+ * (the payer); toUserId is memberB (the recipient). Splits sum and
+ * other invariants are not relevant for settlements — only the listed
+ * field set and extension-point locks.
+ */
+function validSettlementDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    fromUserId: memberA,
+    toUserId: memberB,
+    amountPaise: 5000,
+    contextType: "friendship",
+    contextId: FID,
+    date: serverTimestamp(),
+    note: null,
+    method: "manual",                  // ARCH-EXT-01
+    verificationStatus: "unverified",  // ARCH-EXT-06
+    currency: "INR",                   // ARCH-EXT-02
+    createdAt: serverTimestamp(),
+    deleted: false,
+    ...overrides,
+  };
+}
+
+/** Seeds the parent friendship doc via admin (bypasses rules). */
+async function seedFriendship(testEnv: RulesTestEnvironment) {
+  const path = `friendships/${FID}`;
+  await testEnv.withSecurityRulesDisabled(async (adminCtx) => {
+    await setDoc(doc(adminCtx.firestore(), path), {
+      memberIds: [memberA, memberB],
+      createdBy: memberA,
+      lastActivityAt: new Date(),
+      simplifiedBalances: {},
+    });
+  });
+  trackPath(path);
+}
+
+/** Seeds a valid settlement doc via admin (bypasses rules). */
+async function seedSettlement(
+  testEnv: RulesTestEnvironment,
+  settlementId: string = SETTLEMENT_ID,
+  overrides: Record<string, unknown> = {},
+) {
+  const path = `settlements/${settlementId}`;
+  await testEnv.withSecurityRulesDisabled(async (adminCtx) => {
+    await setDoc(
+      doc(adminCtx.firestore(), path),
+      {
+        fromUserId: memberA,
+        toUserId: memberB,
+        amountPaise: 5000,
+        contextType: "friendship",
+        contextId: FID,
+        date: new Date(),
+        note: null,
+        method: "manual",
+        verificationStatus: "unverified",
+        currency: "INR",
+        createdAt: new Date(),
+        deleted: false,
+        ...overrides,
+      },
+    );
+  });
+  trackPath(path);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+let testEnv: RulesTestEnvironment;
+
+// Track docs created during each test so afterEach can delete them
+// targeted (instead of `clearFirestore`, which acquires a global lock
+// that can time out when an in-flight on-settlement-write trigger
+// transaction is still draining). The on-settlement-write trigger
+// reads BOTH the per-context friendship doc AND the top-level
+// settlements collection inside a single transaction, so it has a
+// wider race window with the global clearFirestore lock than the
+// PR #36 expense trigger does (the latter reads only the per-context
+// expenses subcollection).
+const createdDocPaths: string[] = [];
+
+function trackPath(path: string) {
+  if (!createdDocPaths.includes(path)) {
+    createdDocPaths.push(path);
+  }
+}
+
+beforeAll(async () => {
+  setLogLevel("error");
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, "utf8"),
+      host: "127.0.0.1",
+      port: 8181,
+    },
+  });
+});
+
+afterEach(async () => {
+  // Brief drain delay before deleting docs. The on-settlement-write
+  // trigger reads BOTH the per-context friendship doc AND the top-level
+  // settlements collection inside a single transaction. Targeted
+  // deletes (instead of clearFirestore) avoid the global Firestore
+  // lock; the brief delay lets pending trigger transactions complete
+  // cleanly. This is test-only and does not affect production
+  // semantics.
+  await new Promise((r) => setTimeout(r, 100));
+  await testEnv.withSecurityRulesDisabled(async (adminCtx) => {
+    // Known paths the test suite may create. Includes tracked seeds
+    // PLUS the well-known settlement-ID suffixes used by CREATE tests
+    // (which write via authenticated contexts, not the helpers).
+    const knownPaths = [
+      `friendships/${FID}`,
+      `settlements/${SETTLEMENT_ID}`,
+      `settlements/${SETTLEMENT_ID}-deleted`,
+      `settlements/${SETTLEMENT_ID}-neg`,
+      `settlements/${SETTLEMENT_ID}-2`,
+      ...createdDocPaths,
+    ];
+    // De-duplicate then sort longest paths first (deepest first).
+    const uniqueSorted = [...new Set(knownPaths)].sort(
+      (a, b) => b.length - a.length,
+    );
+    for (const path of uniqueSorted) {
+      try {
+        await deleteDoc(doc(adminCtx.firestore(), path));
+      } catch {
+        // ignore — may already be gone
+      }
+    }
+  });
+  createdDocPaths.length = 0;
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// AC-2 — READ tests
+// ---------------------------------------------------------------------------
+
+describe("settlements/{sid} — read rules (AC-2)", () => {
+  beforeEach(async () => {
+    await seedFriendship(testEnv);
+    await seedSettlement(testEnv);
+  });
+
+  it("allows the fromUserId to read", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertSucceeds(
+      getDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("allows the toUserId to read", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertSucceeds(
+      getDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("rejects read by an outsider", async () => {
+    const ctx = testEnv.authenticatedContext(outsider);
+    await assertFails(
+      getDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("rejects unauthenticated read", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    await assertFails(
+      getDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-1, AC-4 — CREATE tests
+// ---------------------------------------------------------------------------
+
+describe("settlements/{sid} — create rules (AC-1, AC-4)", () => {
+  beforeEach(async () => {
+    await seedFriendship(testEnv);
+  });
+
+  it("allows fromUserId == request.auth.uid to create a valid settlement", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertSucceeds(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc(),
+      ),
+    );
+  });
+
+  it("allows memberB to create with fromUserId == memberB", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertSucceeds(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({fromUserId: memberB, toUserId: memberA}),
+      ),
+    );
+  });
+
+  it("rejects creation when fromUserId != request.auth.uid (memberB authoring as memberA)", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({fromUserId: memberA}),
+      ),
+    );
+  });
+
+  it("rejects creation by an outsider (not a member of the context)", async () => {
+    const ctx = testEnv.authenticatedContext(outsider);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({fromUserId: outsider, toUserId: memberA}),
+      ),
+    );
+  });
+
+  it("rejects creation by an unauthenticated caller", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc(),
+      ),
+    );
+  });
+
+  it("rejects creation when fromUserId == toUserId", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({toUserId: memberA}),
+      ),
+    );
+  });
+
+  it("rejects creation when toUserId is not a member of the context", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({toUserId: outsider}),
+      ),
+    );
+  });
+
+  it("rejects creation when amountPaise <= 0 (Invariant 1)", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({amountPaise: 0}),
+      ),
+    );
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}-neg`),
+        validSettlementDoc({amountPaise: -100}),
+      ),
+    );
+  });
+
+  it("rejects creation when amountPaise is not an integer", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({amountPaise: 1.5}),
+      ),
+    );
+  });
+
+  // ── Extension-point locks (AC-4) ──────────────────────────────────────
+
+  it("rejects creation when method != 'manual' (ARCH-EXT-01)", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({method: "upi"}),
+      ),
+    );
+  });
+
+  it("rejects creation when currency != 'INR' (ARCH-EXT-02)", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({currency: "USD"}),
+      ),
+    );
+  });
+
+  it("rejects creation when verificationStatus != 'unverified' (ARCH-EXT-06)", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({verificationStatus: "verified"}),
+      ),
+    );
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}-2`),
+        validSettlementDoc({verificationStatus: "pending"}),
+      ),
+    );
+  });
+
+  // ── Schema discipline ────────────────────────────────────────────────
+
+  it("rejects creation when contextType is unknown", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({contextType: "team"}),
+      ),
+    );
+  });
+
+  it("rejects creation with deleted: true on create", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({deleted: true}),
+      ),
+    );
+  });
+
+  it("rejects creation with an unknown extra field", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({rogueField: "value"}),
+      ),
+    );
+  });
+
+  it("rejects creation when contextId is empty", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({contextId: ""}),
+      ),
+    );
+  });
+
+  it("rejects creation when createdAt != request.time", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      setDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        validSettlementDoc({createdAt: new Date(2020, 0, 1)}),
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3, AC-5 — UPDATE tests
+// ---------------------------------------------------------------------------
+
+describe("settlements/{sid} — update rules (AC-3, AC-5)", () => {
+  beforeEach(async () => {
+    await seedFriendship(testEnv);
+    await seedSettlement(testEnv);
+  });
+
+  // ── Soft-delete (the ONLY supported update by any party) ────────────
+
+  it("allows fromUserId to soft-delete (set deleted=true)", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertSucceeds(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {deleted: true},
+      ),
+    );
+  });
+
+  it("allows toUserId to soft-delete (set deleted=true)", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertSucceeds(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {deleted: true},
+      ),
+    );
+  });
+
+  it("rejects soft-delete by an outsider", async () => {
+    const ctx = testEnv.authenticatedContext(outsider);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {deleted: true},
+      ),
+    );
+  });
+
+  it("rejects setting deleted back to false (un-delete is admin-only)", async () => {
+    await seedSettlement(testEnv, `${SETTLEMENT_ID}-deleted`, {deleted: true});
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}-deleted`),
+        {deleted: false},
+      ),
+    );
+  });
+
+  // ── Immutability (AC-5) ─────────────────────────────────────────────
+
+  it("rejects update that mutates fromUserId", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {fromUserId: memberB},
+      ),
+    );
+  });
+
+  it("rejects update that mutates toUserId", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {toUserId: outsider},
+      ),
+    );
+  });
+
+  it("rejects update that mutates amountPaise", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {amountPaise: 9999},
+      ),
+    );
+  });
+
+  it("rejects update that mutates contextType", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {contextType: "group"},
+      ),
+    );
+  });
+
+  it("rejects update that mutates contextId", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {contextId: "another-fid"},
+      ),
+    );
+  });
+
+  it("rejects update that mutates createdAt", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {createdAt: new Date(2020, 0, 1)},
+      ),
+    );
+  });
+
+  it("rejects update that mutates note", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {note: "edited after the fact"},
+      ),
+    );
+  });
+
+  it("rejects update that mutates method", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {method: "upi"},
+      ),
+    );
+  });
+
+  it("rejects update that mutates currency", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {currency: "USD"},
+      ),
+    );
+  });
+
+  // ── verificationStatus is server-only (Invariant-2 parallel, AC-3) ──
+
+  it("rejects update that mutates verificationStatus (Invariant-2 parallel)", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {verificationStatus: "verified"},
+      ),
+    );
+  });
+
+  it("rejects update that mutates verificationStatus by the toUserId", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {verificationStatus: "pending"},
+      ),
+    );
+  });
+
+  it("rejects multi-field update even if one field is the allowed deleted flag", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {deleted: true, note: "extra"},
+      ),
+    );
+  });
+
+  it("rejects unauthenticated update", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    await assertFails(
+      updateDoc(
+        doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`),
+        {deleted: true},
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6 — DELETE tests (hard delete denied)
+// ---------------------------------------------------------------------------
+
+describe("settlements/{sid} — delete rules (AC-6)", () => {
+  beforeEach(async () => {
+    await seedFriendship(testEnv);
+    await seedSettlement(testEnv);
+  });
+
+  it("rejects hard delete by fromUserId", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    await assertFails(
+      deleteDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("rejects hard delete by toUserId", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertFails(
+      deleteDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("rejects hard delete by an outsider", async () => {
+    const ctx = testEnv.authenticatedContext(outsider);
+    await assertFails(
+      deleteDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("rejects unauthenticated hard delete", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    await assertFails(
+      deleteDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
+    );
+  });
+
+  it("allows admin SDK to hard delete (rules bypass)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (adminCtx) => {
+      await deleteDoc(
+        doc(adminCtx.firestore(), `settlements/${SETTLEMENT_ID}`),
+      );
+      const snap = await getDoc(
+        doc(adminCtx.firestore(), `settlements/${SETTLEMENT_ID}`),
+      );
+      expect(snap.exists()).toBe(false);
+    });
+  });
+});

--- a/functions/test/integration/on-settlement-write.integration.test.ts
+++ b/functions/test/integration/on-settlement-write.integration.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Integration tests for the onSettlementWrite Firestore trigger.
+ *
+ * These tests run inside `firebase emulators:exec --only auth,firestore,
+ * functions,storage` so that the trigger registered in
+ * `functions/src/triggers/on-settlement-write/index.ts` actually fires on
+ * Firestore writes. The Functions emulator must be running with the
+ * compiled bundle from `functions/lib/`.
+ *
+ * Setup (CI): the PR workflow at .github/workflows/pr.yml runs
+ *   firebase emulators:exec --only auth,firestore,functions,storage \
+ *     "... && cd functions && npm run test:rules && npm run test:integration"
+ *
+ * Setup (local):
+ *   1. cd functions && npm run build
+ *   2. firebase emulators:start --only auth,firestore,functions,storage
+ *   3. (separate shell) cd functions && npm run test:integration
+ *
+ * Coverage targets (story FR-SE-05/06 ACs):
+ *   - AC-7, AC-8: algorithm reads settlements and filters soft-deleted.
+ *   - AC-9: create event triggers atomic balance + lastActivityAt write.
+ *   - AC-10: update + soft-delete walk.
+ *   - AC-12: CONTEXT_NOT_FOUND graceful — write a settlement with
+ *     contextId pointing at a non-existent friendship.
+ *   - AC-15: canonical settlement matrix (full debt settlement, partial
+ *     settlement, overshoot).
+ *
+ * @module test/integration/on-settlement-write.integration.test.ts
+ */
+
+process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8181";
+
+import {initializeApp, deleteApp, getApp} from "firebase-admin/app";
+import {getFirestore, Timestamp} from "firebase-admin/firestore";
+
+const PROJECT_ID = "demo-onebytwo";
+const APP_NAME = "integration-test-on-settlement-write";
+
+const POLL_INTERVAL_MS = 100;
+const POLL_TIMEOUT_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+let db: FirebaseFirestore.Firestore;
+const createdDocPaths: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  const app = initializeApp({projectId: PROJECT_ID}, APP_NAME);
+  db = getFirestore(app);
+});
+
+afterEach(async () => {
+  const sorted = [...createdDocPaths].sort((a, b) => b.length - a.length);
+  for (const docPath of sorted) {
+    try {
+      await db.doc(docPath).delete();
+    } catch {
+      // ignore — may already have been deleted
+    }
+  }
+  createdDocPaths.length = 0;
+});
+
+afterAll(async () => {
+  const app = getApp(APP_NAME);
+  await deleteApp(app);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedDoc(
+  path: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await db.doc(path).set(data);
+  createdDocPaths.push(path);
+}
+
+function makeExpense(opts: {
+  payerId: string;
+  amountPaise: number;
+  splits: Array<{userId: string; sharePaise: number}>;
+  deleted?: boolean;
+  description?: string;
+}): Record<string, unknown> {
+  return {
+    payerId: opts.payerId,
+    amountPaise: opts.amountPaise,
+    splits: opts.splits,
+    deleted: opts.deleted ?? false,
+    description: opts.description ?? "Integration test expense",
+    category: "general",
+    date: Timestamp.now(),
+    splitMethod: "equal",
+    createdBy: opts.payerId,
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+    receiptUrl: null,
+    source: "manual",
+    currency: "INR",
+    recurringRule: null,
+  };
+}
+
+function makeSettlement(opts: {
+  fromUserId: string;
+  toUserId: string;
+  amountPaise: number;
+  contextType?: "friendship" | "group";
+  contextId: string;
+  deleted?: boolean;
+  note?: string | null;
+}): Record<string, unknown> {
+  return {
+    fromUserId: opts.fromUserId,
+    toUserId: opts.toUserId,
+    amountPaise: opts.amountPaise,
+    contextType: opts.contextType ?? "friendship",
+    contextId: opts.contextId,
+    date: Timestamp.now(),
+    note: opts.note ?? null,
+    method: "manual",
+    verificationStatus: "unverified",
+    currency: "INR",
+    createdAt: Timestamp.now(),
+    deleted: opts.deleted ?? false,
+  };
+}
+
+/**
+ * Polls the parent friendship doc until `simplifiedBalances` matches the
+ * expected value (or the timeout elapses). Returns the final snapshot data.
+ */
+async function waitForBalances(
+  contextPath: string,
+  expected: Record<string, unknown>,
+): Promise<FirebaseFirestore.DocumentData | undefined> {
+  const start = Date.now();
+  let lastData: FirebaseFirestore.DocumentData | undefined;
+  while (Date.now() - start < POLL_TIMEOUT_MS) {
+    const snap = await db.doc(contextPath).get();
+    lastData = snap.data();
+    if (
+      lastData &&
+      JSON.stringify(lastData.simplifiedBalances) === JSON.stringify(expected)
+    ) {
+      return lastData;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return lastData;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("onSettlementWrite — integration (registered trigger)", () => {
+  // -------------------------------------------------------------------------
+  // AC-15 Case A — Full debt settlement zeroes the debt
+  //
+  // 1. A pays 10000 (split equally) → B owes A 5000.
+  // 2. B pays A 5000 cash (the settlement) → debt cleared.
+  // 3. simplifiedBalances becomes {}.
+  // -------------------------------------------------------------------------
+  describe("AC-15 case A — full debt settlement zeroes simplifiedBalances", () => {
+    const fid = "int-on-settle-full";
+    const contextPath = `friendships/${fid}`;
+
+    beforeEach(async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["A", "B"],
+        createdBy: "A",
+        lastActivityAt: Timestamp.fromDate(new Date("2026-01-01T00:00:00.000Z")),
+        simplifiedBalances: {},
+      });
+      await seedDoc(`${contextPath}/expenses/exp1`, makeExpense({
+        payerId: "A",
+        amountPaise: 10000,
+        splits: [
+          {userId: "A", sharePaise: 5000},
+          {userId: "B", sharePaise: 5000},
+        ],
+      }));
+      // Wait for the expense trigger to settle balances at {B: {A: 5000}}.
+      await waitForBalances(contextPath, {B: {A: 5000}});
+    });
+
+    it("settles the debt to empty when B pays A 5000", async () => {
+      const settlementPath = `settlements/int-on-settle-full-s1`;
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "B",
+        toUserId: "A",
+        amountPaise: 5000,
+        contextId: fid,
+      }));
+
+      const data = await waitForBalances(contextPath, {});
+      expect(data).toBeDefined();
+      expect(data!.simplifiedBalances).toEqual({});
+      expect(data!.lastActivityAt).toBeDefined();
+      // lastActivityAt should be advanced past the seeded value.
+      const newTs = (data!.lastActivityAt as Timestamp).toMillis();
+      const seededTs = new Date("2026-01-01T00:00:00.000Z").getTime();
+      expect(newTs).toBeGreaterThan(seededTs);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC-15 Case B — Partial settlement (FR-SE-06)
+  //
+  // B owes A 5000; B pays A 2000 → residual: B owes A 3000.
+  // -------------------------------------------------------------------------
+  describe("AC-15 case B — partial settlement leaves residual debt (FR-SE-06)", () => {
+    const fid = "int-on-settle-partial";
+    const contextPath = `friendships/${fid}`;
+
+    beforeEach(async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["X", "Y"],
+        createdBy: "X",
+        lastActivityAt: Timestamp.now(),
+        simplifiedBalances: {},
+      });
+      await seedDoc(`${contextPath}/expenses/exp1`, makeExpense({
+        payerId: "X",
+        amountPaise: 10000,
+        splits: [
+          {userId: "X", sharePaise: 5000},
+          {userId: "Y", sharePaise: 5000},
+        ],
+      }));
+      await waitForBalances(contextPath, {Y: {X: 5000}});
+    });
+
+    it("residual is exactly the unpaid portion (FR-SE-06)", async () => {
+      const settlementPath = `settlements/int-on-settle-partial-s1`;
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "Y",
+        toUserId: "X",
+        amountPaise: 2000,
+        contextId: fid,
+      }));
+
+      const data = await waitForBalances(contextPath, {Y: {X: 3000}});
+      expect(data!.simplifiedBalances).toEqual({Y: {X: 3000}});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC-15 Case C — Overshoot (debtor pays more than owed)
+  //
+  // B owes A 5000; B pays A 8000 → A now owes B 3000 (net flip).
+  // -------------------------------------------------------------------------
+  describe("AC-15 case C — overshoot flips the net balance sign", () => {
+    const fid = "int-on-settle-overshoot";
+    const contextPath = `friendships/${fid}`;
+
+    beforeEach(async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["M", "N"],
+        createdBy: "M",
+        lastActivityAt: Timestamp.now(),
+        simplifiedBalances: {},
+      });
+      await seedDoc(`${contextPath}/expenses/exp1`, makeExpense({
+        payerId: "M",
+        amountPaise: 10000,
+        splits: [
+          {userId: "M", sharePaise: 5000},
+          {userId: "N", sharePaise: 5000},
+        ],
+      }));
+      await waitForBalances(contextPath, {N: {M: 5000}});
+    });
+
+    it("net balance flips when the debtor overpays", async () => {
+      const settlementPath = `settlements/int-on-settle-overshoot-s1`;
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "N",
+        toUserId: "M",
+        amountPaise: 8000,
+        contextId: fid,
+      }));
+
+      const data = await waitForBalances(contextPath, {M: {N: 3000}});
+      expect(data!.simplifiedBalances).toEqual({M: {N: 3000}});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC-10 — update + soft-delete walk
+  //
+  // 1. Seed friendship + expense (B owes A 5000).
+  // 2. Create settlement B→A 2000 → residual {B: {A: 3000}}.
+  // 3. Soft-delete the settlement → residual returns to {B: {A: 5000}}.
+  // -------------------------------------------------------------------------
+  describe("AC-10 — update + soft-delete walk", () => {
+    const fid = "int-on-settle-walk";
+    const contextPath = `friendships/${fid}`;
+    const settlementPath = `settlements/int-on-settle-walk-s1`;
+
+    beforeEach(async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["P", "Q"],
+        createdBy: "P",
+        lastActivityAt: Timestamp.now(),
+        simplifiedBalances: {},
+      });
+      await seedDoc(`${contextPath}/expenses/exp1`, makeExpense({
+        payerId: "P",
+        amountPaise: 10000,
+        splits: [
+          {userId: "P", sharePaise: 5000},
+          {userId: "Q", sharePaise: 5000},
+        ],
+      }));
+      await waitForBalances(contextPath, {Q: {P: 5000}});
+    });
+
+    it("walks create → soft-delete with correct balances at each step", async () => {
+      // ── 1. Create settlement Q→P 2000 ⇒ residual {Q:{P:3000}} ──
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "Q",
+        toUserId: "P",
+        amountPaise: 2000,
+        contextId: fid,
+      }));
+      await waitForBalances(contextPath, {Q: {P: 3000}});
+
+      // ── 2. Soft-delete settlement ⇒ residual reverts to {Q:{P:5000}} ──
+      await db.doc(settlementPath).update({deleted: true});
+      const final = await waitForBalances(contextPath, {Q: {P: 5000}});
+      expect(final!.simplifiedBalances).toEqual({Q: {P: 5000}});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC-12 — CONTEXT_NOT_FOUND graceful handling
+  //
+  // Settlement with contextId pointing at a non-existent friendship.
+  // Friendship doc remains absent; settlement doc remains present;
+  // no retry storm (asserted via the unit test, not here).
+  // -------------------------------------------------------------------------
+  describe("AC-12 context-not-found graceful handling", () => {
+    it("does not create the parent friendship doc when contextId is orphan", async () => {
+      const orphanFid = "int-on-settle-orphan";
+      const settlementPath = `settlements/int-on-settle-orphan-s1`;
+      // Note: friendship doc is deliberately NOT seeded.
+
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "A",
+        toUserId: "B",
+        amountPaise: 5000,
+        contextId: orphanFid,
+      }));
+
+      // Brief wait for the trigger to fire at least once.
+      await new Promise((r) => setTimeout(r, 1500));
+
+      // The friendship doc must remain absent — the trigger's missing-
+      // context guard returns before any write is attempted.
+      const friendshipSnap = await db.doc(`friendships/${orphanFid}`).get();
+      expect(friendshipSnap.exists).toBe(false);
+
+      // The orphan settlement doc must still exist.
+      const settlementSnap = await db.doc(settlementPath).get();
+      expect(settlementSnap.exists).toBe(true);
+    }, 10000);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC-17 (regression — explicit) — settlement that fires AFTER the expense
+  // trigger has already settled balances. Proves the new
+  // `recomputeAndWrite` settlement-read extension doesn't break the existing
+  // expense-trigger codepath even when both triggers operate on the same
+  // context document in rapid succession.
+  // -------------------------------------------------------------------------
+  describe("AC-17 regression — expense + settlement triggers cooperate", () => {
+    const fid = "int-on-settle-coop";
+    const contextPath = `friendships/${fid}`;
+
+    it("expense trigger then settlement trigger produce correct final state", async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["U", "V"],
+        createdBy: "U",
+        lastActivityAt: Timestamp.now(),
+        simplifiedBalances: {},
+      });
+
+      // Expense first.
+      await seedDoc(`${contextPath}/expenses/exp1`, makeExpense({
+        payerId: "U",
+        amountPaise: 8000,
+        splits: [
+          {userId: "U", sharePaise: 4000},
+          {userId: "V", sharePaise: 4000},
+        ],
+      }));
+      await waitForBalances(contextPath, {V: {U: 4000}});
+
+      // Settlement next.
+      await seedDoc(`settlements/int-on-settle-coop-s1`, makeSettlement({
+        fromUserId: "V",
+        toUserId: "U",
+        amountPaise: 4000,
+        contextId: fid,
+      }));
+
+      const final = await waitForBalances(contextPath, {});
+      expect(final!.simplifiedBalances).toEqual({});
+    });
+  });
+});

--- a/functions/test/simplified-debts/algorithm.property.test.ts
+++ b/functions/test/simplified-debts/algorithm.property.test.ts
@@ -8,7 +8,7 @@ import { computeNetBalances } from "../../src/simplified-debts/function";
  * Uses fast-check to generate random valid inputs and verify structural
  * properties that must hold for any input.
  *
- * PR #37 (FR-SE-05/06) extends the test surface to cover
+ * FR-SE-05/06 extends the test surface to cover
  * `computeNetBalances` over MIXED expense + settlement sequences. The
  * load-bearing property: for any random mix of expenses (which credit
  * the payer and debit the split members) AND settlements (which credit
@@ -136,7 +136,7 @@ describe("simplifyDebts property-based tests", () => {
 });
 
 // ---------------------------------------------------------------------------
-// PR #37 — Mixed expense + settlement property tests for computeNetBalances
+// FR-SE-05/06 — Mixed expense + settlement property tests for computeNetBalances
 // ---------------------------------------------------------------------------
 
 /**

--- a/functions/test/simplified-debts/algorithm.property.test.ts
+++ b/functions/test/simplified-debts/algorithm.property.test.ts
@@ -1,11 +1,20 @@
 import fc from "fast-check";
 import { simplifyDebts } from "../../src/simplified-debts/algorithm";
+import { computeNetBalances } from "../../src/simplified-debts/function";
 
 /**
  * Property-based tests for the simplified-debts algorithm.
  *
  * Uses fast-check to generate random valid inputs and verify structural
  * properties that must hold for any input.
+ *
+ * PR #37 (FR-SE-05/06) extends the test surface to cover
+ * `computeNetBalances` over MIXED expense + settlement sequences. The
+ * load-bearing property: for any random mix of expenses (which credit
+ * the payer and debit the split members) AND settlements (which credit
+ * the fromUserId and debit the toUserId), the resulting net-balance
+ * map preserves the zero-sum invariant — the canonical pre-condition
+ * for `simplifyDebts` not throwing `BALANCE_INVARIANT_VIOLATED`.
  */
 
 /**
@@ -120,6 +129,197 @@ describe("simplifyDebts property-based tests", () => {
           expect(t.amountPaise).toBeGreaterThan(0);
           expect(Number.isInteger(t.amountPaise)).toBe(true);
         }
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #37 — Mixed expense + settlement property tests for computeNetBalances
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a QueryDocumentSnapshot-shaped fake from a data record. Only the
+ * `data()` method is consumed by `computeNetBalances`; the rest of the
+ * Firestore snapshot surface is not exercised.
+ */
+function fakeSnap(
+  data: Record<string, unknown>,
+): FirebaseFirestore.QueryDocumentSnapshot {
+  return {
+    data: () => data,
+  } as unknown as FirebaseFirestore.QueryDocumentSnapshot;
+}
+
+/**
+ * Arbitrary that picks a member from a small fixed roster. Using a fixed
+ * roster (rather than randomised UIDs) ensures expense splits and settlement
+ * counterparties refer to the same identifier set so credits and debits net
+ * meaningfully.
+ */
+const memberArb = fc.constantFrom("alice", "bob", "carol", "dave");
+
+/**
+ * Generates a valid two-member expense over the fixed roster:
+ *   - `payerId` is a random member.
+ *   - `amountPaise` is a positive integer in [1, 1_000_000].
+ *   - `splits` always sums to `amountPaise` exactly (Invariant 1).
+ *
+ * Splits between two distinct roster members. The first share is in
+ * [0, amountPaise]; the second is the residual. This mirrors the real
+ * security-rules cap (friendship splits.size() <= 2).
+ */
+const expenseArb = fc
+  .record({
+    payer: memberArb,
+    other: memberArb,
+    amountPaise: fc.integer({ min: 1, max: 1_000_000 }),
+    payerShareFraction: fc.integer({ min: 0, max: 1000 }),
+    deleted: fc.boolean(),
+  })
+  .filter((e) => e.payer !== e.other)
+  .map((e) => {
+    const payerShare = Math.floor((e.amountPaise * e.payerShareFraction) / 1000);
+    const otherShare = e.amountPaise - payerShare;
+    return {
+      payerId: e.payer,
+      amountPaise: e.amountPaise,
+      splits: [
+        { userId: e.payer, sharePaise: payerShare },
+        { userId: e.other, sharePaise: otherShare },
+      ],
+      deleted: e.deleted,
+    };
+  });
+
+/**
+ * Generates a valid settlement between two distinct roster members. The
+ * `deleted` flag is also randomised so the in-code soft-delete filter is
+ * exercised on every run.
+ */
+const settlementArb = fc
+  .record({
+    from: memberArb,
+    to: memberArb,
+    amountPaise: fc.integer({ min: 1, max: 1_000_000 }),
+    deleted: fc.boolean(),
+    contextType: fc.constant("friendship"),
+    contextId: fc.constant("fid"),
+  })
+  .filter((s) => s.from !== s.to)
+  .map((s) => ({
+    fromUserId: s.from,
+    toUserId: s.to,
+    amountPaise: s.amountPaise,
+    deleted: s.deleted,
+    contextType: s.contextType,
+    contextId: s.contextId,
+  }));
+
+describe("computeNetBalances property-based tests — mixed expense + settlement", () => {
+  it("preserves zero-sum invariant under any mixed sequence", () => {
+    fc.assert(
+      fc.property(
+        fc.array(expenseArb, { minLength: 0, maxLength: 10 }),
+        fc.array(settlementArb, { minLength: 0, maxLength: 10 }),
+        (expenses, settlements) => {
+          const expenseSnaps = expenses.map(fakeSnap);
+          const settlementSnaps = settlements.map(fakeSnap);
+
+          const net = computeNetBalances(expenseSnaps, settlementSnaps);
+
+          let sum = 0;
+          for (const v of net.values()) {
+            sum += v;
+          }
+          expect(sum).toBe(0);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("simplifyDebts never throws BALANCE_INVARIANT_VIOLATED on the output of computeNetBalances", () => {
+    fc.assert(
+      fc.property(
+        fc.array(expenseArb, { minLength: 0, maxLength: 10 }),
+        fc.array(settlementArb, { minLength: 0, maxLength: 10 }),
+        (expenses, settlements) => {
+          const expenseSnaps = expenses.map(fakeSnap);
+          const settlementSnaps = settlements.map(fakeSnap);
+
+          const net = computeNetBalances(expenseSnaps, settlementSnaps);
+
+          // simplifyDebts must succeed without throwing the zero-sum
+          // violation. Any other throw is a test failure.
+          expect(() => simplifyDebts(net)).not.toThrow();
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("excludes soft-deleted settlements from the fold (expenses are query-filtered upstream)", () => {
+    // `computeNetBalances` is the unit under test. Soft-deleted expenses
+    // are filtered at the Firestore QUERY level
+    // (`where('deleted', '!=', true)`) so the snapshot list never
+    // contains them by the time it reaches this function.
+    // Soft-deleted SETTLEMENTS are filtered IN CODE because the
+    // settlements query carries two equality filters and a third
+    // inequality would require an unnecessarily over-specified
+    // composite index (see Architect Notes §2). So this property test
+    // exercises only the in-code settlement filter.
+    fc.assert(
+      fc.property(
+        fc.array(expenseArb, { minLength: 0, maxLength: 5 }),
+        fc.array(settlementArb, { minLength: 1, maxLength: 5 }),
+        (expenses, settlements) => {
+          // All expenses non-deleted (mirror real query behaviour);
+          // all settlements force-deleted (must be filtered in code).
+          const expensesActive = expenses.map((e) => ({ ...e, deleted: false }));
+          const settlementsDeleted = settlements.map((s) => ({
+            ...s,
+            deleted: true,
+          }));
+
+          const netWithDeleted = computeNetBalances(
+            expensesActive.map(fakeSnap),
+            settlementsDeleted.map(fakeSnap),
+          );
+
+          // Same net balances must result from passing no settlements at
+          // all — the deleted ones contribute nothing.
+          const netWithoutSettlements = computeNetBalances(
+            expensesActive.map(fakeSnap),
+            [],
+          );
+
+          // Compare maps key-by-key.
+          const allKeys = new Set([
+            ...netWithDeleted.keys(),
+            ...netWithoutSettlements.keys(),
+          ]);
+          for (const k of allKeys) {
+            expect(netWithDeleted.get(k) ?? 0).toBe(
+              netWithoutSettlements.get(k) ?? 0,
+            );
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("settlement-only sequence produces the credit-fromUserId / debit-toUserId net map", () => {
+    fc.assert(
+      fc.property(settlementArb, (s) => {
+        // Force non-deleted so the settlement is included in the fold.
+        const settlement = { ...s, deleted: false };
+        const net = computeNetBalances([], [fakeSnap(settlement)]);
+
+        expect(net.get(settlement.fromUserId)).toBe(settlement.amountPaise);
+        expect(net.get(settlement.toUserId)).toBe(-settlement.amountPaise);
       }),
       { numRuns: 200 },
     );

--- a/functions/test/simplified-debts/function.test.ts
+++ b/functions/test/simplified-debts/function.test.ts
@@ -28,17 +28,38 @@ function createMockLogger() {
 /**
  * Creates a minimal mock Firestore that returns the provided context document
  * and expense documents inside a transaction.
+ *
+ * PR #37 extension: also returns settlement documents from the top-level
+ * `settlements` collection. The mock dispatches by the FIRST argument to
+ * `db.collection()`:
+ *   - `'friendships'` / `'groups'` → context doc + expenses subcollection
+ *     (existing chain — `tx.get(docRef)` for context, `tx.get(query)` for
+ *     expenses where the query carries `_queryKind: 'expenses'`).
+ *   - `'settlements'` → top-level settlements query
+ *     (`tx.get(query)` where the query carries `_queryKind: 'settlements'`).
+ *
+ * If `settlements` is omitted, the settlements query returns an empty list —
+ * preserves backward compatibility with existing tests that never seeded
+ * settlements.
  */
 function createMockDb(opts: {
   contextExists: boolean;
   contextData?: Record<string, unknown>;
   expenses?: Array<{id: string; data: Record<string, unknown>}>;
+  settlements?: Array<{id: string; data: Record<string, unknown>}>;
 }): FirebaseFirestore.Firestore {
   const expenseDocs = (opts.expenses ?? []).map((e) => ({
     id: e.id,
     exists: true,
     data: () => e.data,
     ref: {path: `mock/expenses/${e.id}`},
+  }));
+
+  const settlementDocs = (opts.settlements ?? []).map((s) => ({
+    id: s.id,
+    exists: true,
+    data: () => s.data,
+    ref: {path: `settlements/${s.id}`},
   }));
 
   const contextSnap = {
@@ -49,28 +70,42 @@ function createMockDb(opts: {
 
   const updateFn = jest.fn();
 
-  // Build mock query/collection/doc chain
-  const mockDb = {
-    collection: jest.fn().mockReturnValue({
-      doc: jest.fn().mockReturnValue({
-        collection: jest.fn().mockReturnValue({
-          where: jest.fn().mockReturnValue({
-            // This object is passed to tx.get() for expenses
-            _isQuery: true,
-          }),
-        }),
-        // This ref is passed to tx.get() for context document
-        _isDocRef: true,
+  // Settlements chain: db.collection('settlements').where(...).where(...)
+  const settlementsQuery = {_queryKind: "settlements"};
+  const settlementsChain = {
+    where: jest.fn().mockReturnValue({
+      where: jest.fn().mockReturnValue(settlementsQuery),
+    }),
+  };
+
+  // Friendships/groups chain: db.collection(X).doc(Y).collection('expenses').where('deleted','!=',true)
+  const expensesQuery = {_queryKind: "expenses"};
+  const contextChain = {
+    doc: jest.fn().mockReturnValue({
+      collection: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue(expensesQuery),
       }),
+      _isDocRef: true,
+    }),
+  };
+
+  const mockDb = {
+    collection: jest.fn((name: string) => {
+      if (name === "settlements") {
+        return settlementsChain;
+      }
+      return contextChain;
     }),
     runTransaction: jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
       const tx = {
         get: jest.fn((ref: unknown) => {
-          // If ref is the query, return expenses
-          if ((ref as Record<string, boolean>)._isQuery) {
+          const r = ref as Record<string, unknown>;
+          if (r._queryKind === "expenses") {
             return Promise.resolve({docs: expenseDocs});
           }
-          // Otherwise return context document
+          if (r._queryKind === "settlements") {
+            return Promise.resolve({docs: settlementDocs});
+          }
           return Promise.resolve(contextSnap);
         }),
         update: updateFn,
@@ -414,5 +449,322 @@ describe("recomputeAndWrite — alsoSet reserved-key guard", () => {
         alsoSet: {lastActivityAt: "2026-01-01T00:00:00.000Z"},
       }),
     ).rejects.toThrow(/lastActivityAt must be a Firestore Timestamp/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #37 (FR-SE-05/06) — recomputeAndWrite settlement-read extension
+//
+// Validates that the shared core now reads settlements in the same
+// transaction as expenses and folds them into the net-balance map. The
+// public signature of recomputeAndWrite stays the same; settlements are an
+// internal implementation detail of the algorithm's reading shape.
+// ---------------------------------------------------------------------------
+
+describe("recomputeAndWrite — settlement-read extension", () => {
+  // -----------------------------------------------------------------------
+  // 1. Settlement-only context: credit fromUserId / debit toUserId
+  //
+  // A pays B 5000 (no expenses). Net balances: A = +5000, B = -5000.
+  // simplifiedBalances = {B: {A: 5000}} (debtor B owes creditor A 5000 —
+  // because A is positive, A is the creditor in the simplified graph).
+  // -----------------------------------------------------------------------
+  it("returns expected balances for a settlement-only context (credit-from/debit-to)", async () => {
+    const {deps} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [
+        {
+          id: "set1",
+          data: {
+            fromUserId: "userA",
+            toUserId: "userB",
+            amountPaise: 5000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+      ],
+    });
+
+    const handler = createHandler(deps);
+    const result = await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(result.ok).toBe(true);
+    expect(result.simplifiedBalances).toEqual({userB: {userA: 5000}});
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Mixed expense + settlement: settlement reduces the existing debt
+  //
+  // A paid 10000 (split equally) → B owes A 5000.
+  // B then pays A 3000 (a partial settlement).
+  // Residual: B owes A 2000.
+  // -----------------------------------------------------------------------
+  it("folds settlements alongside expenses (partial-settlement reduces debt)", async () => {
+    const {deps} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 5000},
+              {userId: "userB", sharePaise: 5000},
+            ],
+          },
+        },
+      ],
+      settlements: [
+        {
+          id: "set1",
+          data: {
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 3000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+      ],
+    });
+
+    const handler = createHandler(deps);
+    const result = await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(result.ok).toBe(true);
+    expect(result.simplifiedBalances).toEqual({userB: {userA: 2000}});
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Settlement zeroes the debt exactly
+  // -----------------------------------------------------------------------
+  it("produces empty simplifiedBalances when a settlement fully zeroes the debt", async () => {
+    const {deps} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 5000},
+              {userId: "userB", sharePaise: 5000},
+            ],
+          },
+        },
+      ],
+      settlements: [
+        {
+          id: "set1",
+          data: {
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 5000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+      ],
+    });
+
+    const handler = createHandler(deps);
+    const result = await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(result.ok).toBe(true);
+    expect(result.simplifiedBalances).toEqual({});
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Settlement overshoot: debtor pays more than owed → net flips sign
+  //
+  // B owed A 5000; B pays A 8000 → A now owes B 3000.
+  // simplifiedBalances = {A: {B: 3000}}.
+  // -----------------------------------------------------------------------
+  it("flips the net balance sign on overshoot (debtor overpays)", async () => {
+    const {deps} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 5000},
+              {userId: "userB", sharePaise: 5000},
+            ],
+          },
+        },
+      ],
+      settlements: [
+        {
+          id: "set1",
+          data: {
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 8000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+      ],
+    });
+
+    const handler = createHandler(deps);
+    const result = await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(result.ok).toBe(true);
+    expect(result.simplifiedBalances).toEqual({userA: {userB: 3000}});
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Soft-deleted settlements are excluded from the fold
+  //
+  // The implementation filters `deleted === true` settlements in code
+  // (because the cross-field `==`,`==`,`!=` query would require an
+  // unnecessary composite index; see Architect Notes §2).
+  // -----------------------------------------------------------------------
+  it("excludes settlements with deleted=true from the net-balance fold", async () => {
+    const {deps} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 5000},
+              {userId: "userB", sharePaise: 5000},
+            ],
+          },
+        },
+      ],
+      settlements: [
+        {
+          id: "set1",
+          data: {
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 5000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: true, // soft-deleted — must be filtered out
+          },
+        },
+      ],
+    });
+
+    const handler = createHandler(deps);
+    const result = await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(result.ok).toBe(true);
+    // The soft-deleted settlement is ignored ⇒ residual debt remains.
+    expect(result.simplifiedBalances).toEqual({userB: {userA: 5000}});
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Multiple settlements accumulate correctly
+  //
+  // B owes A 10000 → B pays A 3000 + B pays A 4000 + A pays B 1000 →
+  // residual: B owes A (10000 - 3000 - 4000 + 1000) = 4000.
+  // -----------------------------------------------------------------------
+  it("accumulates multiple settlements in the same fold", async () => {
+    const {deps} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 20000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 10000},
+              {userId: "userB", sharePaise: 10000},
+            ],
+          },
+        },
+      ],
+      settlements: [
+        {
+          id: "s1",
+          data: {
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 3000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+        {
+          id: "s2",
+          data: {
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 4000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+        {
+          id: "s3",
+          data: {
+            fromUserId: "userA",
+            toUserId: "userB",
+            amountPaise: 1000,
+            contextType: "friendship",
+            contextId: "ctx1",
+            deleted: false,
+          },
+        },
+      ],
+    });
+
+    const handler = createHandler(deps);
+    const result = await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(result.ok).toBe(true);
+    expect(result.simplifiedBalances).toEqual({userB: {userA: 4000}});
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Settlements query is invoked against the top-level 'settlements'
+  //    collection (not a subcollection)
+  // -----------------------------------------------------------------------
+  it("reads from the top-level 'settlements' collection", async () => {
+    const {deps, db} = createDeps({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [],
+    });
+
+    const handler = createHandler(deps);
+    await handler({contextType: "friendship", contextId: "ctx1"});
+
+    expect(
+      (db as unknown as {collection: jest.Mock}).collection,
+    ).toHaveBeenCalledWith("settlements");
   });
 });

--- a/functions/test/simplified-debts/function.test.ts
+++ b/functions/test/simplified-debts/function.test.ts
@@ -29,7 +29,7 @@ function createMockLogger() {
  * Creates a minimal mock Firestore that returns the provided context document
  * and expense documents inside a transaction.
  *
- * PR #37 extension: also returns settlement documents from the top-level
+ * FR-SE-05/06 extension: also returns settlement documents from the top-level
  * `settlements` collection. The mock dispatches by the FIRST argument to
  * `db.collection()`:
  *   - `'friendships'` / `'groups'` → context doc + expenses subcollection
@@ -453,7 +453,7 @@ describe("recomputeAndWrite — alsoSet reserved-key guard", () => {
 });
 
 // ---------------------------------------------------------------------------
-// PR #37 (FR-SE-05/06) — recomputeAndWrite settlement-read extension
+// FR-SE-05/06 — recomputeAndWrite settlement-read extension
 //
 // Validates that the shared core now reads settlements in the same
 // transaction as expenses and folds them into the net-balance map. The

--- a/functions/test/triggers/on-expense-write/function.test.ts
+++ b/functions/test/triggers/on-expense-write/function.test.ts
@@ -50,17 +50,29 @@ function createMockLogger() {
  * Builds a mock Firestore where the friendship doc and its expenses
  * subcollection can be configured per-test. Records every `tx.update(...)`
  * call for assertion.
+ *
+ * PR #37: also handles the top-level `settlements` collection query
+ * introduced by the `recomputeAndWrite` settlement-read extension. When
+ * `settlements` is omitted, the settlements query returns an empty list.
  */
 function createMockDb(opts: {
   contextExists: boolean;
   contextData?: Record<string, unknown>;
   expenses?: Array<{id: string; data: Record<string, unknown>}>;
+  settlements?: Array<{id: string; data: Record<string, unknown>}>;
 }): FirebaseFirestore.Firestore {
   const expenseDocs = (opts.expenses ?? []).map((e) => ({
     id: e.id,
     exists: true,
     data: () => e.data,
     ref: {path: `friendships/fid/expenses/${e.id}`},
+  }));
+
+  const settlementDocs = (opts.settlements ?? []).map((s) => ({
+    id: s.id,
+    exists: true,
+    data: () => s.data,
+    ref: {path: `settlements/${s.id}`},
   }));
 
   const contextSnap = {
@@ -71,20 +83,36 @@ function createMockDb(opts: {
 
   const updateFn = jest.fn();
 
+  const settlementsQuery = {_queryKind: "settlements"};
+  const expensesQuery = {_queryKind: "expenses"};
+
   const mockDb = {
-    collection: jest.fn().mockReturnValue({
-      doc: jest.fn().mockReturnValue({
-        collection: jest.fn().mockReturnValue({
-          where: jest.fn().mockReturnValue({_isQuery: true}),
+    collection: jest.fn((name: string) => {
+      if (name === "settlements") {
+        return {
+          where: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue(settlementsQuery),
+          }),
+        };
+      }
+      return {
+        doc: jest.fn().mockReturnValue({
+          collection: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue(expensesQuery),
+          }),
+          _isDocRef: true,
         }),
-        _isDocRef: true,
-      }),
+      };
     }),
     runTransaction: jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
       const tx = {
         get: jest.fn((ref: unknown) => {
-          if ((ref as Record<string, boolean>)._isQuery) {
+          const r = ref as Record<string, unknown>;
+          if (r._queryKind === "expenses") {
             return Promise.resolve({docs: expenseDocs});
+          }
+          if (r._queryKind === "settlements") {
+            return Promise.resolve({docs: settlementDocs});
           }
           return Promise.resolve(contextSnap);
         }),

--- a/functions/test/triggers/on-expense-write/function.test.ts
+++ b/functions/test/triggers/on-expense-write/function.test.ts
@@ -51,7 +51,7 @@ function createMockLogger() {
  * subcollection can be configured per-test. Records every `tx.update(...)`
  * call for assertion.
  *
- * PR #37: also handles the top-level `settlements` collection query
+ * FR-SE-05/06: also handles the top-level `settlements` collection query
  * introduced by the `recomputeAndWrite` settlement-read extension. When
  * `settlements` is omitted, the settlements query returns an empty list.
  */

--- a/functions/test/triggers/on-settlement-write/function.test.ts
+++ b/functions/test/triggers/on-settlement-write/function.test.ts
@@ -4,8 +4,8 @@
  * These tests exercise `createTriggerHandler(deps)` directly with mocked
  * Firestore + logger — no emulator required. The trigger handler is the
  * thin orchestration layer wrapping the shared `recomputeAndWrite` core
- * (extended in PR #37 to read settlements alongside expenses); this suite
- * asserts the trigger-specific concerns: discriminator-from-doc-data
+ * (extended in this story to read settlements alongside expenses); this
+ * suite asserts the trigger-specific concerns: discriminator-from-doc-data
  * extraction (after-side on create/update; before-side on hard delete),
  * stale-event guard, `lastActivityAt` monotonicity, error-policy mapping,
  * structured telemetry, and PII-free logging.
@@ -24,7 +24,7 @@ import {createTriggerHandler} from
 
 // ---------------------------------------------------------------------------
 // Mock helpers — copy the function.test.ts pattern with the settlements
-// extension (PR #37). The mock dispatches by collection name:
+// extension (FR-SE-05/06). The mock dispatches by collection name:
 //   - 'friendships' / 'groups' → context doc + expenses subcollection.
 //   - 'settlements' → top-level settlements query.
 // ---------------------------------------------------------------------------

--- a/functions/test/triggers/on-settlement-write/function.test.ts
+++ b/functions/test/triggers/on-settlement-write/function.test.ts
@@ -1,0 +1,769 @@
+/**
+ * Function-boundary tests for the onSettlementWrite trigger.
+ *
+ * These tests exercise `createTriggerHandler(deps)` directly with mocked
+ * Firestore + logger — no emulator required. The trigger handler is the
+ * thin orchestration layer wrapping the shared `recomputeAndWrite` core
+ * (extended in PR #37 to read settlements alongside expenses); this suite
+ * asserts the trigger-specific concerns: discriminator-from-doc-data
+ * extraction (after-side on create/update; before-side on hard delete),
+ * stale-event guard, `lastActivityAt` monotonicity, error-policy mapping,
+ * structured telemetry, and PII-free logging.
+ *
+ * Coverage target per the per-module gate: >= 70% of
+ * functions/src/triggers/on-settlement-write/.
+ *
+ * @module test/triggers/on-settlement-write/function.test.ts
+ */
+
+import {Timestamp} from "firebase-admin/firestore";
+import type {Change, DocumentSnapshot, FirestoreEvent} from
+  "firebase-functions/v2/firestore";
+import {createTriggerHandler} from
+  "../../../src/triggers/on-settlement-write/function";
+
+// ---------------------------------------------------------------------------
+// Mock helpers — copy the function.test.ts pattern with the settlements
+// extension (PR #37). The mock dispatches by collection name:
+//   - 'friendships' / 'groups' → context doc + expenses subcollection.
+//   - 'settlements' → top-level settlements query.
+// ---------------------------------------------------------------------------
+
+interface LoggerCall {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "warn", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+function createMockDb(opts: {
+  contextExists: boolean;
+  contextData?: Record<string, unknown>;
+  expenses?: Array<{id: string; data: Record<string, unknown>}>;
+  settlements?: Array<{id: string; data: Record<string, unknown>}>;
+}): FirebaseFirestore.Firestore {
+  const expenseDocs = (opts.expenses ?? []).map((e) => ({
+    id: e.id,
+    exists: true,
+    data: () => e.data,
+    ref: {path: `friendships/fid/expenses/${e.id}`},
+  }));
+
+  const settlementDocs = (opts.settlements ?? []).map((s) => ({
+    id: s.id,
+    exists: true,
+    data: () => s.data,
+    ref: {path: `settlements/${s.id}`},
+  }));
+
+  const contextSnap = {
+    exists: opts.contextExists,
+    data: () => opts.contextData ?? {},
+    ref: {path: "friendships/fid"},
+  };
+
+  const updateFn = jest.fn();
+
+  const settlementsQuery = {_queryKind: "settlements"};
+  const expensesQuery = {_queryKind: "expenses"};
+
+  const mockDb = {
+    collection: jest.fn((name: string) => {
+      if (name === "settlements") {
+        return {
+          where: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue(settlementsQuery),
+          }),
+        };
+      }
+      return {
+        doc: jest.fn().mockReturnValue({
+          collection: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue(expensesQuery),
+          }),
+          _isDocRef: true,
+        }),
+      };
+    }),
+    runTransaction: jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        get: jest.fn((ref: unknown) => {
+          const r = ref as Record<string, unknown>;
+          if (r._queryKind === "expenses") {
+            return Promise.resolve({docs: expenseDocs});
+          }
+          if (r._queryKind === "settlements") {
+            return Promise.resolve({docs: settlementDocs});
+          }
+          return Promise.resolve(contextSnap);
+        }),
+        update: updateFn,
+      };
+      return fn(tx);
+    }),
+    _updateFn: updateFn,
+  };
+
+  return mockDb as unknown as FirebaseFirestore.Firestore;
+}
+
+/**
+ * Settlement document data — a typed shape that the trigger reads from
+ * `change.after.data()` (create/update) or `change.before.data()` (hard
+ * delete) to extract `contextType` and `contextId`.
+ */
+function validSettlementData(overrides: Record<string, unknown> = {}) {
+  return {
+    fromUserId: "userA",
+    toUserId: "userB",
+    amountPaise: 5000,
+    contextType: "friendship",
+    contextId: "fid",
+    date: Timestamp.now(),
+    note: null,
+    method: "manual",
+    verificationStatus: "unverified",
+    currency: "INR",
+    createdAt: Timestamp.now(),
+    deleted: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a minimal FirestoreEvent for a top-level settlement write. Unlike
+ * the expense trigger event (which carries `friendshipId` + `expenseId` in
+ * event.params), the settlement trigger only carries `settlementId`. The
+ * context discriminator (`contextType`, `contextId`) is read from the doc
+ * data instead.
+ */
+function makeEvent(opts: {
+  changeType: "create" | "update" | "delete";
+  settlementId?: string;
+  eventTime?: string;
+  beforeData?: Record<string, unknown>;
+  afterData?: Record<string, unknown>;
+}): FirestoreEvent<
+  Change<DocumentSnapshot> | undefined,
+  {settlementId: string}
+> {
+  const settlementId = opts.settlementId ?? "sid";
+  const eventTime = opts.eventTime ?? new Date().toISOString();
+
+  const beforeExists =
+    opts.changeType === "update" || opts.changeType === "delete";
+  const afterExists =
+    opts.changeType === "create" || opts.changeType === "update";
+
+  const beforeSnap = {
+    exists: beforeExists,
+    data: () => opts.beforeData ?? {},
+    ref: {path: `settlements/${settlementId}`},
+  } as unknown as DocumentSnapshot;
+
+  const afterSnap = {
+    exists: afterExists,
+    data: () => opts.afterData ?? {},
+    ref: {path: `settlements/${settlementId}`},
+  } as unknown as DocumentSnapshot;
+
+  const change = {before: beforeSnap, after: afterSnap} as unknown as Change<
+    DocumentSnapshot
+  >;
+
+  return {
+    id: "event-id",
+    type: "google.cloud.firestore.document.v1.written",
+    specversion: "1.0",
+    source: "//firestore.googleapis.com/projects/demo-onebytwo",
+    time: eventTime,
+    document: `settlements/${settlementId}`,
+    params: {settlementId},
+    data: change,
+    location: "asia-south1",
+    project: "demo-onebytwo",
+    database: "(default)",
+    namespace: "(default)",
+  } as unknown as FirestoreEvent<
+    Change<DocumentSnapshot> | undefined,
+    {settlementId: string}
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("onSettlementWrite handler — boundary", () => {
+  // -------------------------------------------------------------------------
+  // 1. CREATE event recomputes balances and writes lastActivityAt
+  //
+  // A settlement of {fromA: 5000, toB: 5000} on a context with one expense
+  // (A paid 10000 split equally — B owes A 5000) → settlement zeroes the
+  // debt → simplifiedBalances = {}.
+  // -------------------------------------------------------------------------
+  it("recomputes simplifiedBalances on create and writes lastActivityAt atomically", async () => {
+    const eventTime = new Date(Date.now() - 30 * 1000).toISOString();
+    const expectedTimestamp = Timestamp.fromDate(new Date(eventTime));
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {
+        memberIds: ["userA", "userB"],
+        lastActivityAt: Timestamp.fromDate(
+          new Date(Date.now() - 24 * 60 * 60 * 1000),
+        ),
+      },
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 5000},
+              {userId: "userB", sharePaise: 5000},
+            ],
+          },
+        },
+      ],
+      settlements: [
+        {id: "sid", data: validSettlementData({fromUserId: "userB", toUserId: "userA", amountPaise: 5000})},
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime,
+        afterData: validSettlementData({
+          fromUserId: "userB",
+          toUserId: "userA",
+          amountPaise: 5000,
+        }),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    const [, payload] = updateFn.mock.calls[0];
+    expect(payload).toEqual({
+      simplifiedBalances: {},
+      lastActivityAt: expectedTimestamp,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. UPDATE event reads contextType/contextId from the after-side
+  //
+  // No prior expenses. A settlement of {fromA: 7000, toB: 7000} means A
+  // paid B 7000 in cash. With no prior debt, A now has positive net
+  // (+7000) — A is the creditor; B owes A 7000 ⇒ {userB: {userA: 7000}}.
+  // -------------------------------------------------------------------------
+  it("extracts contextType/contextId from change.after on update", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [
+        {id: "sid", data: validSettlementData({amountPaise: 7000})},
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "update",
+        beforeData: validSettlementData({amountPaise: 5000}),
+        afterData: validSettlementData({amountPaise: 7000}),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(updateFn.mock.calls[0][1].simplifiedBalances).toEqual({
+      userB: {userA: 7000},
+    });
+    // db.collection('friendships').doc('fid') should have been resolved
+    // from the doc data's {contextType: 'friendship', contextId: 'fid'}.
+    expect(
+      (db as unknown as {collection: jest.Mock}).collection,
+    ).toHaveBeenCalledWith("friendships");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. SOFT-DELETE: the soft-deleted settlement is filtered out of the
+  //    in-code soft-delete filter, so balances reflect the state WITHOUT
+  //    the settlement.
+  // -------------------------------------------------------------------------
+  it("recomputes on soft-delete (deleted=true settlement is filtered in-code)", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 5000},
+              {userId: "userB", sharePaise: 5000},
+            ],
+          },
+        },
+      ],
+      // Settlement marked deleted=true — algorithm should ignore it.
+      settlements: [
+        {
+          id: "sid",
+          data: validSettlementData({
+            fromUserId: "userB",
+            toUserId: "userA",
+            amountPaise: 5000,
+            deleted: true,
+          }),
+        },
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "update",
+        beforeData: validSettlementData({deleted: false}),
+        afterData: validSettlementData({deleted: true}),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    // Settlement excluded → residual debt remains.
+    expect(updateFn.mock.calls[0][1].simplifiedBalances).toEqual({
+      userB: {userA: 5000},
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. HARD-DELETE: change.after.exists === false; discriminator must come
+  //    from change.before.data().
+  // -------------------------------------------------------------------------
+  it("extracts contextType/contextId from change.before on hard delete", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "delete",
+        beforeData: validSettlementData(),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    // No expenses, no settlements ⇒ empty balances.
+    expect(updateFn.mock.calls[0][1].simplifiedBalances).toEqual({});
+    expect(
+      (db as unknown as {collection: jest.Mock}).collection,
+    ).toHaveBeenCalledWith("friendships");
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Idempotency: second invocation with the same event produces identical
+  //    simplifiedBalances.
+  // -------------------------------------------------------------------------
+  it("is idempotent: identical second invocation yields identical balances", async () => {
+    const eventTime = new Date(Date.now() - 30 * 1000).toISOString();
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [
+        {id: "sid", data: validSettlementData()},
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(makeEvent({changeType: "create", eventTime, afterData: validSettlementData()}));
+    await handler(makeEvent({changeType: "create", eventTime, afterData: validSettlementData()}));
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(2);
+    expect(updateFn.mock.calls[0][1].simplifiedBalances).toEqual(
+      updateFn.mock.calls[1][1].simplifiedBalances,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Stale-event guard: events older than 7 days do not write
+  // -------------------------------------------------------------------------
+  it("drops stale events (>7 days old) without writing", async () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: eightDaysAgo,
+        afterData: validSettlementData(),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).not.toHaveBeenCalled();
+
+    const droppedLog = logger.calls.find(
+      (c) => c.data?.event === "settlement_trigger_stale_event_dropped",
+    );
+    expect(droppedLog).toBeDefined();
+    expect(droppedLog!.data!.contextType).toBe("friendship");
+    expect(typeof droppedLog!.data!.contextIdHash).toBe("string");
+    expect(droppedLog!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(typeof droppedLog!.data!.settlementIdHash).toBe("string");
+    expect(typeof droppedLog!.data!.ageMs).toBe("number");
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. CONTEXT_NOT_FOUND: friendship doc deleted → log and return, no throw
+  // -------------------------------------------------------------------------
+  it("logs CONTEXT_NOT_FOUND and returns successfully (no throw, no retry)", async () => {
+    const db = createMockDb({
+      contextExists: false,
+      settlements: [],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(makeEvent({changeType: "create", afterData: validSettlementData()})),
+    ).resolves.toBeUndefined();
+
+    const failedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_failed",
+    );
+    expect(failedLog).toBeDefined();
+    expect(failedLog!.data!.errorCode).toBe("CONTEXT_NOT_FOUND");
+    expect(failedLog!.level).toBe("error");
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. BALANCE_INVARIANT_VIOLATED: trigger logs AND throws so CF retries.
+  //
+  // Construct an expense where sharePaise sum != amountPaise.
+  // -------------------------------------------------------------------------
+  it("logs BALANCE_INVARIANT_VIOLATED and throws so Cloud Functions retries", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 4000},
+              {userId: "userB", sharePaise: 3000},
+            ],
+          },
+        },
+      ],
+      settlements: [],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(makeEvent({changeType: "create", afterData: validSettlementData()})),
+    ).rejects.toThrow();
+
+    const failedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_failed",
+    );
+    expect(failedLog).toBeDefined();
+    expect(failedLog!.data!.errorCode).toBe("BALANCE_INVARIANT_VIOLATED");
+    expect(failedLog!.level).toBe("error");
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. PII guard: structured logger NEVER receives fromUserId, toUserId,
+  //    amountPaise, note, OR the raw composite friendship contextId. Only
+  //    hashed identifiers are loggable.
+  // -------------------------------------------------------------------------
+  it("never logs PII (raw UIDs in contextId, fromUserId/toUserId, amounts, note)", async () => {
+    const uidAlice = "pii-uid-alice";
+    const uidBob = "pii-uid-bob";
+    const realisticFriendshipId = `${uidAlice}_${uidBob}`;
+    const realisticSettlementId = "pii-settlement-secret-id";
+
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: [uidAlice, uidBob]},
+      expenses: [],
+      settlements: [
+        {
+          id: realisticSettlementId,
+          data: {
+            fromUserId: uidAlice,
+            toUserId: uidBob,
+            amountPaise: 987654,
+            contextType: "friendship",
+            contextId: realisticFriendshipId,
+            note: "PII-secret-note",
+            deleted: false,
+          },
+        },
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        settlementId: realisticSettlementId,
+        afterData: {
+          fromUserId: uidAlice,
+          toUserId: uidBob,
+          amountPaise: 987654,
+          contextType: "friendship",
+          contextId: realisticFriendshipId,
+          note: "PII-secret-note",
+          deleted: false,
+        },
+      }),
+    );
+
+    for (const call of logger.calls) {
+      const serialised = JSON.stringify(call.data);
+      // Raw UIDs (from contextId, fromUserId, toUserId)
+      expect(serialised).not.toContain(uidAlice);
+      expect(serialised).not.toContain(uidBob);
+      // The raw composite friendship contextId
+      expect(serialised).not.toContain(realisticFriendshipId);
+      // Raw settlementId
+      expect(serialised).not.toContain(realisticSettlementId);
+      // Monetary value
+      expect(serialised).not.toContain("987654");
+      // Note text
+      expect(serialised).not.toContain("PII-secret-note");
+    }
+
+    // Affirmative check: hashed contextIdHash is present (production
+    // ops still get correlation IDs).
+    for (const call of logger.calls) {
+      const data = call.data ?? {};
+      if ("contextIdHash" in data) {
+        expect((data as Record<string, unknown>).contextIdHash).toMatch(
+          /^[0-9a-f]{16}$/,
+        );
+      }
+      if ("settlementIdHash" in data) {
+        expect((data as Record<string, unknown>).settlementIdHash).toMatch(
+          /^[0-9a-f]{16}$/,
+        );
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. settlement_trigger_fired is the FIRST log call (top of handler)
+  // -------------------------------------------------------------------------
+  it("emits settlement_trigger_fired as the first log call with hashed IDs", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(makeEvent({changeType: "create", afterData: validSettlementData()}));
+
+    expect(logger.calls.length).toBeGreaterThan(0);
+    expect(logger.calls[0].data?.event).toBe("settlement_trigger_fired");
+    expect(logger.calls[0].data?.contextType).toBe("friendship");
+    expect(logger.calls[0].data?.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(logger.calls[0].data?.settlementIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(logger.calls[0].data?.changeType).toBe("create");
+    expect(typeof logger.calls[0].data?.eventTime).toBe("string");
+    // Raw IDs MUST NOT appear in the fired log.
+    expect(logger.calls[0].data).not.toHaveProperty("contextId");
+    expect(logger.calls[0].data).not.toHaveProperty("settlementId");
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. lastActivityAt monotonicity: older event does NOT regress existing
+  // -------------------------------------------------------------------------
+  it("does not regress lastActivityAt when an older event arrives", async () => {
+    const olderEventTime = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const existingNewerTimestamp = Timestamp.fromDate(
+      new Date(Date.now() - 5 * 60 * 1000),
+    );
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {
+        memberIds: ["userA", "userB"],
+        lastActivityAt: existingNewerTimestamp,
+      },
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: olderEventTime,
+        afterData: validSettlementData(),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(updateFn.mock.calls[0][1].lastActivityAt).toEqual(
+      existingNewerTimestamp,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. lastActivityAt updated when newer than existing
+  // -------------------------------------------------------------------------
+  it("updates lastActivityAt when the event is newer than the existing value", async () => {
+    const newerEventTime = new Date(Date.now() - 60 * 1000).toISOString();
+    const newerTimestamp = Timestamp.fromDate(new Date(newerEventTime));
+    const existingOlderTimestamp = Timestamp.fromDate(
+      new Date(Date.now() - 60 * 60 * 1000),
+    );
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {
+        memberIds: ["userA", "userB"],
+        lastActivityAt: existingOlderTimestamp,
+      },
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: newerEventTime,
+        afterData: validSettlementData(),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(updateFn.mock.calls[0][1].lastActivityAt).toEqual(newerTimestamp);
+  });
+
+  // -------------------------------------------------------------------------
+  // 13. lastActivityAt set when existing is missing
+  // -------------------------------------------------------------------------
+  it("writes lastActivityAt when the existing value is missing", async () => {
+    const eventTime = new Date(Date.now() - 60 * 1000).toISOString();
+    const expectedTimestamp = Timestamp.fromDate(new Date(eventTime));
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime,
+        afterData: validSettlementData(),
+      }),
+    );
+
+    const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(updateFn.mock.calls[0][1].lastActivityAt).toEqual(expectedTimestamp);
+  });
+
+  // -------------------------------------------------------------------------
+  // 14. Group context discriminator: trigger reads contextType='group' from
+  //     doc data and resolves to the 'groups' collection.
+  // -------------------------------------------------------------------------
+  it("resolves to 'groups' collection when contextType is 'group'", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB", "userC"]},
+      expenses: [],
+      settlements: [
+        {
+          id: "sid",
+          data: validSettlementData({
+            contextType: "group",
+            contextId: "gid",
+          }),
+        },
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        afterData: validSettlementData({
+          contextType: "group",
+          contextId: "gid",
+        }),
+      }),
+    );
+
+    expect(
+      (db as unknown as {collection: jest.Mock}).collection,
+    ).toHaveBeenCalledWith("groups");
+  });
+});


### PR DESCRIPTION
## Summary

Ships the **`onSettlementWrite` Firestore trigger** — the second trigger in the application's history and the **first on a top-level collection** — plus the prerequisite **settlements security rules** (none existed; default-deny blocked all client writes) and an extension of **`recomputeAndWrite`** to read settlements into the simplified-debts net-balance computation.

This is the first PR that makes `simplifiedBalances` reflect BOTH expenses AND settlements. The Cloud Functions catalogue's section 1 read table (which previously claimed to read settlements) is now truthful for the first time.

Story: `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` (covers FR-SE-05 + FR-SE-06; 5 SP)

## Three coupled pieces

1. **Algorithm extension** — `recomputeAndWrite` now reads settlements alongside expenses in the same Firestore transaction. `computeNetBalances` folds settlement payments (credit `fromUserId` / debit `toUserId`) into the net-balance map. Public signature unchanged; the pure `simplifyDebts` algorithm in `algorithm.ts` is locked.

2. **Settlements security rules** — new `match /settlements/{settlementId}` block. `fromUserId == request.auth.uid` on create; member-of-context enforced; extension-point locks (`method='manual'`, `currency='INR'`, `verificationStatus='unverified'`); historical-field immutability (only soft-delete via `deleted: true` is permitted on update); hard-delete admin-only. **`verificationStatus` is server-only** — the Invariant-2 PARALLEL for settlements per ARCH-EXT-06.

3. **`onSettlementWrite` trigger** — top-level collection. Reads `contextType` + `contextId` from doc data (after-side on create/update, before-side on hard-delete). Inherits PR #36's architecture verbatim: PII-safe `hashId()` logging, stale-event guard (>7 days), `lastActivityAt` monotonicity guard, retry policy (CONTEXT_NOT_FOUND returns successfully; BALANCE_INVARIANT_VIOLATED + INTERNAL throw).

## Invariant compliance

| Invariant | Status | Verification |
|---|---|---|
| **Inv 1** (paise int) | ✅ | Settlement `amountPaise` is int; computeNetBalances fold is integer arithmetic; rules enforce `is int && > 0`. |
| **Inv 2** (`simplifiedBalances` server-only) | ✅ | `grep -rEn "tx\.update.*simplifiedBalances" functions/src/` returns exactly 1 match (the existing `recomputeAndWrite` writer). The settlements read is INPUT to the algorithm, not a second writer. |
| **Inv 2 PARALLEL** (`verificationStatus` server-only on settlements per ARCH-EXT-06) | ✅ | New rules block enforces field-level diff. v1.0 has no server-side writer; `grep -rEn "verificationStatus" functions/src/` returns 0 matches. |
| **Inv 4** (single Firebase project) | ✅ | No new project. |

## AC-17 regression (existing behaviour preserved)

- `on-expense-write/function.test.ts` — 13 PR #36 boundary tests pass unmodified after the mock was extended to dispatch by collection name (friendships/groups vs settlements).
- `simplified-debts.integration.test.ts` — existing callable end-to-end tests pass unmodified.
- `on-expense-write.integration.test.ts` — PR #36 trigger integration tests pass unmodified.

## Coverage

| Module | Before (PR #36 baseline) | After (PR #37) | Status |
|---|---|---|---|
| `functions/src/triggers/on-settlement-write/` | N/A (new) | **84.37%** stmts / 75% branches | ≥70% per-module gate ✅ |
| `functions/src/simplified-debts/` (branches) | 86.44% | **87.69%** | ≥ baseline ✅ |
| Functions overall (statements) | ~91% | **91.84%** | ≥50% ✅ |

## Verification

Local runs (macOS, Node 20, Firebase CLI 13.35.1):

```
cd functions && npm run lint && npm run build && npm test
# 100 passed, 100 total

firebase emulators:exec --only auth,firestore,functions,storage demo-onebytwo \
  "cd functions && npm run test:rules && npm run test:integration"
# Rules: 149 passed, 149 total (stable across 5 consecutive runs)
# Integration: 28 passed, 5 skipped (pre-existing lookup-user rate-limit bug)
```

## Deferred items (hand-off seams in trigger source)

- **Activity-feed item writes** — `// TODO(FR-AC-01)` comment.
- **FCM push notifications to recipient** — `// TODO(FR-AC-03)` comment.
- **`onExpenseWriteGroup` trigger binding** — Sprint 3 (groups epic).
- **`verificationStatus` state machine** — post-v1.0 UPI integration per ARCH-EXT-06.
- **Flutter settle-up UI (FR-SE-08)** — later PR. The trigger ships BEFORE its first client producer so balances "just work" the moment the UI lands.
- **Fix for pre-existing `lookup-user-by-phone-number` rate-limit doc-path bug** — out of scope (5 `describe.skip`'d integration tests; separate follow-up PR).

## Schema additions (additive — no production settlement docs exist yet)

The schema docs (`firestore-schema.md`) now list two fields the implementation requires:

- `deleted: bool` (default `false`) — supports soft-delete via update; the algorithm filters `deleted === true` settlements out of the net-balance fold.
- `createdAt: timestamp` (immutable; `== request.time` on create) — audit field consistent with every other write-rule-enforced immutable timestamp in the codebase.

Both `firestore-schema.md` and `firestore-security-rules.md` settlements sections reconciled with the implementation in this PR.

## Deploy sequence

Per Phase 5 step 7 of `docs/copilot_prompts/sprint_2/6.md` and DoD §3:

1. Merge to `main` (squash). PR title becomes the squash commit message.
2. CI runs the release pipeline: `firebase deploy --only firestore:rules,firestore:indexes,functions:onSettlementWrite --project onebytwo-avtanshgupta --region asia-south1`.
3. Verify in production:
   - `firebase functions:list --project onebytwo-avtanshgupta` shows `onSettlementWrite` with `google.cloud.firestore.document.v1.written` trigger.
   - The composite index `settlements (contextType ASC, contextId ASC)` is in BUILDING then READY state.

## Files changed

- `firestore.rules` — `match /settlements/{settlementId}` block + helpers.
- `firestore.indexes.json` — composite index `settlements (contextType ASC, contextId ASC)`.
- `functions/src/simplified-debts/function.ts` — `recomputeAndWrite` settlements read + `computeNetBalances` extension.
- `functions/src/triggers/on-settlement-write/` (new) — trigger module + registration.
- `functions/src/index.ts` — re-export `onSettlementWrite`.
- `functions/test/triggers/on-settlement-write/function.test.ts` (new) — 14 boundary tests.
- `functions/test/firestore-rules/settlements.test.ts` (new) — 43 rules tests.
- `functions/test/integration/on-settlement-write.integration.test.ts` (new) — 6 end-to-end tests.
- `functions/test/simplified-debts/function.test.ts` — 7 settlement-input mock cases + mock dispatcher update.
- `functions/test/simplified-debts/algorithm.property.test.ts` — 4 mixed expense+settlement property tests.
- `functions/test/triggers/on-expense-write/function.test.ts` — mock dispatcher update (AC-17 regression preserved).
- `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` (new) — full story + architect notes (9 sections).
- `docs/design/07-technical/cloud-functions-catalogue.md` — section 3 trigger-type fix; Appendix A status flip.
- `docs/design/07-technical/firestore-schema.md` — settlements table reconciled.
- `docs/design/07-technical/firestore-security-rules.md` — settlements section reconciled.
- `docs/sprint-zero/sprint-2-plan.md` — PR #37 status + Pattern Extension section.
- `docs/sprint-zero/next-three-prs.md` — rolled to PR #38 (FR-EX-01 + chore #25 bundle).

Next PR: PR #38 — FR-EX-01 Expense Creation UI (Flutter) with mandatory chore #25 bundle per Critical Constraint C-1.
