### PR TITLE
chore(plan): file #39 + #40 for D5 deadline; update backlog cross-refs

### DIFF
--- a/docs/audits/sprint-1/07-bucket-b-burndown.md
+++ b/docs/audits/sprint-1/07-bucket-b-burndown.md
@@ -123,7 +123,8 @@ so INV2 remains partially addressed pending the dedicated chore.
 | D1 | Riverpod 3.x migration | Dedicated chore PR, Sprint 2 or 3 |
 | D2 | `share_plus` upgrade (10 to 13) | Before first share-using PR |
 | D4 | `build_runner` upgrade (discontinued transitives) | When convenient |
-| D5 | `firebase-functions` 7.x evaluation | Before Sprint 2 CF work |
+| D5a | Cloud Functions Node 20 runtime decommissioned **2026-10-31** (tracked as [#39](https://github.com/avtansh-code/OneByTwo/issues/39)) | **Before 2026-09-30** (one deploy cycle of slack) |
+| D5b | `firebase-functions` package outdated (6.x → 7.x; tracked as [#40](https://github.com/avtansh-code/OneByTwo/issues/40)) | Bundle with D5a |
 | D6 | npm audit moderate vulnerabilities | When firebase-admin/functions upgraded |
 | D7 | Jest 30, TypeScript 6, ESLint 9 major bumps | When convenient |
 

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -120,13 +120,13 @@ multiple devs (Option B), QA.
 
 ---
 
-## PR #42 — Post-PR #38 cleanup (S4 docs + tests) OR Bucket-B chore PR
+## PR #42 — Post-PR #38 cleanup (S4 docs + tests) OR Bucket-B chore PR OR D5 deadline PR
 
 **Status:** Planned.
 
 **Scope:**
 
-Two candidates after PR #41:
+Three candidates after PR #41:
 
 - **Option A — Post-PR #38 cleanup PR.** Bundles the three S4 follow-ups
   surfaced by the PR #38 QA sign-off — see
@@ -149,18 +149,31 @@ Two candidates after PR #41:
   Option B notes — Sprint 2 polish set (M1 / S1 / S3 / S4 / CV2) or the
   telemetry sweep (#16 / #18-S5). Roughly 2-3 SP.
 
+- **Option C — D5 deadline PR (Node 22 + firebase-functions 7.x).**
+  Closes [#39](https://github.com/avtansh-code/OneByTwo/issues/39)
+  (Cloud Functions runtime Node 20 decommissioned **2026-10-31**;
+  ~5 months runway as of filing) **and**
+  [#40](https://github.com/avtansh-code/OneByTwo/issues/40)
+  (`firebase-functions` 6.x → 7.x breaking-change reconciliation) in a
+  single bundle. Must ship before mid-September 2026 to leave a deploy
+  cycle of slack before the cutoff; if the orchestrator does not slot
+  it into PR #42, it must surface again no later than PR #44. SP
+  estimate sized by Architect at kickoff (likely 3-5 SP because of
+  breaking-change reconciliation across 5 functions + integration
+  tests + CI workflow Node-version pin update).
+
 **Likely choice:** Option A if PR #41 picks its Option A (lookup
-rate-limit fix). The two together would close the lookup bug AND drain
-the Post-Merge Cleanup Backlog before PR #43 starts a fresh feature
-cycle. The architect makes the final call at PR #42 kickoff.
+rate-limit fix) — drains the Post-Merge Cleanup Backlog. If the
+deadline runway is the priority, Option C jumps ahead and the cleanup
+slips to PR #43. The architect makes the final call at PR #42 kickoff.
 
-**Stories required before kickoff:** none — the three S4 items are
-fully specified in `docs/sprint-zero/sprint-2-plan.md` "Post-Merge
-Cleanup Backlog" and the QA Sign-Off section of
-`docs/sprint-zero/stories/FR-EX-01-expense-creation.md`.
+**Stories required before kickoff:** none for Option A (fully specified
+in the "Post-Merge Cleanup Backlog"); none for Option C either (issues
+#39 and #40 are the spec). Option B may need a story depending on the
+bundle.
 
-**Agents involved:** Flutter Dev OR PM (single-commit docs/test change),
-QA (sign-off only).
+**Agents involved:** Flutter Dev OR PM (Option A), Functions Dev
+(Option C), QA (sign-off).
 
 ---
 

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -333,6 +333,40 @@ slot).
 hygiene) → item 3 (discoverability nicety). All three can ship in a
 single docs/tests-only PR.
 
+### From PR #38 deploy (Firebase CLI warnings, 2026-06-06)
+
+Two **deadline-bound** items surfaced by the post-PR #38 functions deploy.
+Filed as standalone GitHub issues (not S4 — these are S2 because of the
+hard 2026-10-31 deploy-blocker) and tracked separately from the S4 set
+above. Both should ship in the SAME PR — see PR #42 Option C in
+`docs/sprint-zero/next-three-prs.md` for the recommended slot.
+
+4. **Cloud Functions runtime Node 20 decommissioned 2026-10-31** —
+   tracked as [#39](https://github.com/avtansh-code/OneByTwo/issues/39).
+   After this date, `firebase deploy --only functions` will be rejected
+   for the Node 20 runtime. Upgrade target: **Node 22 LTS**. Touches
+   `functions/package.json` `engines.node`, `firebase.json`
+   `functions[].runtime`, and the `actions/setup-node` pin in
+   `.github/workflows/pr.yml`.
+
+   **Why deadline-bound:** hard cutoff. The next functions deploy after
+   2026-10-31 will fail. **Recommended ship-by date: mid-September 2026**
+   to leave one deploy cycle of slack.
+
+5. **`firebase-functions` package outdated (6.x → 7.x)** — tracked as
+   [#40](https://github.com/avtansh-code/OneByTwo/issues/40). CLI warns
+   on every deploy. Breaking changes affect v2 trigger and callable
+   surfaces (i.e. all 5 of our deployed functions).
+
+   **Why bundled with #4:** the Node-22 + `firebase-functions@7.x`
+   matrix is the only combination that future-proofs all the way
+   through. Doing them separately doubles the breaking-change
+   reconciliation surface.
+
+Both close umbrella item D5 in
+`docs/audits/sprint-1/07-bucket-b-burndown.md`. Issue #22 (umbrella
+dependency-upgrade backlog) retains D1, D2, D4, D6, D7.
+
 ---
 
 ## Sprint 2 Chore Backlog (open GitHub issues)
@@ -362,7 +396,7 @@ Status legend:
 | [#19](https://github.com/avtansh-code/OneByTwo/issues/19) | Add PR coverage tracking to conventions | CV2 | Partially addressed | `feature-pr-conventions.md` has an enforced-thresholds section and `.github/PULL_REQUEST_TEMPLATE.md` has a "Coverage thresholds maintained" checkbox. **Still missing:** explicit before/after coverage fields requested by the issue. |
 | [#20](https://github.com/avtansh-code/OneByTwo/issues/20) | Improve test coverage gaps | SC1, SC2, SC3, SC4, **CV3** | Partially addressed | **CV3 closed by PR #36** — `functions/src/simplified-debts/function.ts` branch coverage now **90%** (was 76%) thanks to the `recomputeAndWrite` variant 2.3(b) refactor. SC1 (concurrent submit guard), SC2 (OTP auto-retrieval timeout), SC3 (`MAX_SAFE_INTEGER`), SC4 (large-group scalability) still open. |
 | [#21](https://github.com/avtansh-code/OneByTwo/issues/21) | Firestore + Storage rules test gaps | **R1, R2, R3, R4**; R5-R8 | Partially addressed | **R1, R2, R3 closed by PR #32** (friendship create/update/delete rules tests). **R4 closed by PR #36** — new `expenses-friendship.test.ts` covers 45 cases including sum check, extension-point locks, immutables, soft-delete. R5-R6 (group rules) still open (Sprint 3). R7-R8 (Storage avatar file-size / content-type) still open — `storage-rules/avatars.test.ts` only covers basic read/write. |
-| [#22](https://github.com/avtansh-code/OneByTwo/issues/22) | Dependency upgrades — Riverpod 3.x, share_plus, firebase-functions 7.x | D1, D2, D4, D5, D6, D7 | Open | No upgrade PRs merged. Firebase deploy warnings surfaced D5 (`firebase-functions` 6→7) and the Node 20 deprecation deadline (Oct 2026). |
+| [#22](https://github.com/avtansh-code/OneByTwo/issues/22) | Dependency upgrades — Riverpod 3.x, share_plus, firebase-functions 7.x | D1, D2, D4, D5, D6, D7 | **Open — D5 now URGENT** (split into [#39](https://github.com/avtansh-code/OneByTwo/issues/39) Node 20 decommissioned **2026-10-31** and [#40](https://github.com/avtansh-code/OneByTwo/issues/40) firebase-functions 6→7) | Sprint 1 audit deferral. D5 was reinforced by the post-PR #38 deploy warnings (2026-06-06) and split into two deadline-aware sub-issues; #39 has ~5 months runway before the next `firebase deploy --only functions` is rejected. D1, D2, D4, D6, D7 remain tracked on the umbrella. |
 | [#23](https://github.com/avtansh-code/OneByTwo/issues/23) | Expand integration tests for Sprint 2 flows | PY3, RT2, INV2 | Partially addressed | **PR #36 enabled `npm run test:integration` inside `firebase emulators:exec`** — every future trigger PR exercises its actual registration in CI (helps PY3). Friend-add stub `test/integration/friends/friends_list_flow_test.dart` shipped in PR #35 (still skipped). RT2 (CI step duration logging) not yet added. INV2 (share-sheet verification) — system share sheet is the only path, but no test asserts the package-import boundary. Expense-create flow integration tests blocked on FR-EX-01. |
 | [#24](https://github.com/avtansh-code/OneByTwo/issues/24) | Conventions doc — CF PR checklist and Jest config separation | CN3, CN4 | Open | `feature-pr-conventions.md` does not yet enumerate the Jest config split (`jest.config.js` vs `jest.rules.config.js` vs `jest.integration.config.js`) nor CF-specific PR checklist items (region pinning, error-code mapping, transaction usage, idempotency). |
 | [#25](https://github.com/avtansh-code/OneByTwo/issues/25) | Expense event naming convention decision | SR8 | **Closed by PR #38** (Camp B adopted — see Critical Constraint C-1 above, marked RESOLVED) | Decision: `expense_save_succeeded` / `expense_save_failed` per Architect Notes §2.0 of FR-EX-01. Five telemetry-plan occurrences renamed; `lib/features/expenses/application/expense_telemetry.dart` ships the matching constants. `Closes #25` recorded in PR #38 body. |
@@ -400,6 +434,6 @@ batched into a standalone chore PR. The orchestrator's recommendation:
 | **Pre-FR-EX-01 design polish PR (2 SP)** | **#18 (S1, S3, S4), #28** | Spec alignment + friends mockup before the expense screens land so the design system stabilises. |
 | **Standalone CF chore PR (Sprint 3 ramp — 3 SP)** | **#24** | CF PR checklist + Jest config docs make Sprint 3's groups trigger work less ambiguous. |
 | **Defer to Sprint 3** | **#21 (R5-R8)** | Group rules tests pair with the groups epic; Storage size/content-type can also wait. |
-| **Defer to Sprint 4+** | **#22, #27** | Dependency upgrades and the Invariant-1 hook are non-urgent; type system + boundary contracts suffice for now. |
+| **Defer to Sprint 4+** | **#22 (D1/D2/D4/D6/D7 remaining), #27** | Dependency upgrades and the Invariant-1 hook are non-urgent; type system + boundary contracts suffice for now. **D5 has been split out into #39 (Node 20 decommissioned 2026-10-31) and #40 (firebase-functions 6→7) and is URGENT** — slot the pair into PR #41 or PR #42 so the Cloud Functions deploy path stays open past the cutoff. |
 | **Defer to Sprint 6** | **#26** | Release-only secrets and DPDP review explicitly tied to release execution. |
 | **Already covered** | **#23 (PY3 partial)** | PR #36 enabled `test:integration` in CI. Remaining INV2 / RT2 sub-items deferred. |


### PR DESCRIPTION
## Summary

Surfaces the **D5 deadline** from the post-PR #38 functions deploy
(2026-06-06) as two deadline-aware GitHub issues + updates the rolling
plan + bucket-B burndown + next-three-prs.md so the urgency is
discoverable.

## What this changes

**Issues filed** (both labelled `sprint-2-chore` + `enhancement`):

- **#39** — Cloud Functions runtime Node 20 decommissioned **2026-10-31**.
  Hard cutoff; the next `firebase deploy --only functions` after this
  date will be rejected by the platform. ~5 months runway as of filing.
  Recommended ship-by date: **mid-September 2026** (one deploy cycle of
  slack).

- **#40** — `firebase-functions` npm package outdated (6.x → 7.x).
  Breaking changes affect all 5 deployed functions (v2 triggers +
  callables + `onRequest`). Companion to #39 — same D5 sub-item,
  different lever. Recommended bundle: same PR.

**Docs updated:**

- `docs/sprint-zero/sprint-2-plan.md` — Sprint 2 Chore Backlog row for
  #22 now flags D5 as URGENT and cross-references #39 + #40; sequencing
  table marks the dependency-upgrade slot as URGENT for the D5 pair;
  Post-Merge Cleanup Backlog gains a "From PR #38 deploy" sub-section
  with items #4 (Node 22) and #5 (firebase-functions 7.x) recorded at
  S2 severity.
- `docs/audits/sprint-1/07-bucket-b-burndown.md` — D5 row split into
  D5a (Node 20 → #39) and D5b (firebase-functions → #40) with explicit
  cutoff date and bundling guidance.
- `docs/sprint-zero/next-three-prs.md` — PR #42 slot now has Option C
  (D5 deadline PR) as a third candidate; the title is rewritten to flag
  the three options; the "Likely choice" note explains when Option C
  jumps ahead of Options A and B.
- Issue #22 (the umbrella) carries a comment linking #39 + #40 and
  noting the remaining D1/D2/D4/D6/D7 items stay tracked there.

## Why now

The Firebase CLI warned during the post-PR #38 deploy:

> Runtime Node.js 20 was deprecated on 2026-04-30 and will be
> decommissioned on 2026-10-31, after which you will not be able to
> deploy without upgrading.

> package.json indicates an outdated version of firebase-functions.
> Please upgrade using `npm install --save firebase-functions@latest` in
> your functions directory. Please note that there will be breaking
> changes when you upgrade.

The Node 20 deadline is a hard platform-side cutoff. The
`firebase-functions` upgrade is a soft deadline but tied to the same
upgrade window because the Node-22 + `firebase-functions@7.x` matrix is
the only combination that future-proofs all the way through.

## Invariants

No runtime behaviour change. No source code or test files touched. No
rules / functions / indexes / Storage rules change. The four invariants
are unaffected.

## Gates

`flutter analyze`, `flutter test`, and `npm test` are unchanged on the
docs-only diff. CI will still run them and they should remain green.

## Out of scope

This PR does NOT execute the upgrade. It only files the issues and
makes them discoverable. The upgrade itself is PR #42 Option C (or
later, slotted by the orchestrator) per `next-three-prs.md`.

Closes: nothing yet (this PR documents work that the future D5 deadline
PR will close).
