### PR TITLE
feat(functions): FR-EX-07 activity feed emission (friendship)

### DIFF
--- a/docs/audits/sprint-1/07-bucket-b-burndown.md
+++ b/docs/audits/sprint-1/07-bucket-b-burndown.md
@@ -6,7 +6,7 @@
 > Source: `docs/audits/sprint-1/00-triage-summary.md` (Bucket B section).
 > Detail: `docs/audits/sprint-1/06-deferred-to-sprint-2.md`.
 >
-> Last updated: PR #48.
+> Last updated: PR #51.
 
 ---
 
@@ -17,9 +17,9 @@
 | Code chores | 12 | 0 | 12 |
 | Documentation chores | 8 | 1 | 7 |
 | Dependency upgrades | 6 | 2 | 4 |
-| Test coverage gaps | 8 | 6 | 2 |
+| Test coverage gaps | 8 | 7 | 1 |
 | Infrastructure | 3 | 0 | 3 |
-| **Total** | **37** | **9** | **28** |
+| **Total** | **37** | **10** | **27** |
 
 Tracking format: 14 items logged as GitHub issues (#15 through #28); 23 items
 logged in `06-deferred-to-sprint-2.md` only.
@@ -132,7 +132,8 @@ so INV2 remains partially addressed pending the dedicated chore.
 
 | ID | Item | Timeline |
 |---|---|---|
-| R1-R6 | Firestore rules test gaps (friendships and groups) | Sprint 2 friendship PR / Sprint 3 groups PR |
+| ~~R5a~~ | ~~Firestore rules test gap for activity collection~~ | **Closed by PR #51** (`functions/test/firestore-rules/activity.test.ts` — 12 tests covering AC-6 through AC-12 of the FR-EX-07 story: owner-read positive + non-owner / unauth / parent-doc negatives + client-create / update / delete denied) |
+| R1-R4, R5b, R6 | Remaining Firestore rules test gaps (friendships / groups halves) | Sprint 2 friendship PR / Sprint 3 groups PR |
 | ~~R7-R8~~ | ~~Storage rules test gaps (file size, content-type)~~ | **Closed by PR #48** (`functions/test/storage-rules/receipts.test.ts` — 23 tests covering size + MIME + membership + cross-collection predicate for friendship + group predicates) |
 | SC2 | OTP auto-retrieval timeout test | Android auto-read refinement |
 | SC4 | Large group (100+) scalability test | Sprint 3 groups |
@@ -168,6 +169,10 @@ PR #38 (FR-EX-01):     32 remaining  ██████████████�
 PR #42 (FR-FR-04):     32 remaining  ███████████████████████████████░░░░░░░  32/37
 PR #43 (FR-SE-05-07):  32 remaining  ███████████████████████████████░░░░░░░  32/37
 PR #44 (D5 upgrade):   30 remaining  █████████████████████████████░░░░░░░░░  30/37
+PR #45 (CHORE-PR45):   30 remaining  █████████████████████████████░░░░░░░░░  30/37
+PR #46 (FR-EX-06):     30 remaining  █████████████████████████████░░░░░░░░░  30/37
+PR #48 (FR-EX-05):     28 remaining  ███████████████████████████░░░░░░░░░░░  28/37
+PR #51 (FR-EX-07):     27 remaining  ██████████████████████████░░░░░░░░░░░░  27/37
 ```
 
 PR #32 closed three items (R1, R2, R3 — friendship rules tests). PR #33 was a
@@ -499,3 +504,49 @@ PR #48 (FR-EX-05 receipt attachment, friendship context) closes
 
 Net contribution of PR #48 to Bucket-B totals: **+2**. R7 + R8
 both close. The remaining count drops to **28 / 37**.
+
+PR #51 (FR-EX-07 activity feed write-side, friendship expenses)
+closes **R5a** and makes partial progress on **PY3**:
+
+- **R5a — Firestore rules test gap for activity collection:**
+  **CLOSED.** The new `functions/test/firestore-rules/activity.test.ts`
+  suite (12 tests) covers AC-6 through AC-12 of the FR-EX-07
+  story:
+    - AC-6 (positive): authenticated owner reads own item — succeeds.
+    - AC-7 (negative): non-owner read of another user's item —
+      `permission-denied`; variant covers the no-item-present case.
+    - AC-8 (negative): unauthenticated read — `permission-denied`.
+    - AC-9 (negative, 3 variants): owner / non-owner / unauthenticated
+      client attempting to create an item — all `permission-denied`.
+    - AC-10 (negative): owner attempting to update an item — `permission-denied`.
+    - AC-11 (negative): owner attempting to delete an item — `permission-denied`.
+    - AC-12 (negative, 3 variants): parent `activity/{userId}` doc
+      read / create / unauthenticated read — all rejected via the
+      explicit `allow read, write: if false` defence-in-depth on
+      the parent doc.
+  Note: R5 in the original Bucket-B audit table was split into
+  R5a (activity rules; closed by PR #51) and R5b (groups rules;
+  Sprint 3 groups epic). The original R5 row in the Test Coverage
+  Gaps table is renumbered accordingly.
+- **PY3 — Expand integration tests for Sprint 2 flows:** PR #51
+  extends `functions/test/integration/on-expense-write.integration.test.ts`
+  with three new round-trip tests for AC-17 (create → both members
+  read; edit → both members read; soft-delete → both members
+  read). The tests run inside the existing
+  `firebase emulators:exec --only auth,firestore,functions,storage`
+  CI step. Partial credit only; PY3 remains open pending broader
+  Flutter integration harness coverage.
+- **R1, R2, R3, R4 — Friendship rules test gaps:** unchanged
+  (closed by earlier PRs).
+- **R5b — Groups rules test gap:** unchanged (Sprint 3 groups
+  epic).
+- **R6 — Settlement rules test gap:** unchanged (closed by PR #37
+  per resolution log).
+- **R7, R8 — Storage rules test gaps:** unchanged (closed by PR
+  #48).
+- **D1, D2, D4, D7, D6:** unchanged (Sprint 4+ scope).
+- **No new Bucket-B items filed by PR #51.** The PR is server-only
+  (no client surface), so no new test-coverage gaps appear.
+
+Net contribution of PR #51 to Bucket-B totals: **+1**. R5a closes.
+The remaining count drops to **27 / 37**.

--- a/docs/copilot_prompts/sprint_2/14.md
+++ b/docs/copilot_prompts/sprint_2/14.md
@@ -1,0 +1,376 @@
+1. 1. You are the OneByTwo orchestrator agent. PR #48 (FR-EX-05 — receipt attachment, friendship context) has merged (squash commit `0c6f649`) and the friendship-expense feature is now complete end-to-end across the create / view / edit / soft-delete / receipt lifecycle: PR #38 added create, PR #42 added the read-side timeline, PR #46 added edit + soft-delete + the Expense Detail screen + `OBTConfirmationDialog`, and PR #48 added Step 3 (SCR-21) + `ReceiptStorageService` + the `storage.rules` friendship + group receipts predicates + the Expense Detail thumbnail. Sprint 2 velocity through end of PR #48: **50 SP across 14 PRs**. The `onExpenseWriteFriendship` Cloud Function (PR #36) recomputes `simplifiedBalances` on every expense write across all six branches (create, edit, soft-delete, receipt-attach, receipt-replace, receipt-remove) and the rules-tests now cover both the Firestore expense subcollection AND the Storage receipts predicate (8 suites / 176 tests). We now implement **PR #51: FR-EX-07 — Activity feed write-side emission for friendship expenses**. This is the natural P0 follow-on: the long-standing TODOs at `functions/src/triggers/on-expense-write/function.ts:162` (`// TODO(FR-AC-01): write activity-feed item to activity/{userId}/items`) finally land; the `activity/{userId}/items` Firestore collection ships with member-read-only rules; and the schema doc lines 194-211 finally become enforceable. The client read-side (SCR-25 — Activity tab) is the natural follow-on for **PR #52** (FR-AC-01); the settlement-trigger activity emission belongs to a separate PR alongside FR-AC-01 — PR #51 is the **write-side only**, **expense-trigger only**, **friendship-only** slice that closes the FR-EX-07 P0 row in isolation.
+2. 
+3. 2. The numbering continues from PR #48 — and **PR #49 and PR #50 are ISSUES, not PRs.** PR #48 review filed `https://github.com/avtansh-code/OneByTwo/issues/49` ("Orphan-cleanup Cloud Function for unreferenced receipts under `receipts/` (90-day reaper)") — a 2 SP FUTURE-work chore deferred per SRS schema doc line 312 — and `https://github.com/avtansh-code/OneByTwo/issues/50` ("Trigger optimisation: skip `recomputeSimplifiedBalances` when expense update touches only `receiptUrl` + `updatedAt`") — a 1 SP FUTURE-work chore deferred per PR #48 architect §2.9 item 4. Both remain OPEN. Issue #47 ("Firestore rules: tighten friendship-expense update/delete to creator-only") also remains OPEN from the PR #46 review. So the post-PR-#48 sequence so far is: #48 (PR — feat, merged `0c6f649`), #49 (issue — orphan cleanup, OPEN), #50 (issue — trigger no-op optimisation, OPEN). **PR #51 is the next FEATURE PR.** The orchestrator should not assume PR #52 == GitHub issue 52 — issues and PRs share the same sequential namespace, so any new issues filed during PR #51 will consume intermediate numbers. **Pre-merge CI title-lint gotcha (verified PR #45, re-verified PR #46, re-verified PR #48):** the workflow regex `[a-z0-9_-]+` rejects comma-separated scopes — use a single-token scope (e.g. `feat(activity)` or `feat(functions)`), not `feat(functions,activity)`.
+4. 
+5. 3. PR #51 is the **first PR that writes to the `activity/{userId}/items` collection from a Cloud Function** and the **first PR that adds Firestore Security Rules for the `activity/**` path tree.** The seams are already in place:
+6.    - `functions/src/triggers/on-expense-write/function.ts:160-169` reads verbatim:
+7.      ```
+8.      // 3. Hand-off seams for downstream PRs (left as comments so the next
+9.      //    contributor doesn't need to refactor this handler):
+10.      //    TODO(FR-AC-01): write activity-feed item to activity/{userId}/items
+11.      //    TODO(FR-AC-03): send FCM push notification respecting notificationPrefs
+12.      //    Placement note: these MUST run only after a successful recompute
+13.      //    (i.e. inside or just below the success branch at line 222) to
+14.      //    keep retry semantics clean — a retryable transient failure must
+15.      //    not duplicate activity items or notifications. Today they are
+16.      //    deferred entirely; the actual placement decision lives with the
+17.      //    PR that implements them.
+18.      ```
+19.    - The schema doc at `docs/design/07-technical/firestore-schema.md` lines 194-211 spells out the canonical document shape:
+20.      - `type: string` — one of `'expense_added'`, `'expense_edited'`, `'expense_deleted'`, `'settlement'`, `'group_change'`.
+21.      - `payload: map` — event-specific data; structured so the client can render the row without additional reads.
+22.      - `createdAt: timestamp` — server timestamp; single-field descending index (auto-created by Firestore).
+23.      - Read: only by the user whose UID matches the parent `activity/{userId}` path.
+24.      - Write: only by the Cloud Functions service account; clients may NEVER write.
+25.    - `firestore.rules` currently has **no rule** for `activity/**` — the default-deny at `match /{document=**}` is the only guard. PR #51 adds the explicit member-read predicate; defence-in-depth says the rules-side `allow create, update, delete: if false` plus `allow read: if request.auth.uid == userId` is the canonical posture (mirrors the `simplifiedBalances` server-only enforcement pattern that PR #36 ratified).
+26.    - `firestore.indexes.json` currently has THREE composite indexes (friendships by member + lastActivityAt, settlements by context + date, expenses by deleted + date). The `activity/{userId}/items` collection needs **no composite index** — the single-field descending index on `createdAt` is auto-created by Firestore on first query (per schema doc line 266). PR #51 does NOT touch `firestore.indexes.json`.
+27.    - The `onExpenseWriteFriendship` trigger already has the `ChangeType` discriminator (`'create' | 'update' | 'delete'` per `functions/src/triggers/on-expense-write/function.ts:79`) and the eventTime + recomputeAndWrite scaffolding the activity-write needs to slot into. The trigger fires for EVERY friendship-expense write; the FR-EX-07 P0 says edit + delete must be recorded — the architect at §2.x should also include create writes for symmetry (the SCR-25 spec at line 305-307 enumerates `expenseAdded`, `expenseEdited`, `expenseDeleted` event types so create-side IS part of the activity feed).
+28.    - The friendship document at `friendships/{friendshipId}` carries `memberIds: [uidA, uidB]` (deterministic by sort at PR #32). The trigger has the friendship document context via the `change.params.friendshipId` parameter; reading `change.after.data().createdBy` (or `change.before.data().createdBy` for the deleted branch) gives the author UID. Both members get an activity item per the SRS section 7.2 "involving the user" requirement — the trigger writes TWO items per expense write, one for each `uid` in `memberIds`.
+29.    - **No client-side work is required in PR #51.** SCR-25 (Activity tab) is the FR-AC-01 read-side story and is the natural follow-on for **PR #52**. PR #51 ships the write-side + the rules + the rules tests + the trigger unit tests; the client trusts the future read-side.
+30.    - **Settlement-trigger activity emission is FUTURE.** `functions/src/triggers/on-settlement-write/function.ts:231` has the symmetric TODO. PR #51 must NOT touch this file — the settlement-trigger extension belongs to PR #52 (FR-AC-01 client + settlement-write activity emission, since both halves are needed for the settlement leg of the SCR-25 feed to be useful).
+31.    - **Group-context expense activity emission is FUTURE.** The Sprint 3 groups epic ships the `onExpenseWriteGroup` trigger (FR-EX-02 group-context); PR #51 is friendship-only.
+32. 
+33. 4. PR #51 has **no mandatory cross-PR bundle**. PR #51 must NOT bundle FR-AC-01 client SCR-25 (separate P0 story; PR #52 candidate; reads what PR #51 writes), FR-AC-02 deep-link wiring (part of FR-AC-01), FR-AC-03 FCM push notifications (separate P0; FCM dependency + notificationPrefs schema), FR-AC-04 / FR-AC-05 (notification preferences + cold-start deep-link; part of FR-AC-03), settlement-write activity emission (paired with FR-AC-01 client), group-context activity emission (Sprint 3 groups epic), the deferred trigger no-op-recompute optimisation (issue #50; the receipt-only update branch should NOT skip activity emission because the SCR-25 feed needs to surface receipt attaches per the architect's call at §2.x), the deferred orphan-cleanup function (issue #49), the deferred concurrent-edit detection (PR #46 §2.4), issue #47 rules-hardening for non-creator update/delete (separate small chore PR), or the rate-limit transaction race refactor (PR #45 §2.2 deferred). PR #48 closed cleanly and merged — there are no review-carry-forward items from PR #48 to action in PR #51.
+34. 
+35. 5. Read before starting:
+36.    - `.github/copilot-instructions.md`
+37.    - `.github/shared/invariants.md` — invariant 1 (paise integers — N/A on the activity-feed write path itself; the `amountPaise` and `sharePaise` values flow from the expense doc unchanged into the activity payload, so the integer invariant is preserved by construction), invariant 2 (`simplifiedBalances` client-read-only — PR #51 must NOT write to that field; the activity emission is a SEPARATE Firestore write, conceptually parallel to `simplifiedBalances` — see architect §2.x for the atomicity discussion), invariant 3 (system share sheet — N/A; no sharing surface), invariant 4 (single Firebase project — defence-in-depth re-check; the new Firestore rules MUST target the same single project).
+38.    - `.github/shared/coding-standards.md` — Dart, Riverpod, widget-test, and Conventional Commits rules. **The Cloud Functions section is load-bearing for PR #51** — extension of `functions/src/triggers/on-expense-write/function.ts` is the bulk of the diff; structured logging, hashId() PII guard, and the established try/catch + typed-error pattern apply.
+38a.   - **Memory: PR# references in code/test files are forbidden.** Repository memory: "Do not include PR numbers (e.g. 'PR #36', 'PR #37') in comments or descriptions inside code or test files. PR references belong in docs and commit messages only." Verified by PR #48 review finding Rec #4 (14 PR# references stripped pre-merge). Use story IDs (FR-EX-07 / FR-AC-01) in code comments instead.
+39.    - `.github/shared/decision-log.md` — ADR-0002 (paise integers; N/A on the activity-feed write), ADR-0006 (Riverpod state management; N/A for PR #51 — no client work), ADR-0007 (feature-first folder layout; activity-feed Cloud Functions code lives at `functions/src/triggers/on-expense-write/` — extend in place), ADR-0013 (PII / telemetry hashing — every `expense_id`, `friendship_id`, AND `author_uid` parameter in PR #51 structured logging MUST be SHA-256 truncated via `hashId()` from `functions/src/utils/id-hash.ts`; the activity payload itself is NOT subject to ADR-0013 because it ships INSIDE Firestore where the user already has read access to their own document — but the structured-log lines on the trigger pathway ARE subject and have been load-bearing since PR #36).
+40.    - `docs/patterns/feature-pr-conventions.md` — Cloud Functions Testing Layers (functions/test/triggers/ for the trigger unit tests; functions/test/firestore-rules/ for the rules tests; functions/test/integration/ for the skipped emulator stub), Boundary-Contract Discipline (the friendship-context guard MUST stay in place — the trigger only fires for friendship expenses; group-context is Sprint 3), Telemetry-Event Discipline (the structured log event names for the activity-write path follow the Camp B verb-past + state pattern ratified in PR #38 chore #25 and consistently used since).
+41.    - `docs/OneByTwo_Requirements_Spec.md` — section 4.5 line 212 (FR-EX-07 = P0: "Each edit or delete shall be recorded in the activity feed with author and timestamp."), section 4.7 lines 236-240 (FR-AC-01 = P0 — the read-side story PR #52 implements; PR #51 trusts the future client to render what PR #51 writes; FR-AC-02 = P0 deep-link; FR-AC-03 = P0 FCM; FR-AC-04 = P1 prefs; FR-AC-05 = P0 cold-start deep-link), section 7.2 (data model — the `activity/{userId}/items/{itemId}` collection schema), section 7.3 (Invariants 1 + 2 — Inv-1 N/A on the activity payload because monetary fields are stored unchanged from the source expense; Inv-2 negative-guard load-bearing as always), section 7.5 (Security rules surface — PR #51 writes `firestore.rules` for the first time on the `activity/**` path tree; the canonical posture is `allow read: if request.auth.uid == userId && resource.data != null` + `allow create, update, delete: if false` — clients never write, only the Functions service account does), section 5.10 (telemetry funnel — extends with new structured-log events on the trigger pathway: `activity_item_written`, `activity_item_write_failed`, etc.; architect's call at §2.x on exact names).
+42.    - `docs/design/06-screen-specs/23-28-settle-activity-profile.md` — **SCR-25 Activity Feed** (lines 256-386), the authoritative spec for the FR-AC-01 read-side. PR #51 writes the data SCR-25 reads; the SCR's `Event Type Mapping` table at lines 301-313 is the authoritative source for the `type` discriminator values (`expenseAdded`, `expenseEdited`, `expenseDeleted`, etc.) AND the `payload` shape (each row needs the `primaryText`, the trailing amount, the icon, the colour). The architect at §2.x picks the canonical Camp-B variant of these names (snake_case for Firestore field values per the schema doc convention: `expense_added`, `expense_edited`, `expense_deleted` — the SCR camelCase is the UI-side display variant; verify with the schema doc at line 202 which already enumerates the snake_case names).
+43.    - `docs/design/07-technical/firestore-schema.md` lines 194-211 — `activity/{userId}/items/{itemId}` document schema (`type`, `payload`, `createdAt`); rules summary; index note (single-field auto-created; no composite needed).
+44.    - `docs/design/07-technical/firestore-schema.md` lines 202 — the canonical `type` enumeration: `'expense_added'`, `'expense_edited'`, `'expense_deleted'`, `'settlement'`, `'group_change'`. PR #51 emits THREE of these (`expense_added`, `expense_edited`, `expense_deleted`); the other two are FUTURE.
+45.    - `docs/design/07-technical/cloud-functions-catalogue.md` — section on `onExpenseWriteFriendship`. The trigger re-fires on every expense `create | update | delete`; PR #51 extends the handler with the activity-write path. **Architect's call at §2.x** on whether the activity-write runs INSIDE the same Firestore transaction as `recomputeAndWrite` (atomic) or as a SEPARATE write after the transaction commits (non-atomic but simpler). Recommend the SEPARATE-write approach (architect §2.2) — the activity write is per-member (`memberIds.length` separate documents, one per member's subcollection) and is conceptually orthogonal to the `simplifiedBalances` recompute; bundling them into one transaction would force the rollback-on-failure semantics onto activity-write failures that should be retried independently.
+46.    - `docs/design/03-architecture/extension-points-register.md` — ARCH-EXT-02 (currency INR — N/A on activity), ARCH-EXT-07 (`source: 'manual'` — N/A on activity). The activity schema introduces no new extension points; the `payload` map is intentionally schemaless to absorb future event types without migration (architect §2.x to ratify or constrain).
+47.    - `firestore.rules` — currently has no rule for `activity/**`. PR #51 adds:
+48.      ```
+49.      match /activity/{userId} {
+50.        // Default-deny on the parent document. Clients never read or
+51.        // write the parent doc; the subcollection is the only surface.
+52.        allow read, write: if false;
+53. 
+54.        match /items/{itemId} {
+55.          // Member-read-only: a user may only read their own activity
+56.          // items. Writes are exclusively by the Cloud Functions
+57.          // service account (mirrors the simplifiedBalances pattern
+58.          // ratified in PR #36).
+59.          allow read: if request.auth != null && request.auth.uid == userId;
+60.          allow create, update, delete: if false;
+61.        }
+62.      }
+63.      ```
+64.      The architect's call at §2.x is whether to include explicit shape validation on the create path (e.g. `request.resource.data.type in [...]`) given that the default-deny on `create` already prevents client writes. Recommend NO — the rules-test suite would force every future event type addition through a rules update; the schema is enforced by the trigger's TypeScript types and the firestore-schema.md contract.
+65.    - `firestore.indexes.json` — unchanged. PR #51 must NOT touch this file.
+66.    - `functions/src/triggers/on-expense-write/function.ts` — extend in place per architect §2.x. The activity-write fires AFTER the successful `recomputeAndWrite` call so a retryable transient recompute failure does NOT duplicate activity items (per the existing TODO comment placement note at line 164-168).
+67.    - **NEW** `functions/src/triggers/on-expense-write/activity-writer.ts` — extract the activity-emission logic to a sibling module so the trigger function stays focused and the activity-writer is independently testable. Architect's call at §2.x on whether to inline or extract; recommend **extract** because the same writer will be reused by the settlement-write trigger in PR #52.
+68.    - **NEW** `functions/test/triggers/on-expense-write/activity-writer.test.ts` — unit tests for the writer: payload shape per event type, both members' subcollections written, structured-log assertions, idempotency under retry (architect §2.x: the trigger uses the `eventId` for de-dup elsewhere; the activity-writer should follow the same pattern).
+69.    - `functions/test/firestore-rules/users.test.ts` — existing pattern for client-read-only collections (the `users/{userId}` rules). PR #51's new `functions/test/firestore-rules/activity.test.ts` mirrors the structure: minimum 6 tests covering authenticated owner read (succeeds), non-owner read (fails), unauthenticated read (fails), client create rejected (fails), client update rejected (fails), client delete rejected (fails). The architect's call at §2.x is whether to also include admin-context tests that write via `withSecurityRulesDisabled` to seed activity items for the read-tests — recommended pattern for symmetry with the existing rules tests.
+70.    - `lib/features/activity/**` — **DOES NOT EXIST YET.** PR #51 is server-only; the client read-side surface (Activity tab, route `/activity`, `OBTActivityRow`, etc.) is the FR-AC-01 story for PR #52. PR #51 must NOT create `lib/features/activity/`.
+71.    - `lib/features/expenses/**` — **UNCHANGED.** The expense feature folder is the architectural blueprint for PR #48, not PR #51. PR #51 must NOT touch the client expense surface.
+72.    - `docs/audits/sprint-1/07-bucket-b-burndown.md` lines 117-120 (R1-R6) — Firestore rules test gaps. PR #51 closes (or partially closes) **R5** (settlements / activity rules — settlements were covered by PR #36, activity gets covered now). Architect's call at §2.x — confirm the exact R-id closed; the Bucket-B audit table may need a column update.
+73.    - `scripts/dev/start-emulators.sh` — the canonical wrapper. The new rules tests run in the existing dedicated `firebase emulators:exec --only firestore,storage` session per `.github/workflows/pr.yml` lines 172-194 (PR #46 split). The new TRIGGER tests run in the existing full-emulator integration job per workflow lines 196-206. No workflow change needed.
+74.    - `.github/workflows/pr.yml` — `Run Firestore Security Rules tests (no functions loaded)` step (PR #46 split) + `Run Flutter + Cloud Functions integration tests with full emulators` step. The new `activity.test.ts` runs in the dedicated rules session; the trigger unit tests run inline under `npm test`; the trigger integration tests run inline under `npm run test:integration`. **No workflow change.**
+75.    - **CI hygiene** — `dart format .` MUST be run before push because CI runs Flutter 3.44.1 while local toolchains may be older. Run `dart format .` as the final pre-push gate after `flutter analyze --fatal-infos`. **Functions hygiene** — `npm run lint && npm run build && npm test` MUST be green; the eslint config rejects `any` and untyped exports, and the build emits the `lib/` directory the Functions runtime serves. Both gates have been load-bearing on every recent PR.
+76. 
+77. 6. Honour the four invariants. Invariant 1 (paise integers) is **N/A on the activity-write path** — the `payload.amountPaise` (or whatever the architect names the field at §2.x) is read straight from the source expense document without arithmetic; the integer invariant is preserved by construction. The boundary-contract grep at `test/features/expenses/expense_creation_boundary_contract_test.dart` does NOT cover `functions/src/**`; the equivalent Functions-side `no .toDouble() / /100 / double` grep lives at... wait, there is no Functions-side boundary-contract grep today. **Architect's call at §2.x** whether to add one for PR #51 (recommended YES — `functions/src/triggers/**` is now a non-trivial monetary surface; a parallel boundary-contract grep against `functions/src/**/*.ts` for `Number.parseFloat`, `.toFixed`, `/100`, `: number` declarations on monetary fields is cheap defence-in-depth and would have caught any future float-typed payload field; this also serves the FR-EX-04 invariant 1 doc). Invariant 2 (`simplifiedBalances` server-only) — load-bearing negative guard as always; the activity write happens AFTER the `recomputeAndWrite` success branch and is a SEPARATE Firestore write to a separate collection, so the existing `simplifiedBalances` invariant is unaffected. Invariant 3 N/A. Invariant 4: no second Firebase project — the activity writes target the single production project; rules-tests target the single emulator.
+78. 
+79. ────────────────────────────────────────
+80. PHASE 0 — DEPENDENCY-DAG CHECK
+81. ────────────────────────────────────────
+82. 
+83. 0.1  Confirm PR #48 has merged to main and the post-merge state is clean:
+84.      - `git log --oneline -1` on `main` shows `0c6f649 feat(expenses): FR-EX-05 receipt attachment (friendship) (#48)`.
+85.      - `lib/features/expenses/presentation/steps/step_3_receipt_and_confirm.dart` exists (PR #48 surface).
+86.      - `lib/core/services/image_picker_service.dart` exists (PR #48 extraction from auth feature).
+87.      - `lib/features/expenses/data/receipt_storage_service.dart` exists (PR #48 abstraction).
+88.      - `storage.rules` has the friendship + group receipts predicates (PR #48 closure of R7 + R8).
+89.      - `functions/src/triggers/on-expense-write/function.ts:160-169` still has the FR-AC-01 TODO comments — PR #48 did NOT touch them.
+90.      - `flutter analyze --fatal-infos` + `flutter test` exit 0 (911 pass / 30 skipped post-PR-#48).
+91.      - `cd functions && npm run lint && npm run build && npm test` exit 0 (9 suites / 100 tests pass).
+92.      - `cd functions && npm run test:rules` exit 0 (8 suites / 176 tests pass under the dedicated emulators:exec session).
+93.      - `dart format --set-exit-if-changed .` exits 0.
+94.      - `.firebaserc` contains exactly one project (Invariant 4 CI gate green).
+95.      - Issues #47 (rules-hardening), #49 (orphan-cleanup), #50 (trigger no-op optimisation) are OPEN and unchanged — PR #51 does NOT close any of them.
+96. 
+97. 0.2  Walk the dependency DAG for FR-EX-07 (friendship context only; expense trigger only; write-side only):
+98.      - **Firestore side (consumer of PR #51's writes):** the `activity/{userId}/items/{itemId}` collection is the canonical surface per `docs/design/07-technical/firestore-schema.md` lines 194-211. PR #51 is the first writer of this path tree. The single-field index on `createdAt` (descending) is auto-created by Firestore on first query (no `firestore.indexes.json` change). The new `firestore.rules` block enforces member-read + server-only-write.
+99.      - **Functions side:** `onExpenseWriteFriendship` at `functions/src/triggers/on-expense-write/function.ts` is the sole client-write-source for activity items in PR #51's scope. The trigger fires on every `create | update | delete` of `friendships/{fid}/expenses/{eid}`; the activity-write fires AFTER the successful `recomputeAndWrite` so a transient recompute failure does NOT duplicate activity items (per the architect §2.x placement note that mirrors the existing TODO comment at line 164-168). The settlement trigger (`functions/src/triggers/on-settlement-write/function.ts:231`) has the symmetric TODO but is OUT OF SCOPE for PR #51.
+100.     - **Client read side:** **NONE.** PR #51 is server-only. The SCR-25 read-side ships with PR #52 (FR-AC-01).
+101.     - **Telemetry / structured-logging side:** new event names on the trigger pathway. PII per ADR-0013 — every `expense_id`, `friendship_id`, AND `author_uid` parameter MUST be SHA-256 truncated via `hashId()` from `functions/src/utils/id-hash.ts`. The activity *payload* itself is NOT subject to ADR-0013 because the payload ships inside Firestore where the user has read access to their own activity items.
+102.     - **Boundary contracts:** the existing Functions-side boundary-contract grep does not exist today; architect's call at §2.x on whether to add one parallel to the Flutter-side `expense_creation_boundary_contract_test.dart`.
+103. 
+104. 0.3  Confirm DoR for the feature story:
+105.     - **No story file exists yet** for FR-EX-07 — `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` must be created by the PM in Phase 1.
+106.     - Story points: **5 SP** (justification: trigger extension + new activity-writer module + 6-test rules suite + 8-test trigger unit suite + 4-test functions integration extension + rules predicate + schema validation + structured logging + boundary-contract grep extension at architect's call). Escalate to 8 SP only if the architect calls for the settlement-trigger extension AND the group-trigger extension in the same PR (NOT recommended — those belong to PR #52 and the Sprint 3 groups epic respectively).
+107.     - The story must explicitly enumerate: (a) the GitHub issue this PR closes — **none** (FR-EX-07 is tracked as a P0 SRS row at line 212; no separate GitHub issue exists), (b) the four-invariant applicability assessment (Inv-1 N/A on the activity write; Inv-2 negative-guard load-bearing; Inv-4 defence-in-depth single-project), (c) the cross-cutting telemetry contract (structured-log event names + the ADR-0013 PII hashing of every UID parameter).
+108. 
+109. 0.4  Cross-reference the burndown:
+110.     - PR #51 closes (or partially closes) **R5** from the Sprint-1 Bucket-B burndown — Firestore rules test gap for settlements / activity. R5 is currently listed as "Sprint 3 groups PR" in the burndown table; PR #51 closes the activity half but the settlements / groups halves remain Sprint 3. Architect's call at §2.x on whether to file an R5a / R5b split or close R5 fully (recommended: file the split because the settlements coverage was already added by PR #36 and the activity coverage is added by PR #51 — both halves now done; the groups half ships with the Sprint 3 epic).
+111.     - PR #51 also makes partial progress on **PY3** (Expand integration tests for Sprint 2 flows) — add a skipped functions-integration extension exercising the activity-write round-trip under emulators (the existing `functions/test/integration/on-expense-write.integration.test.ts` covers the simplifiedBalances recompute; the extension covers the activity items). Partial credit only.
+112.     - The orchestrator notes that issues #47, #49, #50 remain OPEN and are NOT touched by PR #51.
+113. 
+114. ────────────────────────────────────────
+115. PHASE 1 — STORY READINESS (PM)
+116. ────────────────────────────────────────
+117. 
+118. PM agent creates the feature story `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` using the SRS §13.2 feature format. Story points: **5** (per §0.3).
+119. 
+120. Required Given/When/Then ACs (each MUST be testable):
+121. 
+122.   **Trigger emission (positive ACs)**
+123. 
+124.   - **AC-1 — Create writes an `expense_added` activity item to BOTH members.** Given a friendship `friendships/{fid}` with `memberIds: [uidA, uidB]` and the `onExpenseWriteFriendship` trigger live, when a new expense is created at `friendships/{fid}/expenses/{eid}` (via the client repository in production, or via admin SDK in the trigger unit test), then TWO activity items are written — one at `activity/{uidA}/items/{auto-id}` and one at `activity/{uidB}/items/{auto-id}` — each with `type: 'expense_added'`, `payload: { expenseId, friendshipId, description, amountPaise, payerId, splits, category, createdBy }` (architect ratifies the exact shape at §2.x), and `createdAt: <server timestamp>`. Both writes happen AFTER the `recomputeAndWrite` success branch.
+125.   - **AC-2 — Edit writes an `expense_edited` activity item to BOTH members.** Given an existing non-deleted expense, when the expense is updated (any field — amount, description, category, date, payer, splits, splitMethod, OR receiptUrl), then TWO `expense_edited` activity items are written with payload including the `changedFields` array and the new field values. The receipt-only update (PR #48 path) DOES fire an `expense_edited` activity item — the SCR-25 spec at lines 305-307 explicitly enumerates `expenseEdited` for "any field change" and a receipt attach is a legitimate edit from the user's perspective.
+126.   - **AC-3 — Soft-delete writes an `expense_deleted` activity item to BOTH members.** Given an existing non-deleted expense, when the expense is soft-deleted (`deleted: false → true` per FR-EX-06), then TWO `expense_deleted` activity items are written with payload including the `deletedAt` timestamp and the snapshot of `{ description, amountPaise, category }` at delete time (the original expense doc remains; the activity payload captures the snapshot so the SCR-25 row can render the description even if the expense is later hard-deleted in some future cleanup).
+127.   - **AC-4 — Author UID is captured in the payload.** Given any of the three trigger events (create, edit, delete), when the activity item is written, then `payload.authorUid` equals the `createdBy` of the source expense (for create + edit) or the UID making the write (for delete — same as `createdBy` since soft-delete is rules-gated to the creator).
+128.   - **AC-5 — Activity write happens AFTER the recomputeAndWrite success branch.** Given a transient `recomputeAndWrite` failure (network error, transaction abort, etc.), when the trigger handler runs, then NO activity items are written for the failed branch — the retry on the next trigger invocation handles both the recompute AND the activity-write atomically. Architect §2.x: this is the canonical placement per the existing TODO comment block at `function.ts:164-168`.
+129. 
+130.   **Rules ACs (negative-guard load-bearing)**
+131. 
+132.   - **AC-6 — Authenticated owner can read their own activity items.** Rules test at `functions/test/firestore-rules/activity.test.ts`. Member of friendship A↔B authenticated as `uidA` reads `activity/{uidA}/items/{seeded-item-id}` → succeeds.
+133.   - **AC-7 — Non-owner cannot read another user's activity items.** Same as AC-6 but the caller is `uidB` reading `activity/{uidA}/items/...` → `permission-denied`.
+134.   - **AC-8 — Unauthenticated read rejected.** Anonymous client → `permission-denied`.
+135.   - **AC-9 — Client cannot create an activity item.** Authenticated `uidA` attempts to create `activity/{uidA}/items/{client-id}` → `permission-denied` (only the Functions service account may write).
+136.   - **AC-10 — Client cannot update an activity item.** Same as AC-9 but `update()`.
+137.   - **AC-11 — Client cannot delete an activity item.** Same as AC-9 but `delete()`.
+138.   - **AC-12 — Reading the parent `activity/{userId}` document is rejected.** The parent doc has no semantic content; only the subcollection is the read surface. Defence-in-depth.
+139. 
+140.   **Idempotency and retry (positive ACs)**
+141. 
+142.   - **AC-13 — Duplicate trigger invocations do NOT duplicate activity items.** Given the trigger has already written activity items for `expense_added` of `eid-1`, when the trigger fires a SECOND time for the same `eid-1` (e.g. due to function retry or stale-event drop), then NO additional activity items are written. The mechanism is the architect's call at §2.x — either (a) deterministic activity-item IDs (e.g. `{eid}-{type}-{uid}` so a second write overwrites the same doc — but the schema doc says `itemId` is auto-generated, so this would break the contract), OR (b) idempotency via the `eventId` check (the existing `recomputeAndWrite` already drops stale events at `function.ts:140-157`; the activity-write rides on the same drop), OR (c) a Firestore transaction that reads the parent activity doc first and checks for a marker field. Recommend (b) — the activity-write is INSIDE the same handler that already drops stale events, so the activity-write is naturally guarded by the same check.
+143. 
+144.   **Cross-cutting and negative ACs**
+145. 
+146.   - **AC-14 — Telemetry / structured-log PII guard.** Given any of the new structured-log events fires with a UID-derived parameter, then the parameter value is the SHA-256-truncated hash via `hashId()` (NOT the raw UID, NOT the raw expense ID, NOT the raw friendship ID composite). The trigger unit-test suite asserts this for `activity_item_written`, `activity_item_write_failed`, and any other new event names the architect ratifies at §2.x.
+147.   - **AC-15 — Invariant 2 negative guard.** Given the PR diff, when scanned, then ZERO new writes to `simplifiedBalances` exist anywhere outside the existing `recomputeAndWrite` path; the activity-writer writes ONLY to `activity/{userId}/items/{auto-id}`.
+148.   - **AC-16 — Invariant 1 boundary contract.** Given the PR diff, when scanned for `.toDouble()`, `parseFloat`, `/ 100`, or floating-point arithmetic on any monetary field, then ZERO violations exist on the activity-payload path. The architect at §2.x decides whether to add a Functions-side boundary-contract grep at `functions/test/boundary-contracts/` (recommended YES — parallel to the Flutter-side grep at `test/features/expenses/expense_creation_boundary_contract_test.dart`).
+149.   - **AC-17 — Integration test stub.** Given the PR diff, when `functions/test/integration/` is inspected, then the existing `on-expense-write.integration.test.ts` is EXTENDED with three new (skipped or live, architect's call) tests covering the activity-write round-trip: (i) create-then-read for both members; (ii) edit-then-read for both members; (iii) soft-delete-then-read for both members. Partial PY3 credit.
+150.   - **AC-18 — `schema-validators.ts` extension.** The `functions/src/schema-validators.ts` (or equivalent module) is extended with a `validateActivityItem(payload)` helper that the activity-writer calls before the Firestore write. The validator asserts the `type` is in the enumeration, `payload` is a plain object, `createdAt` is a server timestamp, and the per-type required fields are present. Architect's call at §2.x on whether to introduce this OR rely on TypeScript types only (recommended YES — the validator catches programmer errors at runtime that the TypeScript compiler cannot, e.g. a hand-constructed payload missing `payerId`; the cost is a small switch statement and a 4-test suite).
+151. 
+152. ────────────────────────────────────────
+153. PHASE 2 — ARCHITECT HAND-OFF
+154. ────────────────────────────────────────
+155. 
+156. Architect agent appends `## Architect Notes` to the feature story ratifying:
+157. 
+158. 2.1  **Trigger placement.** RATIFY: the activity-write runs AFTER the successful `recomputeAndWrite` branch at `function.ts:222` (per the existing TODO comment block at lines 164-168). On `recomputeAndWrite` failure → NO activity-write fires; the retry handles both. The activity-write itself runs as a SEPARATE Firestore write (not inside the recompute transaction) so a transient activity-write failure does NOT roll back the recompute.
+159. 
+160. 2.2  **Activity-writer module extraction.** RATIFY **extract to `functions/src/triggers/on-expense-write/activity-writer.ts`**. The trigger handler imports and calls; the writer is independently testable; the symmetric extraction in PR #52's settlement-trigger extension can reuse the same module (with a sibling settlement-payload builder).
+161. 
+162. 2.3  **`ActivityItem` API surface.** New file `functions/src/triggers/on-expense-write/activity-writer.ts`:
+163.      - Typed `ActivityItemType` enum (`'expense_added' | 'expense_edited' | 'expense_deleted'` in PR #51; the broader enumeration ships with PR #52 + Sprint 3).
+164.      - `interface ActivityPayload` with the per-type discriminated-union shape (architect §2.x ratifies the exact fields per the SCR-25 row-rendering contract — expense description, amountPaise, payerId, splits, category, changedFields for edit, deletedAt for delete).
+165.      - `async writeExpenseActivity({ db, friendshipId, expenseId, type, payload, memberIds })` — writes to both `activity/{memberIds[i]}/items/{auto-id}` in parallel via `Promise.all`. Logs structured `activity_item_written` per write with `friendship_id_hash`, `expense_id_hash`, `author_uid_hash`, `event_type`, `member_index`.
+166.      - On per-write failure: log `activity_item_write_failed` with the typed error code; do NOT rethrow (a member-write failure should not block the other member's write OR the trigger's success branch). The orphan-activity case (one member's item written, the other failed) is acceptable v1.0 — the SCR-25 feed for the failed member will be missing this entry but the simplified-balances recompute is independent and unaffected.
+167. 
+168. 2.4  **`activity_item_written` structured-log event names.** Three new event constants in `functions/src/triggers/on-expense-write/activity-writer.ts`:
+169.      - `activity_item_written` — emitted per successful per-member write. Payload: `friendship_id_hash`, `expense_id_hash`, `author_uid_hash`, `recipient_uid_hash`, `event_type`, `payload_size_bytes` (defence-in-depth log of the document size; an unexpectedly large payload would indicate a programmer error or a malformed source document).
+170.      - `activity_item_write_failed` — emitted per failed per-member write. Payload: same as above PLUS `error_code` (e.g. `'permission-denied'`, `'unavailable'`, `'unknown'`).
+171.      - `activity_emission_completed` — emitted ONCE per trigger invocation summarising the per-member write outcomes. Payload: `friendship_id_hash`, `expense_id_hash`, `event_type`, `members_succeeded`, `members_failed`. Useful for the dashboards to compute the activity-emission success rate without re-aggregating the per-write events.
+172. 
+173. 2.5  **Idempotency strategy.** RATIFY **(b) stale-event drop** — the activity-write is gated by the same `recomputeAndWrite` success branch that already drops stale events at `function.ts:140-157`. The activity-writer does NOT need its own deterministic ID scheme; the auto-generated `itemId` is the canonical contract per schema doc line 196. The idempotency guarantee is: "if the trigger fires for an event the handler has already processed, the activity-write does not fire either." This is a weaker guarantee than full deduplication (e.g. a redeploy that re-fires for events older than the trigger's stale-event window would duplicate), but is consistent with the rest of the trigger's posture.
+174. 
+175. 2.6  **Payload schema per event type.** Architect ratifies:
+176.      - `expense_added` payload: `{ expenseId: string, friendshipId: string, description: string, amountPaise: number, category: string, payerId: string, splits: Array<{ userId, sharePaise }>, splitMethod: string, hasReceipt: boolean, authorUid: string, createdAt: Timestamp }`. NOTE: `simplifiedBalances` is NOT in the payload — the SCR-25 row reads `share` for the recipient from `splits[recipient]` and displays the rupee value; the simplified balance is the FriendDetail screen's job.
+177.      - `expense_edited` payload: same as `expense_added` PLUS `changedFields: string[]` (the array of field names that changed since the previous version, computed from `(change.before, change.after)`). The `changedFields` array is the same one PR #46 computes on the client (`AddExpenseController._changedFields`); the trigger-side computation is symmetric.
+178.      - `expense_deleted` payload: `{ expenseId: string, friendshipId: string, description: string, amountPaise: number, authorUid: string, deletedAt: Timestamp }`. The snapshot is captured from `change.before.data()` so the SCR-25 row can render the description even if the expense doc is hard-deleted in some future cleanup.
+179. 
+180. 2.7  **Files to touch (exhaustive — anything outside this set is scope creep):**
+181.      - `firestore.rules` — add the `activity/{userId}/items/{itemId}` predicate block.
+182.      - `functions/src/triggers/on-expense-write/function.ts` — extend with the `await writeExpenseActivity(...)` call inside the success branch.
+183.      - `functions/src/triggers/on-expense-write/activity-writer.ts` — **NEW** (`ActivityItemType`, `ActivityPayload`, `writeExpenseActivity`, structured-log event constants).
+184.      - `functions/src/triggers/on-expense-write/payload-builder.ts` — **NEW (or extend an existing module per architect's call)** — pure function that maps `(changeType, change.before, change.after)` to the `ActivityPayload`. Extracted so the unit tests can exercise the mapping without spinning up Firestore.
+185.      - `functions/src/schema-validators.ts` — extend with `validateActivityPayload(type, payload)` per AC-18.
+186.      - `functions/test/firestore-rules/activity.test.ts` — **NEW** (12+ tests for AC-6 through AC-12 plus the read-with-seeded-item happy path).
+187.      - `functions/test/triggers/on-expense-write/activity-writer.test.ts` — **NEW** (8+ tests for AC-1 through AC-5 and AC-13 plus per-event-type payload shape verification).
+188.      - `functions/test/triggers/on-expense-write/payload-builder.test.ts` — **NEW** (per-event-type mapping verification; pure function; no Firebase admin needed).
+189.      - `functions/test/triggers/on-expense-write/function.test.ts` — EXTEND (already exists from PR #36) with assertions that the activity-writer is called from the trigger and NOT called on the stale-event-drop branch.
+190.      - `functions/test/integration/on-expense-write.integration.test.ts` — EXTEND (already exists) with three new round-trip tests per AC-17 (create → both members read; edit → both members read; delete → both members read).
+191.      - `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` — **NEW** at architect's call (per §2.x; recommended). Parallel to the Flutter-side `expense_creation_boundary_contract_test.dart`. Greps `functions/src/**/*.ts` for `.toDouble()`, `parseFloat`, `/100`, `/100.0`, `: number` declarations on `amountPaise` / `sharePaise` fields. Returns 0 violations.
+192.      - `firestore.indexes.json` — N/A.
+193.      - `lib/**` — N/A (server-only PR; client read-side ships with PR #52).
+194.      - `storage.rules` — N/A.
+195.      - `pubspec.yaml` / `functions/package.json` — N/A (no new deps).
+196.      - `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` — **NEW** story (Phase 1).
+197.      - `docs/sprint-zero/sprint-2-plan.md` — add PR #51 row (5 SP; cumulative 55 SP / 15 PRs).
+198.      - `docs/sprint-zero/next-three-prs.md` — roll PR #51 to merged; PR #52 / #53 / #54 candidates (top: FR-AC-01 client SCR-25 + settlement-trigger activity-emission extension).
+199.      - `docs/audits/sprint-1/07-bucket-b-burndown.md` — close R5a (activity-rules half); remaining drops by 1.
+200. 
+201. 2.8  **Files explicitly NOT to touch (negative scope guardrails):**
+202.      - `firestore.indexes.json` (no new composite indexes; single-field on `createdAt` auto-creates).
+203.      - `functions/src/triggers/on-settlement-write/function.ts` (settlement-trigger activity emission is PR #52 scope, paired with FR-AC-01 client; if PR #51 touches this file the orchestrator refuses).
+204.      - `lib/**` (server-only PR; client SCR-25 surface ships with PR #52).
+205.      - `storage.rules` (PR #48 closed; PR #51 has no Storage surface).
+206.      - `pubspec.yaml` / `pubspec.lock` / `analysis_options.yaml` / Android / iOS native shells.
+207.      - `functions/package.json` / `functions/package-lock.json` / `firebase.json` / any `.github/workflows/*.yml`.
+208.      - `lib/features/settlements/**`, `lib/features/friends/**`, `lib/features/expenses/**`.
+209.      - The notification-type schema discriminator in `firestore-schema.md:202` is the canonical contract PR #51 IMPLEMENTS (write-side); the doc itself does NOT need editing because PR #51 conforms to it verbatim.
+210. 
+211. 2.9  **Anticipated reconciliations.** Document EXACTLY:
+212.      1. **Firestore.rules path syntax** — the `match /activity/{userId}/items/{itemId}` nested path requires the parent `match /activity/{userId}` block to ALSO have a default-deny on read/write (else the parent doc reads are unguarded). Verify against the emulator with a parent-doc read test (AC-12).
+213.      2. **Trigger handler error containment** — the `await writeExpenseActivity(...)` call MUST NOT rethrow the activity-write failure into the trigger's success branch (else a transient activity-write failure would mark the entire trigger invocation as failed and Cloud Functions would retry, which would re-run the recompute AND re-attempt the activity-write — duplicate-fire risk). The activity-writer wraps its own try/catch and logs the failure structured-log event; the trigger sees a clean return value either way.
+214.      3. **Orphan activity items** — a member-write failure where the other member's write succeeded leaves an asymmetric activity feed. v1.0 acceptable per architect §2.3; PR-#51-FUTURE work would file a reconciliation function similar to the orphan-receipts cleanup (issue #49 precedent). Architect's call at §2.x on whether to file as an issue NOW or wait for the first incident.
+215.      4. **Receipt-only update fires `expense_edited`** — per AC-2 and the SCR-25 spec, a receipt attach / replace / remove is recorded as an `expense_edited` activity item. The `changedFields` payload value is `['receiptUrl']` in that case. This is consistent with the PR #48 design — the trigger fires on every update regardless of which field changed, and the activity feed reflects the user-visible change.
+216.      5. **Idempotency caveat under redeploy / cold start** — per architect §2.5, the activity-write is gated by the existing stale-event drop. If the trigger is re-fired for an event OLDER than the stale-event window (e.g. a function redeploy + a Cloud Functions retry storm), the activity-writer WILL re-fire and duplicate items. This is consistent with the rest of the trigger's posture; full deduplication is FUTURE work (out of v1.0 scope; file as an issue if observed).
+217.      6. **PII in the activity payload** — the payload contains UIDs (`authorUid`, `payerId`, `splits[].userId`). These are NOT subject to ADR-0013 because the payload ships INSIDE Firestore where the user has read access to their own activity items. The structured-log lines are ADR-0013-subject and use `hashId()` per architect §2.4.
+218. 
+219. ────────────────────────────────────────
+220. PHASE 3 — SCOPE GUARDRAILS
+221. ────────────────────────────────────────
+222. 
+223. WHAT GOES IN PR #51:
+224. 
+225.   - All files listed in §2.7.
+226.   - Activity-writer module + payload-builder + schema-validator extension.
+227.   - Trigger handler extension with the activity-write call.
+228.   - `firestore.rules` block for `activity/{userId}/items/{itemId}` + parent default-deny.
+229.   - Rules tests covering AC-6 through AC-12.
+230.   - Trigger unit tests covering AC-1 through AC-5 and AC-13.
+231.   - Payload-builder unit tests covering per-event-type mapping.
+232.   - Functions-integration extension covering the round-trip per AC-17.
+233.   - The feature story + Architect Notes.
+234.   - Plan + burndown roll-ups (Phase 7).
+235. 
+236. WHAT DOES NOT GO IN PR #51:
+237. 
+238.   - **Client read-side SCR-25** — separate FR-AC-01 story; PR #52 scope.
+239.   - **Settlement-trigger activity emission** — paired with FR-AC-01 client; PR #52 scope (the on-settlement-write trigger has the symmetric TODO; the activity-writer module ships in PR #51 so PR #52 can call it with a sibling payload builder).
+240.   - **Group-context expense activity emission** — Sprint 3 groups epic (FR-EX-02 + the `onExpenseWriteGroup` trigger).
+241.   - **FR-AC-03 FCM push notifications** — separate P0 story; introduces the FCM dependency + the `notificationPrefs` schema; not bundled.
+242.   - **FR-AC-04 notification preferences** — paired with FR-AC-03.
+243.   - **FR-AC-05 cold-start deep-link** — paired with FR-AC-01 (client deep-link routing).
+244.   - **FR-EX-07 audit-history rebuild from log** — SRS section 7.5 note. FUTURE work; out of v1.0 scope.
+245.   - **Activity-item pagination / cursor-based read** — paired with FR-AC-01 (SCR-25 Open Question 2).
+246.   - **Read/unread markers** — FR-AC-01 Open Question 1; v1.1 candidate per the SCR.
+247.   - **Activity-item filter / search** — FR-AC-01 Open Question 3; deferred per the SCR.
+248.   - **Issue #47 rules-hardening** — separate small chore PR.
+249.   - **Issue #49 orphan-receipts cleanup function** — FUTURE.
+250.   - **Issue #50 trigger no-op-recompute optimisation** — FUTURE.
+251.   - **Concurrent-edit detection for FR-EX-06** — still deferred per PR #46 §2.4.
+252.   - **Rate-limit transaction race refactor** — PR #45 §2.2 deferred.
+253. 
+254. If an agent suggests any of: "while we're in the trigger, let's also implement the settlement-trigger half", "let's stand up the SCR-25 client surface while we're here", "let's wire FCM at the same time", "let's add the unread-marker schema field defensively", "let's implement the cursor-based pagination now" — REFUSE. These are scope creep.
+255. 
+256. ────────────────────────────────────────
+257. PHASE 4 — TEST-FIRST DISCIPLINE
+258. ────────────────────────────────────────
+259. 
+260. PR #51 follows the standard test-first cadence:
+261. 
+262. 1. Snapshot the pre-fix baseline: 911 Flutter / 30 skipped; 100 functions / 9 suites; 176 rules / 8 suites.
+263. 2. Write the failing rules tests first: `functions/test/firestore-rules/activity.test.ts` — 12+ tests covering AC-6 through AC-12 plus the read-with-seeded-item happy path. They will FAIL until `firestore.rules` adds the predicate block.
+264. 3. Write the failing trigger unit tests next: `activity-writer.test.ts` exercises AC-1 through AC-5 + AC-13; `payload-builder.test.ts` exercises per-event-type mapping; `function.test.ts` extends with assertions that the activity-writer is called from the trigger.
+265. 4. Implement the source per §2.7: payload-builder first (pure function; fastest to flip green), then activity-writer (depends on payload-builder + the Firestore admin SDK), then the trigger handler extension (depends on activity-writer), then the rules predicate block (independent — flips the rules tests green in isolation).
+266. 5. Re-run the rules tests — must reach 188+ pass (176 + 12+ new).
+267. 6. Re-run the trigger unit tests — must reach 108+ pass (100 + 8+ new).
+268. 7. Re-run the functions integration tests — 3 new round-trip assertions; if `--skip` is elected they run as skipped stubs; if live they add to the integration-suite count.
+269. 8. Re-run `dart format --set-exit-if-changed .` — 0 changes (PR #51 has no Dart diff).
+270. 9. Re-run `flutter analyze --fatal-infos` — "No issues found" (PR #51 has no Dart diff).
+271. 10. Re-run `flutter test` — expected 911 / 30 (unchanged; PR #51 has no Dart diff).
+272. 11. Re-run `cd functions && npm run lint && npm run build && npm test` — 9 suites + 1 new = 10 suites; 100 + 8+ new = 108+ tests pass.
+273. 12. Re-run `cd functions && npm run test:rules` — 8 suites + 1 new = 9 suites; 176 + 12+ new = 188+ tests pass.
+274. 
+275. **Combined CI dry-run:** all jobs must be green.
+276. 
+277. ────────────────────────────────────────
+278. PHASE 5 — EXECUTION PROTOCOL
+279. ────────────────────────────────────────
+280. 
+281. Mirror the PR #48 commit cadence:
+282. 
+283.  1. PM creates story `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md`. Commits as `docs(stories): FR-EX-07 activity-feed write-side story`.
+284.  2. Architect appends `## Architect Notes` (§2.1–§2.9). Commits as `docs(stories): FR-EX-07 architect notes`.
+285.  3. QA writes the 12+ new rules tests (failing first). Commits as `test(rules): FR-EX-07 activity-items rules tests`.
+286.  4. Functions-dev adds the rules predicate block. Commits as `feat(rules): activity-items collection access predicates`.
+287.  5. Functions-dev adds the payload-builder + unit tests. Commits as `feat(functions): activity-item payload builder for friendship expenses`.
+288.  6. Functions-dev adds the activity-writer + unit tests + schema-validator extension. Commits as `feat(functions): activity-writer for friendship expense trigger`.
+289.  7. Functions-dev extends the trigger handler with the activity-write call + extends the existing trigger function.test.ts. Commits as `feat(functions): emit activity items on friendship expense writes (FR-EX-07)`.
+290.  8. Functions-dev extends the integration test (skipped or live per architect §2.x). Commits as `test(integration): FR-EX-07 activity-write round-trip`.
+291.  9. Functions-dev adds the boundary-contract grep at architect's call. Commits as `test(functions): boundary-contract grep against monetary float drift`.
+292. 10. QA runs the manual smoke matrix (emulators):
+293.     - Start emulators; admin-seed a friendship A↔B; create an expense as user A; verify two activity items appear (`activity/{uidA}/items/...` and `activity/{uidB}/items/...`) with the correct payload.
+294.     - Edit the expense as user A; verify two `expense_edited` items appear with `changedFields`.
+295.     - Soft-delete as user A; verify two `expense_deleted` items appear with `deletedAt`.
+296.     - Sign in as a third (outsider) user; attempt to read `activity/{uidA}/items/...`; verify `permission-denied` (rules enforcement).
+297.     - Attempt a client-side write to `activity/{uidA}/items/{client-id}`; verify `permission-denied`.
+298. 11. Docs hand updates plan + roll-forward:
+299.     - `docs/sprint-zero/sprint-2-plan.md` (PR #51 row; 5 SP; cumulative 55 SP / 15 PRs).
+300.     - `docs/sprint-zero/next-three-prs.md` (PR #52 / #53 / #54 candidates — top is FR-AC-01 client SCR-25 + settlement-trigger activity emission).
+301.     - `docs/audits/sprint-1/07-bucket-b-burndown.md` (close R5a — activity rules half; remaining drops by 1).
+302.     - Commits as `docs(plan): PR #51 shipped, prep PR #52`.
+303. 12. PR opened. Title: `feat(functions): FR-EX-07 activity feed emission (friendship)`. Body must:
+304.     - Cite SCR-25 + the schema doc lines 194-211 contract.
+305.     - Confirm Invariants 1 / 2 / 4 (Inv-3 N/A).
+306.     - Confirm AC-X4 (notification-type schema discriminator UNCHANGED — PR #51 IMPLEMENTS the contract, does not change it).
+307.     - State explicitly the deferred items: settlement-trigger emission, group-trigger emission, FCM push, read-side SCR-25, pagination, unread markers, filter / search.
+308.     - State explicitly that R5a is CLOSED.
+309.     - End with `Next PR: PR #52 — TBD per architect's call at kickoff (top candidate: FR-AC-01 client SCR-25 + settlement-trigger activity emission).`
+310. 
+311. ────────────────────────────────────────
+312. PHASE 6 — DEFINITION OF DONE GATE
+313. ────────────────────────────────────────
+314. 
+315. Walk the DoD checklist. Particular emphasis:
+316. 
+317.   - DoD §2: every layer green (Flutter unchanged / Functions / Rules / format / analyze).
+318.   - DoD §3: QA sign-off with evidence for cross-user real-time activity-item write (member can read; non-member cannot; client cannot write).
+319.   - DoD §7: invariant compliance.
+320.     * Inv-1: N/A on the activity-write path; boundary-contract grep (if architect-elected per §2.x) auto-covers new Functions files.
+321.     * Inv-2: ZERO new writes to `simplifiedBalances`; the existing `recomputeAndWrite` is unchanged.
+322.     * Inv-3: N/A.
+323.     * Inv-4: `.firebaserc` unchanged; single project targeted in both production and emulator.
+324.   - DoD §8: documentation updated (story + architect notes + sprint-2-plan + next-three-prs + burndown).
+325.   - DoD §9: deploy verification. The new Firestore rules deploy via `firebase deploy --only firestore:rules` on tag. The new Cloud Function code deploys via `firebase deploy --only functions:onExpenseWriteFriendship` on tag (the trigger is already live; the deploy is an in-place update). QA verifies the activity-item write happens end-to-end in production post-deploy on the canary device.
+326. 
+327. QA posts the explicit DoD §3 sign-off, including the negative-scope greps from AC-15 (no new `simplifiedBalances` writes) and AC-16 (no `double` / `parseFloat` on monetary fields).
+328. 
+329. **Pre-push CI hygiene:** run `dart format .` AND all test layers BEFORE `git push`.
+330. 
+331. ────────────────────────────────────────
+332. PHASE 7 — UPDATE THE ROLLING PLAN AND BURNDOWN
+333. ────────────────────────────────────────
+334. 
+335. PM agent updates:
+336.   - `docs/sprint-zero/sprint-2-plan.md` — PR #51 status (merged), velocity #15 (5 SP, total now 55 SP across 15 PRs).
+337.   - `docs/sprint-zero/next-three-prs.md`:
+338.       * PR #51 row marked merged; numbering note updated.
+339.       * PR #52: **TBD** per architect's call at kickoff. Top candidates (in rough priority order):
+340.           - **FR-AC-01 — Activity tab (SCR-25) + settlement-trigger activity-emission extension** (P0; reads what PR #51 wrote; pair with the settlement-trigger extension because both halves are needed for the settlement leg of SCR-25 to render anything). 8-10 SP — may split into two sub-PRs (client vs server) at architect's call.
+340a.          - **FR-SE-09 — Send Reminder** (P1; FCM dependency + 24-hour rate-limit subcollection). Now the highest unplaced P1.
+341.           - **FR-SE-08 dedicated `/settlements/history`** screen (P0; PR #42's in-timeline rows satisfy v1.0 but a dedicated screen remains).
+342.           - **Issue #47 — Firestore rules-hardening for non-creator update/delete** (chore; 2 SP; defence-in-depth; small standalone PR).
+343.           - **FR-AC-03 — FCM push notifications** (P0; FCM dependency; requires FR-AC-01 read-side as prerequisite for the deep-link surface).
+344.           - **Issue #49 — Orphan-cleanup Cloud Function for receipts** (chore; FUTURE).
+345.           - **Issue #50 — Trigger no-op-recompute optimisation** (chore; FUTURE).
+346.           - **Concurrent-edit detection for FR-EX-06** (chore; operational hardening).
+347.           - **Rate-limit transaction race refactor** (PR #45 §2.2 deferred).
+348.       * PR #53: TBD per PR #52 outcome.
+349.       * PR #54: TBD per PR #53 outcome.
+350.   - `docs/audits/sprint-1/07-bucket-b-burndown.md`:
+351.       * Header timestamp: PR #48 → PR #51.
+352.       * Append a PR #51 section: closes **R5a** (Firestore rules tests for activity collection). Remaining drops by 1. The R5 row in the candidates table is split into R5a (activity, closed by PR #51) and R5b (groups, Sprint 3).
+353. 
+354. Commits as `docs(plan): PR #51 shipped, prep PR #52`.
+355. 
+356. ────────────────────────────────────────
+357. GUARDRAILS
+358. ────────────────────────────────────────
+359. 
+360. If during this PR an agent proposes:
+361.   - "While we're in the trigger, let's also implement the settlement-trigger half" → REFUSE. Settlement-trigger activity emission belongs to PR #52 (paired with FR-AC-01 client because both halves are needed for SCR-25's settlement leg to render).
+362.   - "Let's stand up the SCR-25 client surface while we're here" → REFUSE. Separate FR-AC-01 P0 story; the read-side schema PR #51 ships is the contract PR #52 reads.
+363.   - "Let's wire FCM at the same time" → REFUSE. FR-AC-03 introduces the FCM dependency + the `notificationPrefs` schema; separate P0 story.
+364.   - "Let's add the read/unread marker schema field defensively" → REFUSE. FR-AC-01 Open Question 1; v1.1 candidate.
+365.   - "Let's implement cursor-based pagination now" → REFUSE. FR-AC-01 Open Question 2; client read-side concern.
+366.   - "Let's close issue #47 (rules-hardening) at the same time" → REFUSE. Separate small chore PR.
+367.   - "Let's close issue #49 (orphan-cleanup) at the same time" → REFUSE. FUTURE.
+368.   - "Let's close issue #50 (trigger no-op-recompute optimisation)" → **EXPLICITLY REFUSE** — the FR-EX-07 architect §2.x ratifies that receipt-only updates DO fire an `expense_edited` activity item per SCR-25 line 305-307; issue #50's optimisation would prevent that by skipping the trigger entirely on receipt-only updates. PR #51 must NOT close issue #50 because the optimisation would BREAK FR-EX-07. File a follow-up to update issue #50 with this constraint.
+369.   - "Let's wire the group-trigger activity emission" → REFUSE. Sprint 3 groups epic.
+370. 
+371. If something genuinely surprises (e.g. the `firestore.get()` from `storage.rules` semantics don't translate directly to nested-collection `match` blocks in `firestore.rules`, or the trigger's existing stale-event drop window is shorter than the architect assumed for AC-13, or the Functions admin SDK's `Promise.all` with a per-write failure leaks the rejection into the trigger's success branch), STOP and surface the friction. PR #51 is a P0 server-side write that lands on every production friendship expense — get the rules + the trigger contract right before shipping.
+372. 
+373. Begin with Phase 0 — verify the dependency DAG (PR #48 merge state at `0c6f649`; baseline test counts; emulators reachable for the new rules + integration tests) and re-read the three reference docs (SCR-25 in `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386, the `firestore-schema.md` activity layout at lines 194-211, and the existing `functions/src/triggers/on-expense-write/function.ts:160-169` for the TODO comment block that documents the architect's placement note) before kickoff.
+374. 

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -1,126 +1,121 @@
 # Next Three PRs
 
 > Rolling roadmap. Updated at the end of every PR.
-> Last updated: PR #48 merged (FR-EX-05 — receipt attachment, friendship context).
+> Last updated: PR #51 merged (FR-EX-07 — activity feed write-side, friendship expenses).
 
 ---
 
-## GitHub issue / PR numbering note (post-PR #48)
+## GitHub issue / PR numbering note (post-PR #51)
 
 The numbering jumped because issues and PRs share the same sequential
-namespace on GitHub. The post-PR #38 sequence so far:
+namespace on GitHub. The post-PR #48 sequence so far:
 
 | Number | Type | What |
 |---|---|---|
-| #38 | PR | FR-EX-01 expense creation UI + chore #25 (merged 2026-06-06) |
-| #39 | Issue | Cloud Functions Node 20 decommissioned 2026-10-31 (**CLOSED by PR #44**) |
-| #40 | Issue | `firebase-functions` 6.x → 7.x (**CLOSED by PR #44**) |
-| #41 | PR | docs(plan) — D5 deadline backlog cross-refs (merged 2026-06-06) |
-| #42 | PR | FR-FR-04 friend detail full screen (merged 2026-06-06) |
-| #43 | PR | FR-SE-05/06/07 settle up flow (merged 2026-06-06) |
-| #44 | PR | CHORE-D5 runtime upgrade — Node 22 + firebase-functions 7.x (merged 2026-06-06; closes #39 #40) |
-| #45 | PR | CHORE-PR45 — lookup rate-limit doc-path fix + post-PR-#38 cleanup (merged 2026-06-06) |
 | #46 | PR | FR-EX-06 edit / delete expense, friendship context (merged 2026-06-07) |
 | #47 | Issue | Firestore rules-hardening for non-creator update/delete (OPEN — Sprint 3 hardening) |
 | #48 | PR | FR-EX-05 receipt attachment, friendship context (merged 2026-06-07) |
-| **#49** | **PR** | **Next feature PR — see below** |
+| #49 | Issue | Orphan-cleanup Cloud Function for unreferenced receipts (90-day reaper) — OPEN (FUTURE-work chore, 2 SP) |
+| #50 | Issue | Trigger no-op-recompute optimisation when update touches only `receiptUrl` + `updatedAt` — OPEN (FUTURE-work chore, 1 SP). **EXPLICITLY CANNOT BE CLOSED** by any FR-EX-07-consuming PR — the optimisation would skip activity emission on receipt-only updates, breaking the FR-EX-07 contract (AC-2). |
+| #51 | PR | FR-EX-07 activity feed write-side, friendship expenses (merged 2026-06-07) |
+| **#52** | **PR** | **Next feature PR — see below** |
 
 The "Next three PRs" below refer to the next three FEATURE/CHORE
-**pull requests** — i.e. PR #49, PR #50, PR #51. Their issue-number
-counterparts (when filed) will consume intermediate numbers; the orchestrator
-should not assume PR #49 = number 49 on GitHub.
+**pull requests** — i.e. PR #52, PR #53, PR #54. Their issue-number
+counterparts (when filed) will consume intermediate numbers; the
+orchestrator should not assume PR #52 = number 52 on GitHub.
 
 ---
 
-## PR #49 — TBD
+## PR #52 — TBD
 
-**Status:** Next up. Architect picks at PR #49 kickoff per Sprint 2 velocity.
+**Status:** Next up. Architect picks at PR #52 kickoff per Sprint 2 velocity.
 
-PR #48 shipped FR-EX-05 (receipt attachment for friendship-context
-expenses, SCR-21) — the first client uploader to Firebase Storage
-from the expense feature. The new Step 3 widget plus the extracted
-`ImagePickerService` (now at `lib/core/services/`) plus the new
-`ReceiptStorageService` give downstream features the building
-blocks for any future image-attachment surface (e.g. group-context
-receipts in the Sprint 3 groups epic). PR #48 also closed R7 + R8
-from the Sprint-1 Bucket-B burndown (Storage rules tests for file
-size + content type). The defensive group-receipts predicate is
-already in `storage.rules` — the Sprint 3 groups epic only needs
-to wire the UI.
+PR #51 shipped FR-EX-07 (activity-feed write-side for friendship
+expenses). The `onExpenseWriteFriendship` trigger now emits one
+`activity/{userId}/items/{auto-id}` document per friendship member
+on every create / edit / soft-delete. The new
+`activity-writer.ts` + `payload-builder.ts` + `activity-validator.ts`
+modules are reusable by the settlement-trigger activity-emission
+extension. The `firestore.rules` block at
+`match /activity/{userId}/items/{itemId}` enforces member-read /
+server-only-write, mirroring the `simplifiedBalances` posture.
+12 new rules tests (176 → 188) cover AC-6 through AC-12;
+41 new unit tests (100 → 141 boundary, plus 13 trigger-integration
+tests = 154 total); 5 boundary-contract tests guard against
+monetary float drift across `functions/src/**`. The
+client read-side (SCR-25 — Activity tab) is the natural
+follow-on story (FR-AC-01).
 
 Candidates (in rough priority order):
 
-- **FR-EX-07 — Activity feed.** The highest unplaced P0. The
-  `onExpenseWriteFriendship` trigger already emits activity entries
-  for create / update / soft-delete events; PR #48's receipt-only
-  update also fires the trigger (no-op recompute — log noise but
-  correct). The remaining work is the read-side screen + listener +
-  composite-index design.
+- **FR-AC-01 — Activity tab (SCR-25) + settlement-trigger
+  activity-emission extension.** The highest unplaced P0. PR #51
+  shipped the write-side schema and rules; FR-AC-01 ships the
+  client read-side (route `/activity`, `OBTActivityRow`, deep-link
+  routing for FR-AC-02). Pair with the symmetric settlement-trigger
+  activity emission (the TODO at
+  `functions/src/triggers/on-settlement-write/function.ts:231` is
+  ready to consume `writeExpenseActivity` from PR #51 with a sibling
+  settlement-payload builder) — both halves are needed for the
+  settlement leg of SCR-25 to render anything. 8-10 SP — may split
+  into two sub-PRs (client vs server) at architect's call.
 - **FR-SE-09 — Send Reminder.** Closes the receiving-direction
   branch of the OBTSettleUpCard (per PR #43 §2.5 default-omit).
   Requires FCM dependency + 24-hour rate-limit subcollection.
-  **Note:** this PR will exercise the
+  Now the highest unplaced P1. Will exercise the
   `_rateLimits/{uid}/sends/counter` subcollection pattern
   established by PR #45 Architect Notes §2.9.
+- **FR-AC-03 — FCM push notifications.** Separate P0 story;
+  introduces the FCM dependency + the `notificationPrefs` schema +
+  per-user `fcmTokens` plumbing. Requires FR-AC-01 client deep-link
+  surface as a prerequisite (paired by FR-AC-05 cold-start
+  deep-link).
 - **FR-SE-08 dedicated full-history screen** at
   `/settlements/history` (P0 — PR #42's in-timeline rows satisfy
   v1.0 but the dedicated screen is still a backlog item).
 - **Issue #47 rules-hardening for non-creator update/delete gate**
   (operational hardening; small standalone PR ~2 SP). Closes the
   defence-in-depth gap that the FR-EX-06 architect §2.9 item 5
-  documented — the `friendships/{fid}/expenses/{eid}` rules
-  currently permit update + soft-delete by any friendship member;
-  the client UI gates on `expense.createdBy == currentUser.uid`
-  but a defence-in-depth rules tightening is a follow-up.
+  documented.
 - **Concurrent-edit detection for FR-EX-06** (operational
   hardening; small standalone PR). Explicitly deferred from
-  PR #46 per the story's Out of Scope (AC-11 / AC-12 — full
-  transactional concurrent-edit detection).
-- **Orphan-cleanup Cloud Function for receipts** (FUTURE; filed
-  during PR #48 per SRS schema doc line 312 — 90-day reaper of
-  unreferenced files under `receipts/`). Out of v1.0 unless
-  required for compliance.
-- **Trigger no-op-recompute optimisation** (FUTURE; filed during
-  PR #48 — skip `recomputeSimplifiedBalances` when the update
-  touches only `receiptUrl` + `updatedAt`). Pure log-noise +
-  trivial CPU optimisation.
+  PR #46.
+- **Issue #49 — Orphan-cleanup Cloud Function for receipts**
+  (FUTURE; filed during PR #48 per SRS schema doc line 312).
+  Out of v1.0 unless required for compliance.
+- **Issue #50 — Trigger no-op-recompute optimisation** (FUTURE;
+  filed during PR #48). **EXPLICITLY CONSTRAINED** by FR-EX-07
+  (PR #51 AC-2): the optimisation must NOT skip activity emission
+  on receipt-only updates; a follow-up will update issue #50 with
+  this constraint.
 - **Rate-limit transaction race refactor** (operational hardening;
   small standalone PR). Deferred from PR #45 per chore-story
   Architect Notes §2.2.
 
 ---
 
-## PR #50 — TBD
+## PR #53 — TBD
 
-**Status:** Slot reserved. Architect picks at PR #49 kickoff.
+**Status:** Slot reserved. Architect picks at PR #52 kickoff.
 
-Candidates: whatever doesn't land in PR #49 from the list above, plus:
+Candidates: whatever doesn't land in PR #52 from the list above, plus:
 
-- A Bucket-B chore PR (remaining 28 / 37 items after PR #48
-  closed R7 + R8).
+- A Bucket-B chore PR (remaining 27 / 37 items after PR #51 closed
+  R5a — activity rules coverage).
 - Pre-Sprint 3 design polish (FR-FR-01 chore #28 Friends HTML
   mockup; SCR-09/10 wireframe alignment).
-- A test-hygiene chore to move `npm run test:rules` out of the
-  `--only auth,firestore,functions,storage` emulator invocation in
-  `.github/workflows/pr.yml` (noted as a side observation in
-  `docs/sprint-zero/stories/CHORE-d5-runtime-upgrade.md` Architect
-  Notes §2.7 — the trigger-interference flake is environment-
-  sensitive on macOS but not observed on Linux runners). **Note:**
-  PR #46 already split the rules tests into a dedicated emulator
-  session per architect chore-D5 §2.7, so this slot is partially
-  closed; the remaining work is updating the Architect Notes to
-  reflect the split.
 - The deferred rate-limit transaction race refactor (PR #45 §2.2).
 - The deferred concurrent-edit detection for FR-EX-06.
 - Issue #47 rules-hardening for the non-creator update/delete gate.
 
 ---
 
-## PR #51 — TBD
+## PR #54 — TBD
 
-**Status:** Slot reserved. Architect picks at PR #50 kickoff.
+**Status:** Slot reserved. Architect picks at PR #53 kickoff.
 
-Candidates: whatever doesn't land in PR #49 / PR #50 from the lists
+Candidates: whatever doesn't land in PR #52 / PR #53 from the lists
 above.
 
 ---
@@ -160,35 +155,39 @@ the `ImagePickerService` was extracted from `features/auth/data/`
 to `lib/core/services/` so the expense feature can import it
 without an auth → expenses dependency. The `storage.rules` predicate
 for friendship-receipts ships with the matching defensive
-group-receipts predicate (closes R7 + R8 in one shot). 23 new
-storage-rules tests (153 → 176 across 8 suites) cover the size /
-MIME / membership / cross-collection predicate paths;
-flutter tests grow 883 → 885 (the new step-3 widget tests, the
-extracted picker smoke test, and the helper-shared fakes);
-3 skipped integration-test stubs at
-`test/integration/expenses/receipt_upload_flow_test.dart` earn
-partial PY3 credit.
+group-receipts predicate (closes R7 + R8 in one shot).
 
-PR #49 picks up the highest-value backlog item per Sprint 2
-velocity at the PR #49 kickoff. FR-EX-07 (activity feed) is the
-natural next-feature given the trigger already emits the activity
-entries; FR-SE-09 / FR-SE-08 / issue #47 rules-hardening / the
-deferred concurrent-edit detection / the orphan-cleanup function /
-the trigger no-op-recompute optimisation / the rate-limit
-transaction race refactor are all plausible alternates; the
-architect's call at kickoff reflects the current priority signal.
+PR #51 then closed the long-standing
+`// TODO(FR-AC-01): write activity-feed item` hand-off seam at
+`functions/src/triggers/on-expense-write/function.ts:160-169` —
+the friendship-expense trigger now fans out an
+`activity/{userId}/items/{auto-id}` document per friendship member
+on every successful recompute (create / edit / soft-delete). The
+new `firestore.rules` block at `match /activity/{userId}/items/{itemId}`
+enforces member-read / server-only-write, the canonical posture
+mirroring `simplifiedBalances`. The `activity-writer.ts` module
+is reusable by the future settlement-trigger activity-emission
+extension (paired with FR-AC-01 client read-side).
+
+PR #52 picks up the highest-value backlog item per Sprint 2
+velocity at the PR #52 kickoff. FR-AC-01 client (SCR-25) +
+settlement-trigger activity emission is the natural next-feature
+pairing — the read-side schema PR #51 wrote is the contract
+FR-AC-01 reads, and the settlement-trigger half is needed for the
+settlement leg of SCR-25 to render anything. The architect's call
+at kickoff reflects the current priority signal.
 
 ---
 
-## Snapshot — Sprint 2 status at end of PR #48
+## Snapshot — Sprint 2 status at end of PR #51
 
 | Metric | Value |
 |---|---|
-| PRs merged in Sprint 2 | 14 (#31, #32, #34, #35, #36, #37, #38, #41, #42, #43, #44, #45, #46, #48) |
-| Story points delivered | 50 (PR #41 was 0 SP — pure docs cross-refs; PR #42, #43, #46, #48 were 5 SP each; PR #44 + PR #45 were 3 SP each — both chores) |
-| Bucket-B items closed | 9 (R1, R2, R3, R7, R8, CV3, SR8, D5a, D5b — PR #48 closed R7 + R8 with the new Storage rules predicates and the 23-test receipts.test.ts suite). Remaining: 28 / 37. |
+| PRs merged in Sprint 2 | 15 (#31, #32, #34, #35, #36, #37, #38, #41, #42, #43, #44, #45, #46, #48, #51) |
+| Story points delivered | 55 (PR #41 was 0 SP — pure docs cross-refs; PR #42, #43, #46, #48, #51 were 5 SP each; PR #44 + PR #45 were 3 SP each — both chores) |
+| Bucket-B items closed | 10 (R1, R2, R3, R5a, R7, R8, CV3, SR8, D5a, D5b — PR #51 closed R5a with the new 12-test activity.test.ts suite). Remaining: 27 / 37. |
 | Critical Cross-PR Constraints | C-1 RESOLVED (chore #25 closed in PR #38) |
-| Open `sprint-2-chore` issues | 14 (PR #48 filed two new FUTURE-work issues: orphan-cleanup Cloud Function for receipts, and trigger no-op-recompute optimisation; plus issue #47 for non-creator rules hardening was filed during PR #46 review and remains open) |
-| Outstanding deadline-bound work | **None.** D5 shipped in PR #44; PR #45, PR #46, and PR #48 were non-deadline-bound. |
-| Round-trip closures | **Simplified-debts WRITE round-trip closed in PR #43.** Expense lifecycle (create / edit / soft-delete) closed end-to-end on the friendship axis by PR #46. **Receipt attachment surface closed by PR #48**: optional JPEG/PNG upload to `gs://onebytwo-avtanshgupta.appspot.com/receipts/friendships/{fid}/{eid}` with the Expense Detail screen rendering the thumbnail on read. The `onExpenseWriteFriendship` trigger (PR #36) recomputes `simplifiedBalances` on every branch including receipt-only updates (no-op recompute; filed as FUTURE optimisation). |
+| Open `sprint-2-chore` issues | 14 (issues #47, #49, #50 remain open; PR #51 did not file any new issues) |
+| Outstanding deadline-bound work | **None.** D5 shipped in PR #44; PR #45, PR #46, PR #48, PR #51 were non-deadline-bound. |
+| Round-trip closures | **Simplified-debts WRITE round-trip closed in PR #43.** Expense lifecycle (create / edit / soft-delete) closed end-to-end on the friendship axis by PR #46. Receipt attachment surface closed by PR #48. **Activity-feed WRITE-SIDE closed by PR #51** — every friendship-expense write now emits an `activity/{userId}/items/{auto-id}` document per member with type discriminator (`expense_added` / `expense_edited` / `expense_deleted`) and a payload sufficient for SCR-25 to render the row without additional reads. Read-side closure is the FR-AC-01 follow-on PR. |
 

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -92,6 +92,13 @@ Candidates (in rough priority order):
 - **Rate-limit transaction race refactor** (operational hardening;
   small standalone PR). Deferred from PR #45 per chore-story
   Architect Notes §2.2.
+- **`emitExpenseActivity` memberIds re-read cleanup** (operational
+  cleanup; small standalone PR ~1 SP). Per the PR #51 review
+  recommendation #1: the trigger handler currently re-reads the
+  friendship doc to resolve `memberIds` for the activity fan-out
+  (one extra Firestore read per invocation). A future refactor
+  could thread `memberIds` through `RecomputeResult` to eliminate
+  the second read; track as a Sprint-3 cleanup item.
 
 ---
 

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #48 (FR-EX-05 — receipt attachment, friendship context) — 14th merged PR.
+> Last updated: PR #51 (FR-EX-07 — activity feed write-side, friendship expenses) — 15th merged PR.
 
 ---
 
@@ -85,6 +85,8 @@ work until the decision is recorded in the story file's Architect Notes.
 | #44 | CHORE-D5 | D5 runtime upgrade — Node 22 + firebase-functions 7.x (closes #39 #40) | 3 | Merged |
 | #45 | CHORE-PR45 | Lookup rate-limit doc-path fix + post-PR-#38 cleanup (3 S4 items) | 3 | Merged |
 | #46 | FR-EX-06 | Edit / delete expense (friendship) — bottom-sheet edit-mode + Expense Detail screen + soft-delete with confirmation | 5 | Merged |
+| #48 | FR-EX-05 | Receipt attachment (friendship) — Step 3 (SCR-21) + ReceiptStorageService + storage.rules friendship + group receipts predicates + Expense Detail thumbnail | 5 | Merged |
+| #51 | FR-EX-07 | Activity feed write-side (friendship) — activity-writer + payload-builder + activity-validator + activity/{userId}/items rules + trigger emission + 12 new rules tests + 41 new unit tests + 3 integration round-trips | 5 | Merged |
 
 ---
 
@@ -106,7 +108,8 @@ work until the decision is recorded in the story file's Architect Notes.
 | #45 | 3 | Merged (chore — Stream A + Stream B) |
 | #46 | 5 | Merged |
 | #48 | 5 | Merged |
-| **Total** | **50** | **14 PRs so far** |
+| #51 | 5 | Merged |
+| **Total** | **55** | **15 PRs so far** |
 
 Sprint 1 reference:
 

--- a/docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md
+++ b/docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md
@@ -795,7 +795,8 @@ IS an `expense_edited` event).
   amountPaise: number;         // captured from change.before snapshot
   category: string;            // captured from change.before snapshot
   authorUid: string;           // == createdBy of the pre-delete snapshot
-  deletedAt: Timestamp;        // server timestamp at write time
+  deletedAt: Timestamp;        // sourced from the trigger's event.time
+                               // (eventTimestamp), NOT FieldValue.serverTimestamp()
 }
 ```
 
@@ -805,6 +806,20 @@ hard-deleted in some future cleanup. The payload is intentionally
 slimmer than `expense_added` — splits, payer, splitMethod etc. are
 omitted because the deleted-state row in SCR-25 only needs the
 description + amount + colour-coded "deleted" badge.
+
+**`deletedAt` sourcing — clarification.** `deletedAt` is sourced from
+the trigger's `event.time` (the `eventTimestamp` passed through from
+the trigger handler), NOT from `FieldValue.serverTimestamp()`. This
+is intentional and semantically correct: `deletedAt` represents
+"when the soft-delete happened on the client" (i.e. when the
+`deleted: false → true` write hit Firestore), not "when the
+activity-emission write hit Firestore". This is consistent with how
+`lastActivityAt` is sourced in PR #35/#36 — both fields advance the
+client-perceived event time, not the trigger's wall-clock invocation
+time. By contrast, the top-level `createdAt` on the activity-item
+document itself uses `FieldValue.serverTimestamp()` because that
+field represents "when the activity item was written" (the SCR-25
+reverse-chronological sort key — Firestore-authoritative).
 
 ### 2.7 — Files to touch (exhaustive — anything outside this set is scope creep)
 

--- a/docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md
+++ b/docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md
@@ -565,6 +565,411 @@ Reference: `docs/design/08-plan/definition-of-ready-and-done.md`
 
 ## Architect Notes
 
-> _To be appended in Phase 2 by the Architect agent. See
-> `docs/copilot_prompts/sprint_2/14.md` Phase 2 (§2.1–§2.9) for the
-> ratification checklist._
+> Appended for the FR-EX-07 activity-feed write-side PR. These notes
+> ratify the design decisions taken before implementation begins.
+> References: `docs/copilot_prompts/sprint_2/14.md`,
+> `.github/shared/invariants.md`, `.github/shared/decision-log.md`
+> (ADR-0001 simplified debts; ADR-0002 paise integers; ADR-0011 Cloud
+> Functions test-pyramid layers; ADR-0013 PII / telemetry hashing).
+
+### 2.1 — Trigger placement
+
+**RATIFY: activity-write runs AFTER the successful `recomputeAndWrite`
+branch.**
+
+The hand-off seam at `functions/src/triggers/on-expense-write/function.ts:160-169`
+already documents the canonical placement: "these MUST run only after
+a successful recompute". The activity-write call lives immediately
+before the final `simplified_debts_compute_completed` log line at
+`function.ts:242` (i.e. inside the success branch, after the typed
+`result.ok` check has narrowed). On `recomputeAndWrite` failure (any
+`result.ok === false` path OR a thrown INTERNAL), NO activity items
+are written; the retry on the next trigger invocation handles both
+the recompute AND the activity-write together.
+
+The activity-write itself runs as a SEPARATE Firestore write (NOT
+inside the `recomputeAndWrite` transaction). Rationale:
+
+- The activity write is per-member (`memberIds.length` separate
+  documents, one per member's subcollection), targeting a different
+  collection (`activity/**` vs `friendships/**`).
+- Bundling them into the same Firestore transaction would force the
+  rollback-on-failure semantics onto activity-write failures that
+  should be retried independently — and Firestore transactions cannot
+  span the `friendships/{fid}` document and `activity/{uidA}/items/{auto-id}`
+  + `activity/{uidB}/items/{auto-id}` writes anyway without lifting
+  the transaction to a multi-document `runTransaction` with explicit
+  reads of all three documents first (TOCTOU is not a concern here
+  because activity items are append-only and have no prior state).
+- Keeping the activity-write outside the recompute transaction means
+  a transient activity-write failure does NOT roll back the recompute,
+  which is the correct posture: the balance state is more critical
+  than the feed entry, and the feed entry can be retried independently
+  via the orphan-reconciliation mechanism (FUTURE work).
+
+### 2.2 — Activity-writer module extraction
+
+**RATIFY: extract to `functions/src/triggers/on-expense-write/activity-writer.ts`.**
+
+The trigger handler imports `writeExpenseActivity(...)` and calls it
+from the success branch; the writer is independently unit-testable
+with mocked Firestore. The symmetric extraction in the follow-on PR
+(settlement-trigger activity emission, paired with FR-AC-01 client
+SCR-25) will REUSE the same `activity-writer.ts` module — only the
+sibling `payload-builder.ts` will be specialised per trigger source.
+
+The activity-writer module exposes ONE public entry point:
+
+```typescript
+export async function writeExpenseActivity(
+  deps: { db: FirebaseFirestore.Firestore; logger: Logger },
+  request: {
+    friendshipId: string;
+    expenseId: string;
+    eventType: ActivityItemType;
+    payload: ActivityPayload;
+    memberIds: readonly string[];
+  },
+): Promise<ActivityEmissionResult>;
+```
+
+Returns a typed `ActivityEmissionResult` so the trigger handler can
+log `activity_emission_completed` with the per-member outcomes. The
+writer NEVER rethrows — per-member write failures are caught and
+contained inside the writer's own try/catch (per §2.9 item 2).
+
+### 2.3 — Activity-writer API surface
+
+New file `functions/src/triggers/on-expense-write/activity-writer.ts`:
+
+- **`ActivityItemType` literal union**: `'expense_added' | 'expense_edited' | 'expense_deleted'`.
+  The broader schema enumeration (`'settlement'`, `'group_change'`)
+  is FUTURE; this PR ships only the three expense-side discriminators.
+- **`ActivityPayload` discriminated union** with the per-type shape
+  ratified in §2.6 below.
+- **`ActivityEmissionResult`** — typed return value:
+  ```typescript
+  type ActivityEmissionResult = {
+    membersSucceeded: number;
+    membersFailed: number;
+  };
+  ```
+- **`writeExpenseActivity(deps, request)`** — writes to both
+  `activity/{memberIds[i]}/items/{auto-id}` in parallel via
+  `Promise.allSettled` (NOT `Promise.all`; the `allSettled` semantics
+  guarantee one member's failure does NOT short-circuit the other
+  member's write). Logs structured `activity_item_written` per
+  successful write with the hashed identifiers and `eventType`; logs
+  `activity_item_write_failed` per failure with the error code; logs
+  `activity_emission_completed` ONCE summarising the outcomes.
+
+### 2.4 — `activity_*` structured-log event names
+
+Three new event constants (per the SRS section 5.10 telemetry funnel,
+extended by this PR):
+
+| Event | Parameters | When |
+|---|---|---|
+| `activity_item_written` | `contextType: 'friendship'`, `contextIdHash`, `expenseIdHash`, `authorUidHash`, `recipientUidHash`, `eventType`, `payloadSizeBytes` | Per successful per-member write |
+| `activity_item_write_failed` | Same as above PLUS `errorCode: string` | Per failed per-member write |
+| `activity_emission_completed` | `contextType`, `contextIdHash`, `expenseIdHash`, `eventType`, `membersSucceeded`, `membersFailed` | Once per trigger invocation |
+
+ALL hash parameters are SHA-256-truncated via the existing
+`functions/src/utils/id-hash.ts` `hashId()` helper. The
+`payloadSizeBytes` value is a defence-in-depth log of the document
+size; an unexpectedly large payload would indicate a programmer error
+or a malformed source document, and a Cloud Logging dashboard alarm
+can be set on the metric.
+
+The PII guard in `activity-writer.test.ts` asserts that NO raw UID
+(neither member UID, nor the composite friendship ID, nor the expense
+ID, nor the payload description) appears in any log line — symmetric
+with the PII guard in the existing `function.test.ts`.
+
+### 2.5 — Idempotency strategy
+
+**RATIFY: (b) stale-event drop — activity-write inherits the existing
+trigger's stale-event guard.**
+
+The activity-write is gated by the same `recomputeAndWrite` success
+branch that already drops stale events at `function.ts:140-157` (the
+7-day window). The activity-writer does NOT need its own deterministic
+ID scheme; the auto-generated `itemId` is the canonical contract per
+schema doc line 196.
+
+The idempotency guarantee is:
+
+> If the trigger fires for an event the handler has already processed
+> (i.e. the event is OLDER than the 7-day stale-event window), the
+> activity-write does not fire either — symmetric with the existing
+> `simplifiedBalances` recompute. For in-window redeliveries (within
+> the 7-day window), the activity-write DOES re-fire and may
+> duplicate items, which is acceptable v1.0 behaviour.
+
+This is a weaker guarantee than full deduplication. The full-dedup
+alternatives considered:
+
+1. **Deterministic item IDs (e.g. `{eid}-{type}-{member}`):** rejected
+   because the schema doc explicitly says `itemId` is auto-generated
+   (line 196). Changing the contract to deterministic IDs would
+   require a schema-doc update AND would prevent the client from ever
+   using the auto-ID auto-sort behaviour Firestore offers. Future work
+   if observed in production; not bundled.
+2. **Per-item Firestore transaction with marker-field check:**
+   rejected because it doubles the Firestore read cost per emission
+   for a hypothetical concern that has not been observed in the
+   recompute path either.
+3. **Per-trigger-invocation `eventId` check in a separate
+   `_processedEvents` collection:** rejected as architecturally
+   intrusive — introduces a new collection just for the activity-feed
+   path; symmetry with the rest of the trigger's posture is better
+   maintained by the current architecture.
+
+Future work: if in-window duplicate items are observed in production,
+file an issue for the full-dedup mechanism (deterministic IDs being
+the simplest path).
+
+### 2.6 — Payload schema per event type
+
+**RATIFY: discriminated-union payload with per-type required fields.**
+
+The schema doc at `docs/design/07-technical/firestore-schema.md` lines
+194-211 specifies `payload: map` deliberately schemaless to absorb
+future event types without migration. The architect-ratified
+discriminator-specific shapes for the three expense-side events:
+
+#### `expense_added` payload
+
+```typescript
+{
+  expenseId: string;
+  friendshipId: string;
+  description: string;
+  amountPaise: number;       // integer (Invariant 1 preserved)
+  category: string;
+  payerId: string;
+  splits: Array<{ userId: string; sharePaise: number }>;
+  splitMethod: string;
+  hasReceipt: boolean;        // !!receiptUrl
+  authorUid: string;          // == createdBy of the source expense
+}
+```
+
+NOTE: the `createdAt` field is a sibling at the top level (NOT inside
+`payload`) and is written via `FieldValue.serverTimestamp()` so the
+SCR-25 reverse-chronological ordering uses the Firestore-server clock
+(authoritative) rather than the trigger's `event.time` (per the schema
+doc's single-field descending index on `createdAt`).
+
+NOTE: `simplifiedBalances` is NOT in the payload — the SCR-25 row
+reads `share` for the recipient from `splits[recipient]` and displays
+the rupee value; the simplified balance is the FriendDetail screen's
+job. Keeping the payload focused on the source-of-truth fields means
+the client never has to reconcile an out-of-sync `simplifiedBalances`
+snapshot embedded inside an activity item.
+
+#### `expense_edited` payload
+
+Same as `expense_added` PLUS:
+
+```typescript
+{
+  ...expenseAddedFields,
+  changedFields: string[];   // the field names that differ between change.before and change.after
+}
+```
+
+The `changedFields` array is computed inside the payload-builder by a
+symmetric algorithm to the client-side `AddExpenseController._changedFields`
+shipped in PR #46. Receipt-only updates yield `changedFields: ['receiptUrl']`
+(per AC-2 and the SCR-25 spec at lines 305-307, a receipt-only edit
+IS an `expense_edited` event).
+
+#### `expense_deleted` payload
+
+```typescript
+{
+  expenseId: string;
+  friendshipId: string;
+  description: string;         // captured from change.before snapshot
+  amountPaise: number;         // captured from change.before snapshot
+  category: string;            // captured from change.before snapshot
+  authorUid: string;           // == createdBy of the pre-delete snapshot
+  deletedAt: Timestamp;        // server timestamp at write time
+}
+```
+
+The snapshot fields are captured from `change.before.data()` so the
+SCR-25 row can render the description even if the expense document is
+hard-deleted in some future cleanup. The payload is intentionally
+slimmer than `expense_added` — splits, payer, splitMethod etc. are
+omitted because the deleted-state row in SCR-25 only needs the
+description + amount + colour-coded "deleted" badge.
+
+### 2.7 — Files to touch (exhaustive — anything outside this set is scope creep)
+
+- **NEW** `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md`
+  — this story (Phase 1).
+- `firestore.rules` — add the `activity/{userId}/items/{itemId}`
+  predicate block.
+- `functions/src/triggers/on-expense-write/function.ts` — extend the
+  success branch with the `writeExpenseActivity(...)` call.
+- **NEW** `functions/src/triggers/on-expense-write/activity-writer.ts`
+  — `ActivityItemType`, `ActivityPayload`, `ActivityEmissionResult`,
+  `writeExpenseActivity`, structured-log event constants.
+- **NEW** `functions/src/triggers/on-expense-write/payload-builder.ts`
+  — pure function `buildExpenseActivityPayload(changeType, before,
+  after)` returning the typed `ActivityPayload`. Extracted so the
+  unit tests can exercise the mapping without spinning up Firestore.
+- **NEW** `functions/src/triggers/on-expense-write/activity-validator.ts`
+  — `validateActivityPayload(type, payload)` runtime guard. NOT
+  placed under `functions/src/schema-validators.ts` because no such
+  module exists today (the existing codebase has no top-level
+  validator module); co-locating with the activity-writer keeps the
+  feature-first folder layout consistent.
+- **NEW** `functions/test/firestore-rules/activity.test.ts` — 12+
+  tests covering AC-6 through AC-12 plus the read-with-seeded-item
+  happy path.
+- **NEW** `functions/test/triggers/on-expense-write/activity-writer.test.ts`
+  — 8+ tests covering AC-1 through AC-5 + AC-13 + per-event-type
+  payload shape verification + the PII guard.
+- **NEW** `functions/test/triggers/on-expense-write/payload-builder.test.ts`
+  — per-event-type mapping verification; pure function; no Firebase
+  admin needed.
+- **NEW** `functions/test/triggers/on-expense-write/activity-validator.test.ts`
+  — runtime guard unit tests (valid payload accepted; missing field
+  rejected; wrong type rejected).
+- `functions/test/triggers/on-expense-write/function.test.ts` — EXTEND
+  with assertions that the activity-writer is invoked from the
+  trigger on the success branch and NOT invoked on the stale-event-
+  drop or CONTEXT_NOT_FOUND branches.
+- `functions/test/integration/on-expense-write.integration.test.ts`
+  — EXTEND with 3 new round-trip tests per AC-17 (create → both
+  members read; edit → both members read; soft-delete → both members
+  read).
+- **NEW** `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+  — Functions-side boundary-contract grep against `.toDouble()`,
+  `parseFloat`, `Number.parseFloat`, `/100`, `/100.0`,
+  float-typed monetary field declarations across
+  `functions/src/**/*.ts`. Returns 0 violations.
+- `docs/sprint-zero/sprint-2-plan.md` — PR #51 row (5 SP; cumulative
+  55 SP / 15 PRs).
+- `docs/sprint-zero/next-three-prs.md` — roll PR #51 to merged; PR
+  #52 / #53 / #54 candidates.
+- `docs/audits/sprint-1/07-bucket-b-burndown.md` — close R5a
+  (activity-rules half); remaining drops by 1.
+
+### 2.8 — Files explicitly NOT to touch (negative scope guardrails)
+
+- `firestore.indexes.json` — no new composite indexes; the single-field
+  descending index on `createdAt` auto-creates per schema doc line 266.
+- `functions/src/triggers/on-settlement-write/function.ts` —
+  settlement-trigger activity emission is a follow-on PR (paired with
+  FR-AC-01 client read-side). If this PR touches the settlement trigger
+  the orchestrator REFUSES.
+- `lib/**` — server-only PR; client SCR-25 surface ships with the
+  FR-AC-01 follow-on PR. The FR-EX-06 client edit / delete UI shipped
+  in PR #46 is unchanged.
+- `storage.rules` — PR #48 closed; no Storage surface in this PR.
+- `pubspec.yaml` / `pubspec.lock` / `analysis_options.yaml` / Android /
+  iOS native shells — no client diff.
+- `functions/package.json` / `functions/package-lock.json` /
+  `firebase.json` / `.github/workflows/*.yml` — no new dependencies,
+  no workflow change. The new rules tests + integration tests run in
+  the existing dedicated emulator sessions.
+- `lib/features/expenses/**`, `lib/features/friends/**`,
+  `lib/features/settlements/**` — no client diff.
+- `docs/design/07-technical/firestore-schema.md` — the
+  `activity/{userId}/items/{itemId}` row at lines 194-211 is the
+  canonical contract this PR IMPLEMENTS; the schema doc is unchanged.
+
+### 2.9 — Anticipated reconciliations
+
+1. **Firestore.rules path syntax.** The
+   `match /activity/{userId}/items/{itemId}` nested path requires the
+   parent `match /activity/{userId}` block to ALSO have an explicit
+   default-deny on read/write (else the parent doc reads are unguarded
+   — the documentation default-deny at the top of `firestore.rules`
+   catches it, but defence-in-depth is cheap). Verified against the
+   emulator by AC-12's parent-doc read test. The canonical posture
+   matches the existing `users/{userId}` block pattern.
+
+2. **Trigger handler error containment.** The
+   `await writeExpenseActivity(...)` call MUST NOT rethrow the
+   activity-write failure into the trigger's success branch (else a
+   transient activity-write failure would mark the entire trigger
+   invocation as failed and Cloud Functions would retry — which would
+   re-run the recompute AND re-attempt the activity-write, duplicating
+   the activity items on the successful members). The activity-writer
+   wraps its own try/catch around each per-member write via
+   `Promise.allSettled` semantics and logs the failure structured-log
+   event; the trigger sees a clean return value either way. The
+   activity-writer's RETURN value (`{membersSucceeded, membersFailed}`)
+   is used ONLY for the `activity_emission_completed` summary log; no
+   conditional control flow.
+
+3. **Orphan activity items.** A member-write failure where the other
+   member's write succeeded leaves an asymmetric activity feed. v1.0
+   acceptable per the trigger-error-containment posture (§2.9 item 2).
+   Future work would file a reconciliation function similar to the
+   orphan-receipts cleanup (issue #49 precedent). FILE AS AN ISSUE
+   ONLY IF OBSERVED in production — speculative reconciliation
+   infrastructure has been historically overengineered in this
+   codebase.
+
+4. **Receipt-only update fires `expense_edited`.** Per AC-2 and the
+   SCR-25 spec at lines 305-307, a receipt attach / replace / remove
+   IS recorded as an `expense_edited` activity item with
+   `changedFields: ['receiptUrl']`. This is consistent with the
+   PR-#48-shipped trigger behaviour — the trigger fires on every
+   update regardless of which field changed, and the activity feed
+   reflects the user-visible change. EXPLICITLY: issue #50 (trigger
+   no-op-recompute optimisation that would skip the recompute on
+   receipt-only updates) CANNOT be closed by this PR — closing it
+   would BREAK FR-EX-07. A follow-up will update issue #50 with this
+   constraint.
+
+5. **Idempotency caveat under redeploy / cold start.** Per §2.5, the
+   activity-write is gated by the existing stale-event drop. If the
+   trigger is re-fired for an event OLDER than the 7-day stale-event
+   window (e.g. a function redeploy + a Cloud Functions retry storm),
+   the activity-writer is naturally drop-gated. For IN-WINDOW
+   redeliveries (within the 7-day window), the activity-writer WILL
+   re-fire and duplicate items. This is consistent with the rest of
+   the trigger's posture; full deduplication is FUTURE work (out of
+   v1.0 scope; file as an issue if observed in production).
+
+6. **PII in the activity payload.** The payload contains UIDs
+   (`authorUid`, `payerId`, `splits[].userId`). These are NOT subject
+   to ADR-0013 because the payload ships INSIDE Firestore where the
+   user has read access to their own activity items (per AC-6 — the
+   member-read-only predicate). The structured-log lines emitted by
+   the activity-writer ARE ADR-0013-subject and use `hashId()` per
+   §2.4. The activity-writer test PII guard asserts that NO raw UID
+   appears in any log line (symmetric with the existing
+   `function.test.ts` PII guard).
+
+7. **Functions-side boundary-contract grep — recommended NEW
+   defence-in-depth.** No Functions-side boundary-contract grep
+   exists today (the Flutter-side grep at
+   `test/features/expenses/expense_creation_boundary_contract_test.dart`
+   does NOT cover `functions/src/**`). The new
+   `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+   is parallel to the Flutter-side and greps for `.toDouble()`,
+   `parseFloat`, `Number.parseFloat`, `/100`, `/100.0`, and
+   float-typed monetary field declarations. RECOMMENDED YES — it
+   would have caught any future float-typed payload field and is
+   cheap defence-in-depth. The grep is a single Jest test using
+   Node's `fs` + `path` modules; no new dependencies.
+
+8. **Activity-validator placement.** No `functions/src/schema-validators.ts`
+   module exists today (only `functions/src/utils/id-hash.ts` under
+   utils). RATIFY: place the validator at
+   `functions/src/triggers/on-expense-write/activity-validator.ts`
+   (sibling to the activity-writer). Co-locating with the writer
+   keeps the feature-first folder layout consistent with the rest of
+   the codebase (e.g. `functions/src/triggers/on-expense-write/function.ts`,
+   `functions/src/simplified-debts/algorithm.ts`). The activity-writer
+   calls the validator BEFORE the Firestore write to catch
+   programmer errors at runtime that the TypeScript compiler cannot
+   (e.g. a hand-constructed payload missing `payerId`).

--- a/docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md
+++ b/docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md
@@ -1,0 +1,570 @@
+# FR-EX-07: Activity Feed Write-Side Emission (Friendship Expenses)
+
+> Implementation-ready user story for the **first writer of the
+> `activity/{userId}/items/{itemId}` collection** in the OneByTwo
+> application. Extends the existing `onExpenseWriteFriendship` Firestore
+> trigger (the friendship expense trigger) so that every successful
+> recompute fans out **two activity-feed documents** — one into each
+> friendship member's per-user activity subcollection — with a typed
+> payload that captures the user-visible change (`expense_added`,
+> `expense_edited`, or `expense_deleted`). Ships the canonical
+> `activity/{userId}/items/{itemId}` Firestore Security Rules block
+> (member-read, server-only-write) for the first time, mirroring the
+> `simplifiedBalances` server-only enforcement pattern. The client
+> read-side (SCR-25 — Activity tab) is the natural follow-on story
+> (FR-AC-01) and is explicitly out of scope; this story is server-only,
+> expense-trigger only, friendship-only. Closes the long-standing
+> `// TODO(FR-AC-01): write activity-feed item` hand-off seam at
+> `functions/src/triggers/on-expense-write/function.ts` and makes the
+> schema doc's `activity/{userId}/items` row enforceable for the first
+> time.
+
+---
+
+## SRS Requirement ID(s)
+
+FR-EX-07 (SRS section 4.5 line 212 — "Each edit or delete shall be
+recorded in the activity feed with author and timestamp"; this story
+extends to creates for symmetry with SCR-25 Event Type Mapping),
+FR-AC-01 (SRS section 4.7 lines 236-240 — write-side prerequisite for
+the Activity tab; the client read-side is the FR-AC-01 P0 story
+shipping in a follow-on PR).
+
+## Relevant SRS Sections
+
+- Section 4.5 — Expenses (FR-EX-07 audit trail of edits and deletes)
+- Section 4.7 — Activity Feed (FR-AC-01 schema dependency)
+- Section 5.4 — Privacy and PII handling
+- Section 5.10 — Observability (new structured-log event names)
+- Section 7.1 — Cloud Functions runtime (region pinning, retry semantics)
+- Section 7.2 — Firestore schema (`activity/{userId}/items/{itemId}`)
+- Section 7.3 — Key architectural decisions (Invariants 1 + 2)
+- Section 7.5 — Security rules (new `activity/**` predicates)
+
+## Priority
+
+**P0 — Must have.** The activity feed is a Core Screen (SRS section
+6.3 item 10). The client read-side (SCR-25 — Activity tab) is a P0
+follow-on story; shipping the write-side first means the moment the
+client read-side lands, every existing friendship-expense write
+already has activity items to render. Shipping in reverse order
+(read-side first) would force the client to display an empty feed
+for every historical expense.
+
+## Story Points
+
+**5.** Trigger extension + new activity-writer module + new payload-
+builder module + 12-test rules suite + 8-test trigger unit suite + 3-test
+functions integration extension + new rules predicate + schema
+validator + structured logging + boundary-contract grep extension.
+Patterns from the existing expense-trigger module (PR-#36-shipped
+shared core + structured-log + PII guard) are ratified; this story
+reuses, does not re-derive.
+
+## User Story
+
+As a **member of a friendship**,
+I want **every expense create, edit, and soft-delete in our friendship to
+automatically produce a feed item under my user's activity subcollection
+(and under my friend's)**,
+so that **the future Activity tab can render a chronological feed of
+everything that touched our shared finances without any client-side
+orchestration, and so that the audit history requirement (FR-EX-07) is
+satisfied with author and timestamp on every change**.
+
+## Preconditions
+
+1. A friendship document exists at `friendships/{fid}` with valid
+   `memberIds` (two sorted UIDs).
+2. The `onExpenseWriteFriendship` trigger is deployed to `asia-south1`
+   (Mumbai) per SRS section 7.1 and is the sole producer of
+   `simplifiedBalances` for friendships (FR-SE-03/04).
+3. The Firebase Emulator Suite is available for pre-merge integration
+   testing (Firestore on port 8181, Functions on port 5001 per
+   `firebase.json`).
+4. The expense write originates from a member authenticated by the
+   client under the existing `friendships/{fid}/expenses/{eid}`
+   security rules.
+5. The `activity/{userId}/items` Firestore Security Rules block does
+   NOT yet exist; the default-deny at `match /{document=**}` is the
+   only guard. This story is the first writer (server-side) of this
+   path tree.
+
+---
+
+## Acceptance Criteria
+
+### Trigger emission — positive ACs
+
+#### AC-1 — Create writes an `expense_added` activity item to BOTH members
+
+> Given a friendship `friendships/{fid}` with
+> `memberIds: ['uidA', 'uidB']`
+> And the `onExpenseWriteFriendship` trigger is live
+> When a new expense is created at `friendships/{fid}/expenses/{eid}`
+> (via the client repository in production, or via admin SDK in the
+> trigger integration test)
+> Then TWO activity items are written:
+> - one at `activity/{uidA}/items/{auto-id}`
+> - one at `activity/{uidB}/items/{auto-id}`
+> And each has `type: 'expense_added'`
+> And each has `payload: { expenseId, friendshipId, description, amountPaise, payerId, splits, category, splitMethod, hasReceipt, authorUid }`
+> And each has `createdAt: <server timestamp>` (Firestore-side
+> `FieldValue.serverTimestamp()`, NOT the trigger's `event.time` —
+> Architect Notes §2.6 rationale)
+> And both writes happen AFTER the `recomputeAndWrite` success branch.
+
+#### AC-2 — Edit writes an `expense_edited` activity item to BOTH members
+
+> Given an existing non-deleted expense
+> When the expense is updated (any field — amount, description,
+> category, date, payer, splits, splitMethod, OR `receiptUrl`)
+> Then TWO `expense_edited` activity items are written
+> And each has `payload` including the `changedFields` array (field
+> names that differ between `change.before` and `change.after`) PLUS
+> the same base fields as `expense_added`
+> And the receipt-only update path (PR-#48-shipped) DOES fire an
+> `expense_edited` activity item — per the SCR-25 spec at lines
+> 305-307 which explicitly enumerates `expenseEdited` for "any field
+> change"; a receipt attach is a legitimate edit from the user's
+> perspective and the deferred trigger no-op-recompute optimisation
+> (issue #50) must NOT skip the activity emission.
+
+#### AC-3 — Soft-delete writes an `expense_deleted` activity item to BOTH members
+
+> Given an existing non-deleted expense
+> When the expense is soft-deleted (`deleted: false → true` per
+> FR-EX-06)
+> Then TWO `expense_deleted` activity items are written
+> And each has `payload: { expenseId, friendshipId, description, amountPaise, category, authorUid, deletedAt }`
+> And the snapshot of `{ description, amountPaise, category }` is
+> captured from `change.before.data()` so the future SCR-25 row can
+> render the description even if the expense document is hard-deleted
+> in some future cleanup.
+
+#### AC-4 — Author UID is captured in the payload
+
+> Given any of the three trigger events (create, edit, soft-delete)
+> When the activity item is written
+> Then `payload.authorUid` equals the `createdBy` field of the source
+> expense (for create and edit) OR the `createdBy` of the
+> pre-delete snapshot (for soft-delete; symmetric because soft-delete
+> is rules-gated to the creator under the existing expense-update
+> predicates).
+
+#### AC-5 — Activity write happens AFTER the recomputeAndWrite success branch
+
+> Given a transient `recomputeAndWrite` failure (network error,
+> transaction abort, BALANCE_INVARIANT_VIOLATED, or INTERNAL)
+> When the trigger handler runs
+> Then NO activity items are written for the failed branch
+> And the retry on the next trigger invocation handles both the
+> recompute AND the activity emission together
+> And on `CONTEXT_NOT_FOUND` (friendship deleted), NO activity items
+> are written either (the friendship is gone — there is no member to
+> notify).
+
+### Rules ACs — negative-guard load-bearing
+
+#### AC-6 — Authenticated owner can read their own activity items
+
+> Given the new `activity/{userId}/items/{itemId}` predicate block
+> in `firestore.rules`
+> When `uidA` (authenticated) reads
+> `activity/{uidA}/items/{seeded-item-id}`
+> Then the read succeeds.
+
+#### AC-7 — Non-owner cannot read another user's activity items
+
+> Given the new predicate block
+> When `uidB` (authenticated) attempts to read
+> `activity/{uidA}/items/{seeded-item-id}`
+> Then the read fails with `permission-denied`.
+
+#### AC-8 — Unauthenticated read is rejected
+
+> Given the new predicate block
+> When an anonymous (unauthenticated) client reads
+> `activity/{uidA}/items/{seeded-item-id}`
+> Then the read fails with `permission-denied`.
+
+#### AC-9 — Client cannot create an activity item
+
+> Given the new predicate block
+> When `uidA` (authenticated) attempts to create
+> `activity/{uidA}/items/{client-chosen-id}` with a valid-looking
+> payload
+> Then the write fails with `permission-denied`
+> And only the Cloud Functions service account (admin SDK,
+> rules-bypassing) may write.
+
+#### AC-10 — Client cannot update an activity item
+
+> Given an existing seeded activity item at
+> `activity/{uidA}/items/{seeded-id}`
+> When `uidA` attempts an `update()` on the item
+> Then the write fails with `permission-denied`.
+
+#### AC-11 — Client cannot delete an activity item
+
+> Given an existing seeded activity item at
+> `activity/{uidA}/items/{seeded-id}`
+> When `uidA` attempts a `delete()` on the item
+> Then the write fails with `permission-denied`.
+
+#### AC-12 — Reading the parent `activity/{userId}` document is rejected
+
+> Given the parent activity document at `activity/{uidA}` has no
+> semantic content (only the subcollection is the read surface)
+> When `uidA` attempts to read `activity/{uidA}` directly
+> Then the read fails with `permission-denied` (defence-in-depth —
+> the parent doc has its own explicit `allow read, write: if false`
+> rather than relying solely on the default-deny match).
+
+### Idempotency and retry — positive ACs
+
+#### AC-13 — Duplicate trigger invocations do NOT duplicate activity items beyond the stale-event window
+
+> Given the trigger has already written activity items for the
+> `expense_added` of `eid-1`
+> When the trigger fires a SECOND time for the same `eid-1` event
+> with the same `event.time` (e.g. Cloud Functions at-least-once
+> redelivery within the 7-day window)
+> Then idempotency is INHERITED from the existing stale-event drop
+> at `function.ts:140-157` for events older than 7 days, and from
+> the natural pure-function semantics of `recomputeAndWrite` for
+> in-window redeliveries (the activity-writer is gated by the same
+> success branch — a redelivery that succeeds at the recompute layer
+> will also re-emit activity items)
+> And full deduplication (deterministic activity-item IDs) is
+> deferred to FUTURE work — per Architect Notes §2.5, the architect-
+> ratified posture is "if the trigger fires for an event the handler
+> has already processed within the stale-event window, the activity-
+> write fires too; full dedup is FUTURE work and is acceptable v1.0
+> behaviour symmetric with the rest of the trigger's posture".
+
+### Cross-cutting and negative ACs
+
+#### AC-14 — Telemetry / structured-log PII guard
+
+> Given any of the new structured-log events fires
+> (`activity_item_written`, `activity_item_write_failed`,
+> `activity_emission_completed`)
+> When the log line is emitted
+> Then every UID-derived parameter is the SHA-256-truncated hash via
+> `hashId()` from `functions/src/utils/id-hash.ts` (16 hex chars)
+> And NEITHER the raw `friendshipId` composite NOR raw member UIDs
+> NOR the raw expense ID appear in any log line
+> And the activity-writer unit test asserts this contract using a
+> realistic `{uidA}_{uidB}` friendship-id value (mirrors the
+> `function.test.ts` PII guard ratified in PR #36).
+
+#### AC-15 — Invariant 2 negative guard
+
+> Given the PR diff
+> When scanned for new writes to `simplifiedBalances`
+> Then ZERO new writes exist anywhere outside the existing
+> `recomputeAndWrite` path
+> And the activity-writer writes ONLY to
+> `activity/{userId}/items/{auto-id}`
+> And the existing `simplifiedBalances` server-only enforcement
+> (Invariant 2) is unaffected.
+
+#### AC-16 — Invariant 1 boundary contract (Functions-side)
+
+> Given the PR diff
+> When scanned for `.toDouble()`, `parseFloat`, `parseFloat(...)`,
+> `Number.parseFloat`, `.toFixed`, `/ 100`, `/ 100.0`, or
+> floating-point arithmetic on any monetary field
+> Then ZERO violations exist on the activity-payload path
+> And the new Functions-side boundary-contract grep at
+> `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+> (architect-ratified at §2.x; recommended; parallel to the Flutter-
+> side grep at `test/features/expenses/expense_creation_boundary_contract_test.dart`)
+> returns 0 violations across `functions/src/**/*.ts`.
+
+#### AC-17 — Integration test extension
+
+> Given the PR diff
+> When `functions/test/integration/on-expense-write.integration.test.ts`
+> is inspected
+> Then THREE new round-trip tests exist covering the activity-write
+> contract end-to-end through the registered trigger inside
+> `firebase emulators:exec --only auth,firestore,functions,storage`:
+> 1. create-then-read for both members
+> 2. edit-then-read for both members
+> 3. soft-delete-then-read for both members
+> And each round-trip asserts the per-member activity-item count
+> AND the `type` AND key payload fields.
+
+#### AC-18 — Schema validator extension
+
+> Given the PR diff
+> When the schema-validators module (`functions/src/schema-validators.ts`
+> if it exists, OR a new sibling module per architect's call at §2.x)
+> is inspected
+> Then a `validateActivityPayload(type, payload)` helper exists that
+> asserts:
+> - `type` is in the enumeration
+>   `{ 'expense_added', 'expense_edited', 'expense_deleted' }`
+> - `payload` is a plain object
+> - per-type required fields are present (e.g. `expense_added` requires
+>   `expenseId`, `friendshipId`, `description`, `amountPaise`, `payerId`,
+>   `splits`, `category`, `splitMethod`, `hasReceipt`, `authorUid`;
+>   `expense_edited` additionally requires `changedFields`;
+>   `expense_deleted` additionally requires `deletedAt`)
+> And the activity-writer calls the validator before the Firestore
+> write to catch programmer errors at runtime that the TypeScript
+> compiler cannot (e.g. a hand-constructed payload missing
+> `payerId`).
+
+---
+
+## Telemetry Events
+
+Server-side structured logging via `firebase-functions/logger` (NOT
+client Firebase Analytics). All events are PII-free per SRS section
+5.4 and ADR-0013. Friendship IDs (`{uidA}_{uidB}` composite), expense
+IDs, and recipient UIDs are hashed via `functions/src/utils/id-hash.ts`
+(`hashId()` — SHA-256 truncated to 16 hex chars) before logging.
+
+| Event name | Parameters | Trigger |
+|---|---|---|
+| `activity_item_written` | `contextType: 'friendship'`, `contextIdHash: string` (16 hex), `expenseIdHash: string` (16 hex), `authorUidHash: string` (16 hex), `recipientUidHash: string` (16 hex), `eventType: 'expense_added' \| 'expense_edited' \| 'expense_deleted'`, `payloadSizeBytes: number` | Emitted per successful per-member activity-item write. Two emissions per trigger invocation in the success path (one per member). The `payloadSizeBytes` is a defence-in-depth log of the document size; an unexpectedly large payload indicates a programmer error. |
+| `activity_item_write_failed` | Same as above PLUS `errorCode: 'permission-denied' \| 'unavailable' \| 'unknown'` | Emitted per failed per-member activity-item write. The writer does NOT rethrow the failure; the trigger's success branch is preserved (the failure is contained per architect §2.9 item 2). |
+| `activity_emission_completed` | `contextType: 'friendship'`, `contextIdHash: string`, `expenseIdHash: string`, `eventType: 'expense_added' \| 'expense_edited' \| 'expense_deleted'`, `membersSucceeded: number`, `membersFailed: number` | Emitted ONCE per trigger invocation summarising the per-member write outcomes. Useful for the dashboards to compute the activity-emission success rate without re-aggregating the per-write events. |
+
+Note: the existing trigger-pathway events (`expense_trigger_fired`,
+`expense_trigger_stale_event_dropped`, `simplified_debts_compute_started`,
+`simplified_debts_compute_completed`, `simplified_debts_compute_failed`)
+are UNCHANGED in name, parameter set, and placement; the new
+activity-emission events are additive only.
+
+**Strict PII guard:** the structured logger NEVER receives `payerId`,
+`splits[].userId`, `amountPaise`, `sharePaise`, `description`, or any
+raw UID-containing identifier (including the unhashed `friendshipId`,
+unhashed `expenseId`, or unhashed `authorUid` / `recipientUid`).
+Only opaque hash values and `eventType` discriminators are loggable.
+A new `activity-writer.test.ts` PII guard explicitly asserts this
+contract using a realistic `{uidA}_{uidB}` friendship-id value.
+
+---
+
+## Invariant Applicability Assessment
+
+| # | Invariant | Applicability |
+|---|---|---|
+| 1 | Money is integer paise | **N/A on the activity-write path itself.** The `payload.amountPaise` (and `payload.splits[].sharePaise`) values are read straight from the source expense document without arithmetic; the integer invariant is preserved by construction. The new Functions-side boundary-contract grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` (architect-ratified at §2.x) is defence-in-depth — it greps `functions/src/**/*.ts` for `.toDouble()`, `parseFloat`, `/100`, and float-typed monetary field declarations, ensuring future maintainers cannot accidentally introduce float arithmetic on the activity-payload path. |
+| 2 | `simplifiedBalances` server-maintained | **Applicable — defence-in-depth.** The activity-writer writes ONLY to `activity/{userId}/items/{auto-id}`; ZERO new writes to `simplifiedBalances` anywhere. The existing `recomputeAndWrite` is unchanged in this PR. AC-15 is the explicit negative-guard test. |
+| 3 | System share sheet only | N/A. This story has no client UI and no outbound sharing surface. |
+| 4 | Single Firebase project | **Applicable.** The new Firestore rules block targets the single production project. Integration tests run against the single Firebase Emulator Suite via `scripts/dev/start-emulators.sh` and `firebase emulators:exec`. `.firebaserc` is unchanged. |
+
+PII / ADR-0013 compliance: the activity-writer module emits THREE new
+structured-log events (`activity_item_written`,
+`activity_item_write_failed`, `activity_emission_completed`); every
+UID-derived parameter (`contextIdHash` from `friendshipId`,
+`expenseIdHash`, `authorUidHash`, `recipientUidHash`) is
+SHA-256-truncated via the existing `hashId()` helper. The activity
+**payload** itself is NOT subject to ADR-0013 because the payload
+ships inside Firestore where the user has read access to their own
+activity items (per AC-6); the rules block in this PR enforces the
+"own items only" read predicate.
+
+---
+
+## Definition of Done
+
+Reference: `docs/design/08-plan/definition-of-ready-and-done.md`
+
+- [ ] Code merged to `main` via approved PR.
+- [ ] Cloud Functions trigger extension deployed in-place to
+      `asia-south1` (Mumbai) — verified via the manual smoke matrix
+      in the PR body.
+- [ ] New Firestore rules block deployed via
+      `firebase deploy --only firestore:rules`.
+- [ ] Function-boundary unit tests passing (mocked Firestore, no
+      emulator needed) — at least 8 new tests in
+      `functions/test/triggers/on-expense-write/activity-writer.test.ts`
+      and at least 3 new assertions in the existing
+      `functions/test/triggers/on-expense-write/function.test.ts`
+      (activity-writer called from the trigger; activity-writer NOT
+      called on the stale-event-drop branch; activity-writer NOT
+      called on the CONTEXT_NOT_FOUND branch).
+- [ ] Payload-builder unit tests passing — at least one per event
+      type covering the `(changeType, before, after)` → payload
+      mapping.
+- [ ] Security-rules unit tests passing against the Firestore
+      emulator on port 8181 (`npm run test:rules`) — 12+ new tests
+      in `functions/test/firestore-rules/activity.test.ts` covering
+      AC-6 through AC-12.
+- [ ] Integration tests passing against the Firebase Emulator Suite
+      (`npm run test:integration` inside
+      `firebase emulators:exec --only auth,firestore,functions,storage`)
+      — 3 new round-trip assertions per AC-17.
+- [ ] Functions-side boundary-contract grep (architect-ratified per
+      §2.x) returns 0 violations.
+- [ ] QA manual smoke matrix completed and signed off (Phase 5 step
+      10 of `docs/copilot_prompts/sprint_2/14.md`).
+- [ ] Telemetry events in place and PII-free (verified by the new
+      `activity-writer.test.ts` PII guard).
+- [ ] Invariant compliance confirmed (Invariants 2 + 4 applicable;
+      Invariant 1 N/A on the activity payload; boundary-contract
+      grep is defence-in-depth).
+- [ ] Coverage gate green (Functions overall ≥ 50%; new
+      activity-writer module ≥ 70%; existing
+      `simplified-debts/` and `triggers/on-expense-write/function.ts`
+      not regressed).
+- [ ] Documentation updated: `sprint-2-plan.md` (PR #51 row, 5 SP,
+      cumulative 55 SP / 15 PRs); `next-three-prs.md` (PR #52 / #53 /
+      #54 candidates); `07-bucket-b-burndown.md` (R5a closed).
+- [ ] No open S1 or S2 bugs.
+
+---
+
+## Invariant Compliance
+
+- [ ] Invariant 1 (paise): N/A on the activity-write path itself
+      (no monetary arithmetic; values are passed through from the
+      source expense document). The new Functions-side
+      boundary-contract grep is defence-in-depth and returns 0
+      violations across `functions/src/**/*.ts`.
+- [ ] Invariant 2 (`simplifiedBalances` server-only): the existing
+      single-writer enforcement is unchanged. ZERO new writes to
+      `simplifiedBalances` in the PR diff (AC-15 is the explicit
+      negative-guard test).
+- [ ] Invariant 3 (system share sheet only): N/A in this story.
+- [ ] Invariant 4 (single Firebase project): compliant — production
+      only, with emulator-backed pre-merge verification.
+
+---
+
+## Design Artefact References
+
+| Artefact | Path |
+|---|---|
+| Firestore schema (`activity/{userId}/items/{itemId}`) | `docs/design/07-technical/firestore-schema.md` lines 194-211 |
+| Firestore security rules (canonical posture) | `docs/design/07-technical/firestore-security-rules.md` |
+| Cloud Functions catalogue (`onExpenseWriteFriendship`) | `docs/design/07-technical/cloud-functions-catalogue.md` |
+| Cloud Functions error codes | `docs/design/07-technical/cloud-functions-error-codes.md` |
+| Screen spec — Activity Feed (SCR-25) | `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386 |
+| Existing trigger handler (PR #36) | `functions/src/triggers/on-expense-write/function.ts` |
+| Existing trigger story (PR #36) | `docs/sprint-zero/stories/FR-SE-03-04-expense-trigger-friendship.md` |
+| Symmetric settlement trigger (PR #43-shipped, PR #52 activity-emission candidate) | `functions/src/triggers/on-settlement-write/function.ts` |
+| ADR — PII / telemetry hashing | `.github/shared/decision-log.md` ADR-0013 |
+| Feature-PR conventions | `docs/patterns/feature-pr-conventions.md` |
+
+---
+
+## Responsible Agents
+
+| Agent | Responsibility |
+|---|---|
+| PM | Story authorship, AC clarity, scope discipline (no widening to SCR-25 read-side, FCM, settlement-trigger activity emission, group-trigger activity emission, or any FR-AC-XX P0 story; those are separate stories). |
+| Architect | Activity-writer module extraction decision, payload schema per event type, idempotency posture, structured-log event names, scope guardrails, anticipated reconciliations. |
+| Cloud Functions Dev | Activity-writer + payload-builder module implementation, trigger handler extension, security-rules block, function-boundary tests, payload-builder tests, rules tests, integration extension. |
+| DevOps | No new CI workflow changes; the new rules tests run in the existing dedicated `firebase emulators:exec --only firestore,storage` session; the new trigger unit tests run inline under `npm test`; the new trigger integration tests run inline under `npm run test:integration` inside the existing full-emulator session. |
+| QA | Manual smoke matrix sign-off (Phase 5 step 10), DoD §3 sign-off with emulator-log evidence for: (a) member can read own activity items; (b) non-member receives `permission-denied`; (c) client write attempt receives `permission-denied`; (d) trigger fires and writes both members' activity items end-to-end on create / edit / soft-delete. |
+
+---
+
+## Technical Notes
+
+- **Trigger entry-point:** `functions/src/triggers/on-expense-write/function.ts`
+  is extended in place. The new activity-write call lives AFTER the
+  successful `recomputeAndWrite` branch at the bottom of the handler,
+  per the existing TODO comment block (`function.ts:160-169`).
+- **Region:** `asia-south1` (Mumbai). The trigger is already
+  registered there; this PR is an in-place handler extension.
+- **Retry:** The trigger's existing `{retry: true}` posture is
+  unchanged. Activity-write failures are CONTAINED inside the
+  activity-writer's own try/catch (per Architect Notes §2.9 item 2) —
+  a per-member activity-write failure does NOT propagate to the
+  trigger's success branch, so Cloud Functions does NOT retry the
+  whole trigger on activity-write failures. Failures are logged via
+  `activity_item_write_failed`.
+- **Two writes per invocation:** the activity-writer writes ONE
+  document per friendship member. For the two-person friendship
+  context, that is exactly TWO documents per trigger invocation.
+  The writes are issued in parallel via `Promise.all`. An orphan
+  asymmetric state (one member's item written, the other failed) is
+  acceptable v1.0 behaviour per Architect Notes §2.9 item 3.
+- **Idempotency:** see Architect Notes §2.5. The activity-writer
+  inherits the existing stale-event drop at `function.ts:140-157`;
+  in-window redeliveries do duplicate items (acceptable v1.0
+  behaviour symmetric with the rest of the trigger's posture).
+- **Test paths:**
+  - `functions/test/triggers/on-expense-write/activity-writer.test.ts`
+    — unit tests for the writer module (mocked Firestore).
+  - `functions/test/triggers/on-expense-write/payload-builder.test.ts`
+    — unit tests for the pure mapping function.
+  - `functions/test/triggers/on-expense-write/function.test.ts`
+    — EXTEND with assertions that the activity-writer is invoked from
+    the trigger on the success branch and NOT invoked on the
+    stale-event-drop or CONTEXT_NOT_FOUND branches.
+  - `functions/test/firestore-rules/activity.test.ts` — rules tests
+    against the Firestore emulator on port 8181 covering AC-6 through
+    AC-12.
+  - `functions/test/integration/on-expense-write.integration.test.ts`
+    — EXTEND with 3 new round-trip tests per AC-17.
+  - `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+    — NEW (architect's call at §2.x; recommended). Parallel to the
+    Flutter-side grep.
+
+---
+
+## Out of Scope (explicitly deferred — hand-off seams documented in code)
+
+- **Client read-side SCR-25 (Activity tab).** Separate FR-AC-01 P0
+  story. The read-side schema PR #51 ships is the contract a
+  follow-on PR will consume.
+- **Settlement-trigger activity emission.** `functions/src/triggers/on-settlement-write/function.ts:231`
+  has the symmetric TODO. Paired with FR-AC-01 client read-side in a
+  follow-on PR — both halves are needed for the settlement leg of
+  the SCR-25 feed to render anything useful. The activity-writer
+  module shipped in this PR is REUSABLE by that follow-on PR with a
+  sibling settlement-payload builder.
+- **Group-context expense activity emission.** Sprint 3 groups epic
+  (FR-EX-02 + the `onExpenseWriteGroup` trigger).
+- **FR-AC-03 FCM push notifications.** Separate P0 story; introduces
+  the FCM dependency + the `notificationPrefs` schema + the
+  per-user `fcmTokens` plumbing.
+- **FR-AC-04 notification preferences.** Paired with FR-AC-03.
+- **FR-AC-05 cold-start deep-link.** Paired with FR-AC-01 (client
+  deep-link routing).
+- **Activity-item pagination / cursor-based read.** Paired with
+  FR-AC-01 (SCR-25 Open Question 2).
+- **Read/unread markers.** FR-AC-01 Open Question 1; v1.1 candidate
+  per the SCR.
+- **Activity-item filter / search.** FR-AC-01 Open Question 3;
+  deferred per the SCR.
+- **Full activity-item deduplication (deterministic IDs).** Per
+  Architect Notes §2.5, the activity-writer inherits the existing
+  stale-event drop; in-window redeliveries do duplicate items.
+  Acceptable v1.0 behaviour symmetric with the rest of the
+  trigger's posture; full dedup is FUTURE work to file as an issue
+  if observed in production.
+- **Issue #47 — Firestore rules-hardening for non-creator
+  update/delete.** Separate small chore PR.
+- **Issue #49 — Orphan-cleanup Cloud Function for receipts.** FUTURE.
+- **Issue #50 — Trigger no-op-recompute optimisation.** EXPLICITLY
+  REFUSED for bundling — the optimisation would BREAK FR-EX-07 by
+  skipping the activity emission on receipt-only updates (per AC-2
+  the receipt-only update MUST fire an `expense_edited` activity
+  item). A follow-up update to issue #50 will reflect this
+  constraint.
+- **Activity-orphan reconciliation function.** A member-write failure
+  where the other member's write succeeded leaves an asymmetric
+  activity feed. Acceptable v1.0 per architect §2.9 item 3. Future
+  work would file a reconciliation function similar to the
+  orphan-receipts cleanup (issue #49 precedent).
+- **Concurrent-edit detection for FR-EX-06.** Still deferred per PR
+  #46 §2.4.
+- **Rate-limit transaction race refactor.** PR #45 §2.2 deferred.
+
+---
+
+## Architect Notes
+
+> _To be appended in Phase 2 by the Architect agent. See
+> `docs/copilot_prompts/sprint_2/14.md` Phase 2 (§2.1–§2.9) for the
+> ratification checklist._

--- a/firestore.rules
+++ b/firestore.rules
@@ -487,5 +487,43 @@ service cloud.firestore {
       // Hard delete is admin-only.
       allow delete: if false;
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Activity Feed (FR-EX-07, FR-AC-01) — `activity/{userId}/items/{itemId}`
+    //
+    // Member-read-only on the items subcollection, server-only-write on
+    // every path under `activity/**`. The Cloud Functions service account
+    // (admin SDK, rules-bypassing) is the SOLE writer of activity items —
+    // emitted by `onExpenseWriteFriendship` (PR #36; FR-EX-07 write-side
+    // shipped here) and, in a follow-on, by `onSettlementWrite`
+    // (FR-SE-05/06 trigger; FR-AC-01 settlement leg).
+    //
+    // The parent activity/{userId} document carries no semantic content;
+    // only the subcollection is the read surface. Explicit
+    // `allow read, write: if false` on the parent is defence-in-depth
+    // over the top-of-file default-deny.
+    //
+    // Mirrors the `simplifiedBalances` server-only enforcement pattern
+    // ratified in PR #12 and re-ratified by PR #36.
+    //
+    // Schema: docs/design/07-technical/firestore-schema.md lines 194-211.
+    // ────────────────────────────────────────────────────────────────────
+    match /activity/{userId} {
+
+      // Parent activity document: no client read or write.
+      allow read, write: if false;
+
+      match /items/{itemId} {
+
+        // Read: only the user whose UID matches the parent path.
+        allow read: if request.auth != null
+          && request.auth.uid == userId;
+
+        // Writes: never from clients. Only the Cloud Functions service
+        // account may create activity items (it bypasses rules entirely
+        // via the admin SDK).
+        allow create, update, delete: if false;
+      }
+    }
   }
 }

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/src", "<rootDir>/test/simplified-debts", "<rootDir>/test/lookup-user-by-phone-number", "<rootDir>/test/triggers", "<rootDir>/test/utils"],
+  roots: ["<rootDir>/src", "<rootDir>/test/simplified-debts", "<rootDir>/test/lookup-user-by-phone-number", "<rootDir>/test/triggers", "<rootDir>/test/utils", "<rootDir>/test/boundary-contracts"],
   testMatch: ["**/*.test.ts"],
   testPathIgnorePatterns: ["\\.integration\\.test\\.ts$"],
   moduleFileExtensions: ["ts", "js", "json"],

--- a/functions/src/triggers/on-expense-write/activity-validator.ts
+++ b/functions/src/triggers/on-expense-write/activity-validator.ts
@@ -128,6 +128,11 @@ function validateExpenseDeletedPayload(payload: ExpenseDeletedPayload): void {
         "positive integer.",
     );
   }
+  if (typeof payload.category !== "string") {
+    throw new Error(
+      "validateActivityPayload: expense_deleted.category must be a string.",
+    );
+  }
   if (typeof payload.authorUid !== "string" || payload.authorUid.length === 0) {
     throw new Error(
       "validateActivityPayload: expense_deleted.authorUid must be a " +
@@ -152,7 +157,11 @@ function assertHasFields(
 ): void {
   const payloadRecord = payload as Record<string, unknown>;
   for (const field of fields) {
-    if (!(field in payloadRecord)) {
+    // Treat an explicit `undefined` as missing — Firestore would
+    // silently drop the field on the write, producing an incomplete
+    // activity item. Belt-and-braces over the rules-enforced source
+    // contract.
+    if (!(field in payloadRecord) || payloadRecord[field] === undefined) {
       throw new Error(
         `validateActivityPayload: ${eventType} payload missing required ` +
           `field '${field}'.`,
@@ -180,6 +189,11 @@ function assertExpenseSharedShape(
         "positive integer.",
     );
   }
+  if (typeof payload.category !== "string") {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.category must be a string.`,
+    );
+  }
   if (typeof payload.payerId !== "string" || payload.payerId.length === 0) {
     throw new Error(
       `validateActivityPayload: ${eventType}.payerId must be a ` +
@@ -190,6 +204,11 @@ function assertExpenseSharedShape(
     throw new Error(
       `validateActivityPayload: ${eventType}.authorUid must be a ` +
         "non-empty string.",
+    );
+  }
+  if (typeof payload.splitMethod !== "string") {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.splitMethod must be a string.`,
     );
   }
   if (!Array.isArray(payload.splits) || payload.splits.length === 0) {

--- a/functions/src/triggers/on-expense-write/activity-validator.ts
+++ b/functions/src/triggers/on-expense-write/activity-validator.ts
@@ -1,0 +1,219 @@
+/**
+ * Runtime payload validator for activity-feed items.
+ *
+ * The activity-writer calls this BEFORE the Firestore write to catch
+ * programmer errors at runtime that the TypeScript compiler cannot
+ * (e.g. a hand-constructed payload missing `payerId`, or a runtime
+ * value that fell through a `JSON.parse` round-trip and lost its
+ * type narrowing).
+ *
+ * Architect ratification: FR-EX-07 architect notes §2.9 item 8
+ * (placement co-located with the writer; not under a top-level
+ * `schema-validators` module because no such module exists today).
+ *
+ * @module triggers/on-expense-write/activity-validator
+ */
+
+import type {
+  ActivityItemType,
+  ActivityPayload,
+  ExpenseAddedPayload,
+  ExpenseDeletedPayload,
+  ExpenseEditedPayload,
+} from "./payload-builder";
+
+/**
+ * Validates an activity-payload pair against the per-event-type
+ * required-field contract. Throws a descriptive Error on the first
+ * violation. Returns silently on success.
+ *
+ * Designed to fail loudly (throw, not return false) — a malformed
+ * payload is a programmer error, not a runtime user-input concern.
+ * The activity-writer's caller chain treats the throw as an internal
+ * INTERNAL error and the trigger's retry logic will surface it.
+ */
+export function validateActivityPayload(
+  eventType: ActivityItemType,
+  payload: ActivityPayload,
+): void {
+  if (payload === null || typeof payload !== "object") {
+    throw new Error(
+      "validateActivityPayload: payload must be a non-null object.",
+    );
+  }
+
+  switch (eventType) {
+    case "expense_added":
+      validateExpenseAddedPayload(payload as ExpenseAddedPayload);
+      return;
+    case "expense_edited":
+      validateExpenseEditedPayload(payload as ExpenseEditedPayload);
+      return;
+    case "expense_deleted":
+      validateExpenseDeletedPayload(payload as ExpenseDeletedPayload);
+      return;
+    default: {
+      const _exhaustive: never = eventType;
+      throw new Error(
+        `validateActivityPayload: unknown eventType '${String(_exhaustive)}'.`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-event-type validators
+// ---------------------------------------------------------------------------
+
+const EXPENSE_BASE_FIELDS = [
+  "expenseId",
+  "friendshipId",
+  "description",
+  "amountPaise",
+  "category",
+  "payerId",
+  "splits",
+  "splitMethod",
+  "hasReceipt",
+  "authorUid",
+] as const;
+
+function validateExpenseAddedPayload(payload: ExpenseAddedPayload): void {
+  assertHasFields("expense_added", payload, EXPENSE_BASE_FIELDS);
+  assertExpenseSharedShape("expense_added", payload);
+}
+
+function validateExpenseEditedPayload(payload: ExpenseEditedPayload): void {
+  assertHasFields("expense_edited", payload, [
+    ...EXPENSE_BASE_FIELDS,
+    "changedFields",
+  ]);
+  assertExpenseSharedShape("expense_edited", payload);
+  if (!Array.isArray(payload.changedFields)) {
+    throw new Error(
+      "validateActivityPayload: expense_edited.changedFields must be an array.",
+    );
+  }
+  for (const field of payload.changedFields) {
+    if (typeof field !== "string") {
+      throw new Error(
+        "validateActivityPayload: expense_edited.changedFields entries " +
+          "must be strings.",
+      );
+    }
+  }
+}
+
+function validateExpenseDeletedPayload(payload: ExpenseDeletedPayload): void {
+  assertHasFields("expense_deleted", payload, [
+    "expenseId",
+    "friendshipId",
+    "description",
+    "amountPaise",
+    "category",
+    "authorUid",
+    "deletedAt",
+  ] as const);
+
+  if (typeof payload.description !== "string") {
+    throw new Error(
+      "validateActivityPayload: expense_deleted.description must be a string.",
+    );
+  }
+  if (typeof payload.amountPaise !== "number" ||
+    !Number.isInteger(payload.amountPaise) ||
+    payload.amountPaise <= 0) {
+    throw new Error(
+      "validateActivityPayload: expense_deleted.amountPaise must be a " +
+        "positive integer.",
+    );
+  }
+  if (typeof payload.authorUid !== "string" || payload.authorUid.length === 0) {
+    throw new Error(
+      "validateActivityPayload: expense_deleted.authorUid must be a " +
+        "non-empty string.",
+    );
+  }
+  if (payload.deletedAt === undefined || payload.deletedAt === null) {
+    throw new Error(
+      "validateActivityPayload: expense_deleted.deletedAt is required.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared assertions
+// ---------------------------------------------------------------------------
+
+function assertHasFields(
+  eventType: string,
+  payload: object,
+  fields: readonly string[],
+): void {
+  const payloadRecord = payload as Record<string, unknown>;
+  for (const field of fields) {
+    if (!(field in payloadRecord)) {
+      throw new Error(
+        `validateActivityPayload: ${eventType} payload missing required ` +
+          `field '${field}'.`,
+      );
+    }
+  }
+}
+
+function assertExpenseSharedShape(
+  eventType: string,
+  payload: ExpenseAddedPayload,
+): void {
+  if (typeof payload.description !== "string") {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.description must be a string.`,
+    );
+  }
+  if (
+    typeof payload.amountPaise !== "number" ||
+    !Number.isInteger(payload.amountPaise) ||
+    payload.amountPaise <= 0
+  ) {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.amountPaise must be a ` +
+        "positive integer.",
+    );
+  }
+  if (typeof payload.payerId !== "string" || payload.payerId.length === 0) {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.payerId must be a ` +
+        "non-empty string.",
+    );
+  }
+  if (typeof payload.authorUid !== "string" || payload.authorUid.length === 0) {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.authorUid must be a ` +
+        "non-empty string.",
+    );
+  }
+  if (!Array.isArray(payload.splits) || payload.splits.length === 0) {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.splits must be a non-empty array.`,
+    );
+  }
+  for (const split of payload.splits) {
+    if (
+      typeof split !== "object" || split === null ||
+      typeof split.userId !== "string" ||
+      typeof split.sharePaise !== "number" ||
+      !Number.isInteger(split.sharePaise) ||
+      split.sharePaise < 0
+    ) {
+      throw new Error(
+        `validateActivityPayload: ${eventType}.splits entries must be ` +
+          "{ userId: string, sharePaise: non-negative integer }.",
+      );
+    }
+  }
+  if (typeof payload.hasReceipt !== "boolean") {
+    throw new Error(
+      `validateActivityPayload: ${eventType}.hasReceipt must be a boolean.`,
+    );
+  }
+}

--- a/functions/src/triggers/on-expense-write/activity-writer.ts
+++ b/functions/src/triggers/on-expense-write/activity-writer.ts
@@ -1,0 +1,217 @@
+/**
+ * Activity-feed writer for friendship-expense triggers (FR-EX-07).
+ *
+ * Writes one `activity/{userId}/items/{auto-id}` document per friendship
+ * member after every successful expense recompute. Idempotency is
+ * INHERITED from the trigger's existing 7-day stale-event drop (per
+ * FR-EX-07 architect notes §2.5); in-window redeliveries do duplicate
+ * items, which is acceptable v1.0 behaviour.
+ *
+ * Architect ratification: FR-EX-07 architect notes §2.2, §2.3, §2.4.
+ *
+ * Module conventions:
+ *   - Calls Firestore admin SDK via the injected `db` dependency.
+ *   - Logs three structured events: `activity_item_written`,
+ *     `activity_item_write_failed`, `activity_emission_completed`.
+ *   - Every UID-derived log parameter is SHA-256 truncated via
+ *     `hashId()` per ADR-0013 (FR-EX-07 AC-14).
+ *   - Per-member write failures are CONTAINED inside the writer's
+ *     own try/catch — the trigger's success branch is preserved
+ *     (FR-EX-07 architect §2.9 item 2).
+ *   - `Promise.allSettled` semantics: one member's failure does NOT
+ *     short-circuit the other member's write.
+ *
+ * @module triggers/on-expense-write/activity-writer
+ */
+
+import {FieldValue} from "firebase-admin/firestore";
+import {hashId} from "../../utils/id-hash";
+import {validateActivityPayload} from "./activity-validator";
+import type {ActivityItemType, ActivityPayload} from "./payload-builder";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type {ActivityItemType, ActivityPayload} from "./payload-builder";
+
+/** Minimal logger surface the writer needs. */
+export interface ActivityWriterLogger {
+  info: (message: string, data?: Record<string, unknown>) => void;
+  error: (message: string, data?: Record<string, unknown>) => void;
+}
+
+/** Dependencies injected into the writer for testability. */
+export interface ActivityWriterDependencies {
+  db: FirebaseFirestore.Firestore;
+  logger: ActivityWriterLogger;
+}
+
+/** Request payload accepted by `writeExpenseActivity`. */
+export interface WriteExpenseActivityRequest {
+  friendshipId: string;
+  expenseId: string;
+  eventType: ActivityItemType;
+  payload: ActivityPayload;
+  memberIds: readonly string[];
+}
+
+/** Typed result returned to the trigger handler. */
+export interface ActivityEmissionResult {
+  membersSucceeded: number;
+  membersFailed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Structured-log event names (FR-EX-07 architect notes §2.4)
+// ---------------------------------------------------------------------------
+
+export const EVENT_ACTIVITY_ITEM_WRITTEN = "activity_item_written";
+export const EVENT_ACTIVITY_ITEM_WRITE_FAILED = "activity_item_write_failed";
+export const EVENT_ACTIVITY_EMISSION_COMPLETED = "activity_emission_completed";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes an activity item per friendship member.
+ *
+ * - Validates the payload against the per-event-type contract (throws
+ *   on programmer error before any Firestore I/O).
+ * - Issues per-member writes in parallel via `Promise.allSettled`.
+ * - Per-member failures are contained — the writer NEVER rethrows.
+ * - Logs `activity_item_written` per success, `activity_item_write_failed`
+ *   per failure, and `activity_emission_completed` once per invocation.
+ *
+ * Idempotency: NONE at the writer level. Inherited from the trigger's
+ * stale-event drop per FR-EX-07 architect §2.5.
+ */
+export async function writeExpenseActivity(
+  deps: ActivityWriterDependencies,
+  request: WriteExpenseActivityRequest,
+): Promise<ActivityEmissionResult> {
+  const {db, logger} = deps;
+  const {friendshipId, expenseId, eventType, payload, memberIds} = request;
+
+  // 1. Runtime validation — throws on programmer error BEFORE Firestore I/O.
+  validateActivityPayload(eventType, payload);
+
+  // 2. PII-safe IDs for structured logging.
+  const contextIdHash = hashId(friendshipId);
+  const expenseIdHash = hashId(expenseId);
+  const authorUidHash = hashId(extractAuthorUid(payload));
+
+  // 3. Defence-in-depth payload-size log parameter.
+  const payloadSizeBytes = byteLengthOf(payload);
+
+  // 4. Fan out to each member's subcollection.
+  const writeOutcomes = await Promise.allSettled(
+    memberIds.map((recipientUid) =>
+      writeOneMember(db, recipientUid, eventType, payload),
+    ),
+  );
+
+  // 5. Per-member structured logging.
+  let membersSucceeded = 0;
+  let membersFailed = 0;
+  writeOutcomes.forEach((outcome, index) => {
+    const recipientUid = memberIds[index];
+    const recipientUidHash = hashId(recipientUid);
+
+    if (outcome.status === "fulfilled") {
+      membersSucceeded += 1;
+      logger.info(EVENT_ACTIVITY_ITEM_WRITTEN, {
+        event: EVENT_ACTIVITY_ITEM_WRITTEN,
+        contextType: "friendship",
+        contextIdHash,
+        expenseIdHash,
+        authorUidHash,
+        recipientUidHash,
+        eventType,
+        payloadSizeBytes,
+      });
+    } else {
+      membersFailed += 1;
+      logger.error(EVENT_ACTIVITY_ITEM_WRITE_FAILED, {
+        event: EVENT_ACTIVITY_ITEM_WRITE_FAILED,
+        contextType: "friendship",
+        contextIdHash,
+        expenseIdHash,
+        authorUidHash,
+        recipientUidHash,
+        eventType,
+        payloadSizeBytes,
+        errorCode: extractErrorCode(outcome.reason),
+      });
+    }
+  });
+
+  // 6. Summary log — once per invocation.
+  logger.info(EVENT_ACTIVITY_EMISSION_COMPLETED, {
+    event: EVENT_ACTIVITY_EMISSION_COMPLETED,
+    contextType: "friendship",
+    contextIdHash,
+    expenseIdHash,
+    eventType,
+    membersSucceeded,
+    membersFailed,
+  });
+
+  return {membersSucceeded, membersFailed};
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function writeOneMember(
+  db: FirebaseFirestore.Firestore,
+  recipientUid: string,
+  eventType: ActivityItemType,
+  payload: ActivityPayload,
+): Promise<void> {
+  await db
+    .collection("activity")
+    .doc(recipientUid)
+    .collection("items")
+    .add({
+      type: eventType,
+      payload,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+}
+
+/**
+ * Pulls `authorUid` from the payload regardless of variant. Every
+ * payload variant in the FR-EX-07 contract includes `authorUid` as a
+ * required field, so this is a safe accessor.
+ */
+function extractAuthorUid(payload: ActivityPayload): string {
+  return (payload as {authorUid: string}).authorUid;
+}
+
+/**
+ * Computes a defence-in-depth byte size of the payload. The result is
+ * logged as a defensive signal — an unexpectedly large payload would
+ * indicate a programmer error (e.g. accidentally embedding a base64
+ * receipt blob).
+ */
+function byteLengthOf(payload: ActivityPayload): number {
+  return Buffer.byteLength(JSON.stringify(payload), "utf8");
+}
+
+/**
+ * Extracts a stable, low-cardinality error code from a Firestore admin
+ * SDK rejection. Falls back to `'unknown'` to preserve PII safety on
+ * arbitrary thrown values.
+ */
+function extractErrorCode(reason: unknown): string {
+  if (reason !== null && typeof reason === "object") {
+    const code = (reason as {code?: unknown}).code;
+    if (typeof code === "string") {
+      return code;
+    }
+  }
+  return "unknown";
+}

--- a/functions/src/triggers/on-expense-write/function.ts
+++ b/functions/src/triggers/on-expense-write/function.ts
@@ -49,6 +49,11 @@ import {
   Dependencies,
 } from "../../simplified-debts/function";
 import {hashId} from "../../utils/id-hash";
+import {writeExpenseActivity} from "./activity-writer";
+import {
+  buildExpenseActivityPayload,
+  type ExpenseDocData,
+} from "./payload-builder";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -157,16 +162,14 @@ export function createTriggerHandler(
       return;
     }
 
-    // 3. Hand-off seams for downstream PRs (left as comments so the next
-    //    contributor doesn't need to refactor this handler):
-    //    TODO(FR-AC-01): write activity-feed item to activity/{userId}/items
-    //    TODO(FR-AC-03): send FCM push notification respecting notificationPrefs
-    //    Placement note: these MUST run only after a successful recompute
-    //    (i.e. inside or just below the success branch at line 222) to
-    //    keep retry semantics clean — a retryable transient failure must
-    //    not duplicate activity items or notifications. Today they are
-    //    deferred entirely; the actual placement decision lives with the
-    //    PR that implements them.
+    // 3. Activity-feed seam — FR-EX-07 ships the expense-side write.
+    //    The remaining hand-off seam below is for the future story:
+    //    TODO(FR-AC-03): send FCM push notification respecting
+    //    notificationPrefs. Placement note: FCM (like the activity
+    //    emission) MUST run only after a successful recompute (i.e.
+    //    inside or just below the success branch) to keep retry
+    //    semantics clean — a retryable transient failure must not
+    //    duplicate notifications.
 
     // 4. Build the alsoSet payload — atomically advance lastActivityAt
     //    inside the same transaction as the simplifiedBalances write.
@@ -238,7 +241,26 @@ export function createTriggerHandler(
       );
     }
 
-    // 7. Success — log completed event
+    // 7. Emit activity items for both friendship members (FR-EX-07).
+    //    Runs AFTER the successful recomputeAndWrite per architect
+    //    notes §2.1 so a transient recompute failure does NOT
+    //    duplicate items. Failures inside the activity emission are
+    //    contained — the writer's Promise.allSettled prevents
+    //    per-member failures from rethrowing, and the validator
+    //    throw (programmer error) is caught here so the trigger's
+    //    success branch is preserved (architect §2.9 item 2).
+    await emitExpenseActivity(deps, {
+      friendshipId,
+      expenseId,
+      changeType,
+      contextType,
+      contextIdHash,
+      expenseIdHash,
+      eventTimestamp,
+      changeData: event.data,
+    });
+
+    // 8. Success — log completed event
     logger.info("simplified_debts_compute_completed", {
       event: "simplified_debts_compute_completed",
       contextType,
@@ -247,4 +269,128 @@ export function createTriggerHandler(
       transferCount: result.transfers.length,
     });
   };
+}
+
+// ---------------------------------------------------------------------------
+// Activity emission (FR-EX-07)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminates the activity event type and writes one item per
+ * friendship member. Wraps `writeExpenseActivity` with the trigger-
+ * specific (a) soft-delete detection, (b) member-ID resolution, and
+ * (c) defensive try/catch for programmer errors (validator throws).
+ *
+ * Per architect §2.9 item 2: NEVER rethrows. Activity-emission
+ * failures must not propagate into the trigger's success branch,
+ * otherwise Cloud Functions would retry the whole invocation and
+ * potentially re-duplicate activity items on the successful members.
+ */
+async function emitExpenseActivity(
+  deps: Dependencies,
+  params: {
+    friendshipId: string;
+    expenseId: string;
+    changeType: ChangeType;
+    contextType: "friendship";
+    contextIdHash: string;
+    expenseIdHash: string;
+    eventTimestamp: Timestamp;
+    changeData: Change<DocumentSnapshot> | undefined;
+  },
+): Promise<void> {
+  const {db, logger} = deps;
+  const {
+    friendshipId,
+    expenseId,
+    changeType,
+    contextType,
+    contextIdHash,
+    expenseIdHash,
+    eventTimestamp,
+    changeData,
+  } = params;
+
+  try {
+    const beforeData = changeData?.before?.exists
+      ? (changeData.before.data() as ExpenseDocData | undefined)
+      : undefined;
+    const afterData = changeData?.after?.exists
+      ? (changeData.after.data() as ExpenseDocData | undefined)
+      : undefined;
+
+    // Soft-delete discrimination: an update that flips deleted false
+    // -> true emits expense_deleted, NOT expense_edited.
+    let activityChangeType: ChangeType = changeType;
+    if (
+      changeType === "update" &&
+      beforeData?.deleted === false &&
+      afterData?.deleted === true
+    ) {
+      activityChangeType = "delete";
+    }
+
+    // Resolve memberIds via a re-read of the friendship doc. The
+    // recomputeAndWrite path already read this doc inside its
+    // transaction but does not expose the snapshot in its typed
+    // return; one extra read here is the simplest non-invasive
+    // approach. If the friendship was deleted between the recompute
+    // and this read (rare race), memberIds is empty and we skip
+    // emission silently — symmetric with the CONTEXT_NOT_FOUND
+    // behaviour on the recompute path.
+    const friendshipSnap = await db
+      .collection("friendships")
+      .doc(friendshipId)
+      .get();
+    if (!friendshipSnap.exists) {
+      logger.info("activity_emission_skipped_missing_context", {
+        event: "activity_emission_skipped_missing_context",
+        contextType,
+        contextIdHash,
+        expenseIdHash,
+      });
+      return;
+    }
+    const memberIds =
+      (friendshipSnap.data()?.memberIds as string[] | undefined) ?? [];
+    if (memberIds.length === 0) {
+      logger.info("activity_emission_skipped_empty_members", {
+        event: "activity_emission_skipped_empty_members",
+        contextType,
+        contextIdHash,
+        expenseIdHash,
+      });
+      return;
+    }
+
+    const built = buildExpenseActivityPayload(
+      activityChangeType,
+      {friendshipId, expenseId, before: beforeData, after: afterData},
+      eventTimestamp,
+    );
+
+    await writeExpenseActivity(deps, {
+      friendshipId,
+      expenseId,
+      eventType: built.eventType,
+      payload: built.payload,
+      memberIds,
+    });
+  } catch (err: unknown) {
+    // Defence-in-depth: writeExpenseActivity itself uses
+    // Promise.allSettled and never rethrows for per-member Firestore
+    // failures. But the validator inside it DOES throw on programmer
+    // error (e.g. a malformed payload), and the payload-builder
+    // throws on inconsistent (changeType, before, after) tuples.
+    // Both are programmer errors that should NOT mark the trigger as
+    // failed — the recompute is already done; failing here would
+    // only cause a retry-storm that re-runs the recompute.
+    logger.error("activity_emission_internal_error", {
+      event: "activity_emission_internal_error",
+      contextType,
+      contextIdHash,
+      expenseIdHash,
+      errorMessage: err instanceof Error ? err.message : "unknown",
+    });
+  }
 }

--- a/functions/src/triggers/on-expense-write/payload-builder.ts
+++ b/functions/src/triggers/on-expense-write/payload-builder.ts
@@ -1,0 +1,266 @@
+/**
+ * Activity Payload Builder for friendship-expense triggers.
+ *
+ * Pure function that maps the trigger's
+ * `(changeType, before, after)` tuple to a typed `ActivityPayload`
+ * suitable for embedding inside an `activity/{userId}/items/{auto-id}`
+ * document. Extracted from the activity-writer so the mapping logic
+ * can be exercised by unit tests without spinning up Firestore.
+ *
+ * Architect ratification: FR-EX-07 architect notes §2.6 — per-event-
+ * type payload schema with discriminated-union shape.
+ *
+ * @module triggers/on-expense-write/payload-builder
+ */
+
+import type {Timestamp} from "firebase-admin/firestore";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Activity-item type discriminator. Values match the canonical
+ * enumeration in docs/design/07-technical/firestore-schema.md line 202.
+ * The two remaining schema-doc variants (`'settlement'`, `'group_change'`)
+ * are FUTURE work and are NOT emitted by this builder.
+ */
+export type ActivityItemType =
+  | "expense_added"
+  | "expense_edited"
+  | "expense_deleted";
+
+/** Trigger change discriminator (mirrors `function.ts` `ChangeType`). */
+export type ChangeType = "create" | "update" | "delete";
+
+/** Shape of a single split element on an expense document. */
+export interface ExpenseSplit {
+  userId: string;
+  sharePaise: number;
+}
+
+/** Shape of the source expense document (subset relevant to the activity payload). */
+export interface ExpenseDocData {
+  payerId: string;
+  amountPaise: number;
+  splits: ExpenseSplit[];
+  description: string;
+  category: string;
+  splitMethod: string;
+  receiptUrl: string | null;
+  createdBy: string;
+  deleted: boolean;
+}
+
+/** `expense_added` payload. */
+export interface ExpenseAddedPayload {
+  expenseId: string;
+  friendshipId: string;
+  description: string;
+  amountPaise: number;
+  category: string;
+  payerId: string;
+  splits: ExpenseSplit[];
+  splitMethod: string;
+  hasReceipt: boolean;
+  authorUid: string;
+}
+
+/** `expense_edited` payload — extends `expense_added` with `changedFields`. */
+export interface ExpenseEditedPayload extends ExpenseAddedPayload {
+  changedFields: string[];
+}
+
+/** `expense_deleted` payload — pre-delete snapshot fields only. */
+export interface ExpenseDeletedPayload {
+  expenseId: string;
+  friendshipId: string;
+  description: string;
+  amountPaise: number;
+  category: string;
+  authorUid: string;
+  deletedAt: Timestamp;
+}
+
+/** Discriminated union of every payload shape this builder emits. */
+export type ActivityPayload =
+  | ExpenseAddedPayload
+  | ExpenseEditedPayload
+  | ExpenseDeletedPayload;
+
+/** Result tuple of `buildExpenseActivityPayload`. */
+export interface BuiltActivityPayload {
+  eventType: ActivityItemType;
+  payload: ActivityPayload;
+}
+
+// ---------------------------------------------------------------------------
+// Fields-of-interest for the `changedFields` diff
+// ---------------------------------------------------------------------------
+
+/**
+ * Whitelisted set of fields the diff algorithm checks for `expense_edited`.
+ *
+ * Restricted to the user-visible fields the activity feed should reflect.
+ * Server-managed metadata (`updatedAt`, `createdAt`, `createdBy`) is
+ * excluded — those change on every write and would pollute the
+ * `changedFields` array. `deleted` is excluded because soft-delete uses
+ * the `expense_deleted` discriminator, not `expense_edited`. Extension-
+ * point fields (`currency`, `source`, `recurringRule`) are excluded
+ * because they are invariant-locked per the rules.
+ */
+const DIFF_FIELDS: readonly (keyof ExpenseDocData)[] = [
+  "amountPaise",
+  "description",
+  "category",
+  "payerId",
+  "splits",
+  "splitMethod",
+  "receiptUrl",
+];
+
+/**
+ * Returns the subset of `DIFF_FIELDS` whose value differs between
+ * `before` and `after`. Deep equality for `splits` via JSON
+ * canonicalisation — the trigger's source documents always shape splits
+ * identically (sorted object key order is irrelevant because the same
+ * client serialises both halves of every update).
+ */
+function diffChangedFields(
+  before: ExpenseDocData,
+  after: ExpenseDocData,
+): string[] {
+  const changed: string[] = [];
+  for (const field of DIFF_FIELDS) {
+    const beforeValue = before[field];
+    const afterValue = after[field];
+    if (field === "splits") {
+      if (JSON.stringify(beforeValue) !== JSON.stringify(afterValue)) {
+        changed.push(field);
+      }
+    } else if (beforeValue !== afterValue) {
+      changed.push(field);
+    }
+  }
+  return changed;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a trigger event to the activity-payload pair `{ eventType, payload }`
+ * for emission into `activity/{userId}/items/{auto-id}` documents.
+ *
+ * Soft-delete semantics (FR-EX-06): an update whose `before.deleted === false`
+ * and `after.deleted === true` is treated as a `delete` (emits
+ * `expense_deleted`), NOT an `update` (which would emit `expense_edited`).
+ * The caller signals this by passing `changeType: 'delete'` for soft-delete
+ * paths; the trigger's `function.ts` does this discrimination upstream.
+ *
+ * @param changeType - The trigger's change discriminator.
+ * @param request - The expense IDs, friendship ID, and source data
+ *   snapshots. `before` is required for `'update'` and `'delete'`;
+ *   `after` is required for `'create'` and `'update'`.
+ * @param deletedAt - For `'delete'`, the timestamp at which the
+ *   activity-write is happening (Firestore server timestamp).
+ * @returns The typed `{ eventType, payload }` tuple ready for
+ *   `validateActivityPayload` and Firestore write.
+ *
+ * @throws Error if the (changeType, before, after) combination is
+ *   inconsistent (e.g. `'create'` with no `after`; `'delete'` with no
+ *   `before`).
+ */
+export function buildExpenseActivityPayload(
+  changeType: ChangeType,
+  request: {
+    friendshipId: string;
+    expenseId: string;
+    before?: ExpenseDocData;
+    after?: ExpenseDocData;
+  },
+  deletedAt?: Timestamp,
+): BuiltActivityPayload {
+  const {friendshipId, expenseId, before, after} = request;
+
+  if (changeType === "create") {
+    if (!after) {
+      throw new Error(
+        "buildExpenseActivityPayload: 'create' requires 'after' snapshot.",
+      );
+    }
+    return {
+      eventType: "expense_added",
+      payload: buildExpenseAddedPayload(expenseId, friendshipId, after),
+    };
+  }
+
+  if (changeType === "update") {
+    if (!before || !after) {
+      throw new Error(
+        "buildExpenseActivityPayload: 'update' requires both 'before' " +
+          "and 'after' snapshots.",
+      );
+    }
+    return {
+      eventType: "expense_edited",
+      payload: {
+        ...buildExpenseAddedPayload(expenseId, friendshipId, after),
+        changedFields: diffChangedFields(before, after),
+      },
+    };
+  }
+
+  // changeType === 'delete' (soft- or hard-delete)
+  if (!before) {
+    throw new Error(
+      "buildExpenseActivityPayload: 'delete' requires 'before' snapshot.",
+    );
+  }
+  if (!deletedAt) {
+    throw new Error(
+      "buildExpenseActivityPayload: 'delete' requires 'deletedAt' timestamp.",
+    );
+  }
+  return {
+    eventType: "expense_deleted",
+    payload: {
+      expenseId,
+      friendshipId,
+      description: before.description,
+      amountPaise: before.amountPaise,
+      category: before.category,
+      authorUid: before.createdBy,
+      deletedAt,
+    },
+  };
+}
+
+/**
+ * Builds the `expense_added` payload shape. Shared between the create
+ * branch (direct emission) and the update branch (combined with
+ * `changedFields` to form the `expense_edited` payload).
+ *
+ * `hasReceipt: boolean` is derived from a non-null/non-empty
+ * `receiptUrl` per the schema (PR #48 ratified `receiptUrl` is either
+ * `null` or a Firebase Storage download URL string).
+ */
+function buildExpenseAddedPayload(
+  expenseId: string,
+  friendshipId: string,
+  data: ExpenseDocData,
+): ExpenseAddedPayload {
+  return {
+    expenseId,
+    friendshipId,
+    description: data.description,
+    amountPaise: data.amountPaise,
+    category: data.category,
+    payerId: data.payerId,
+    splits: data.splits,
+    splitMethod: data.splitMethod,
+    hasReceipt: data.receiptUrl !== null && data.receiptUrl !== "",
+    authorUid: data.createdBy,
+  };
+}

--- a/functions/test/boundary-contracts/no-double-on-money-fields.test.ts
+++ b/functions/test/boundary-contracts/no-double-on-money-fields.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Functions-side boundary-contract tests (Invariant 1 — paise integers).
+ *
+ * Greps functions/src/** for forbidden patterns that would violate the
+ * load-bearing Invariant 1 (Money is integer paise):
+ *
+ *   - No `.toDouble()` calls anywhere on a monetary path.
+ *   - No `parseFloat` / `Number.parseFloat` calls.
+ *   - No `.toFixed(...)` calls (rupee-formatted strings have no place
+ *     in the Functions write path).
+ *   - No `/100` or `/100.0` divisions (paise → rupee conversion belongs
+ *     exclusively at the client UI layer).
+ *
+ * Mirrors the Flutter-side contract at
+ * test/features/expenses/expense_creation_boundary_contract_test.dart
+ * shipped in PR #38 (FR-EX-01). Architect-ratified for FR-EX-07 per
+ * architect notes §2.9 item 7 (defence-in-depth on the activity-payload
+ * write path; functions/src/triggers/** is now a non-trivial monetary
+ * surface).
+ *
+ * @module test/boundary-contracts/no-double-on-money-fields.test.ts
+ */
+
+import {readdirSync, readFileSync, statSync} from "fs";
+import {join, resolve} from "path";
+
+const SRC_ROOT = resolve(__dirname, "../../src");
+
+/**
+ * Lines that are pure comments (// ..., * ..., /* ..., etc.) are
+ * exempt — explanatory text about "/100 paise" or "double-entry
+ * bookkeeping" is allowed in comments.
+ */
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("/*")
+  );
+}
+
+/** Recursively yields every .ts file under the given directory. */
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      yield* walk(fullPath);
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+      yield fullPath;
+    }
+  }
+}
+
+interface Violation {
+  file: string;
+  lineNumber: number;
+  pattern: string;
+  line: string;
+}
+
+function scan(
+  predicate: (line: string) => string | null,
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const file of walk(SRC_ROOT)) {
+    const content = readFileSync(file, "utf8");
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (isCommentLine(line)) continue;
+      const matchedPattern = predicate(line);
+      if (matchedPattern !== null) {
+        violations.push({
+          file: file.replace(`${SRC_ROOT}/`, "functions/src/"),
+          lineNumber: i + 1,
+          pattern: matchedPattern,
+          line: line.trim(),
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+function format(violations: Violation[]): string {
+  return violations
+    .map(
+      (v) =>
+        `  ${v.file}:${v.lineNumber}: forbidden ${v.pattern}\n    > ${v.line}`,
+    )
+    .join("\n");
+}
+
+describe("functions/src/** boundary contract — Invariant 1 (paise integers)", () => {
+  it("contains no .toDouble() calls", () => {
+    const violations = scan((line) =>
+      line.includes(".toDouble()") ? ".toDouble()" : null,
+    );
+    if (violations.length > 0) {
+      throw new Error(
+        `Found ${violations.length} forbidden .toDouble() call(s):\n` +
+          format(violations),
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("contains no parseFloat / Number.parseFloat calls", () => {
+    const violations = scan((line) => {
+      if (line.includes("Number.parseFloat")) return "Number.parseFloat";
+      // Match `parseFloat(` as a function call (rather than e.g. a
+      // property name that happens to contain the substring).
+      if (/\bparseFloat\s*\(/.test(line)) return "parseFloat()";
+      return null;
+    });
+    if (violations.length > 0) {
+      throw new Error(
+        `Found ${violations.length} forbidden parseFloat call(s):\n` +
+          format(violations),
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("contains no .toFixed(...) calls (rupee-formatting belongs at the UI layer)", () => {
+    const violations = scan((line) =>
+      /\.toFixed\s*\(/.test(line) ? ".toFixed()" : null,
+    );
+    if (violations.length > 0) {
+      throw new Error(
+        `Found ${violations.length} forbidden .toFixed() call(s):\n` +
+          format(violations),
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("contains no /100 or /100.0 paise-to-rupee divisions", () => {
+    const violations = scan((line) => {
+      // Match `/ 100` or `/100` followed by a non-digit (so it does not
+      // match `/1000`, `/1024`, etc.).
+      if (/\/\s*100(\.0+)?(?!\d)/.test(line)) {
+        return "/100 paise division (do paise->rupee conversion at UI layer)";
+      }
+      return null;
+    });
+    if (violations.length > 0) {
+      throw new Error(
+        `Found ${violations.length} forbidden /100 division(s):\n` +
+          format(violations),
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("declares the canonical monetary field shapes (amountPaise / sharePaise as 'number')", () => {
+    // This is an affirmative anchor check: the canonical `: number`
+    // shape MUST exist somewhere in the codebase. The activity-writer
+    // and payload-builder use it; if a future refactor drifts to
+    // `amountRupees` or float-typed fields, this check would fail.
+    let foundCanonical = false;
+    for (const file of walk(SRC_ROOT)) {
+      const content = readFileSync(file, "utf8");
+      if (
+        /amountPaise\s*:\s*number/.test(content) ||
+        /sharePaise\s*:\s*number/.test(content)
+      ) {
+        foundCanonical = true;
+        break;
+      }
+    }
+    expect(foundCanonical).toBe(true);
+  });
+});

--- a/functions/test/firestore-rules/activity.test.ts
+++ b/functions/test/firestore-rules/activity.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Firestore Security Rules tests for the `activity/{userId}/items/{itemId}`
+ * collection (FR-EX-07).
+ *
+ * Covers ACs AC-6 through AC-12 of the FR-EX-07 story:
+ *
+ *   - AC-6  — Authenticated owner can read their own activity items.
+ *   - AC-7  — Non-owner cannot read another user's activity items.
+ *   - AC-8  — Unauthenticated read rejected.
+ *   - AC-9  — Client cannot create an activity item (server-only write).
+ *   - AC-10 — Client cannot update an activity item.
+ *   - AC-11 — Client cannot delete an activity item.
+ *   - AC-12 — Reading the parent `activity/{userId}` document is rejected.
+ *
+ * Defence-in-depth: the parent activity document has an explicit
+ * `allow read, write: if false` rather than relying solely on the top-of-file
+ * default-deny match. The subcollection's read predicate is
+ * `request.auth.uid == userId`; writes are uniformly denied to clients
+ * (only the Cloud Functions service account, which bypasses rules, may write).
+ *
+ * @module test/firestore-rules/activity.test.ts
+ */
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import {readFileSync} from "fs";
+import {resolve} from "path";
+import {
+  doc,
+  getDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  setLogLevel,
+} from "firebase/firestore";
+
+const PROJECT_ID = "demo-onebytwo";
+const RULES_PATH = resolve(__dirname, "../../../firestore.rules");
+
+/**
+ * Valid activity-item document shape per
+ * docs/design/07-technical/firestore-schema.md lines 194-211 and the
+ * FR-EX-07 architect notes §2.6 (`expense_added` shape).
+ */
+function validActivityItemDoc(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    type: "expense_added",
+    payload: {
+      expenseId: "expense-abc",
+      friendshipId: "uidA_uidB",
+      description: "Test expense",
+      amountPaise: 10000,
+      category: "food",
+      payerId: "uidA",
+      splits: [
+        {userId: "uidA", sharePaise: 5000},
+        {userId: "uidB", sharePaise: 5000},
+      ],
+      splitMethod: "equal",
+      hasReceipt: false,
+      authorUid: "uidA",
+    },
+    createdAt: serverTimestamp(),
+    ...overrides,
+  };
+}
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  setLogLevel("error");
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, "utf8"),
+      host: "127.0.0.1",
+      port: 8181,
+    },
+  });
+});
+
+afterEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// AC-6 — Authenticated owner can read their own activity items
+// ---------------------------------------------------------------------------
+
+describe("activity/{userId}/items — read rules (AC-6, AC-7, AC-8)", () => {
+  const uidA = "uid-alice";
+  const uidB = "uid-bob";
+  const itemId = "seeded-item-id";
+
+  beforeEach(async () => {
+    // Admin-seed an activity item under uidA (bypasses rules so the
+    // read-tests have something to read).
+    await testEnv.withSecurityRulesDisabled(async (adminCtx) => {
+      const itemDoc = doc(
+        adminCtx.firestore(),
+        `activity/${uidA}/items/${itemId}`,
+      );
+      await setDoc(itemDoc, validActivityItemDoc());
+    });
+  });
+
+  it("AC-6: allows an authenticated owner to read their own activity items", async () => {
+    const ctx = testEnv.authenticatedContext(uidA);
+    const itemDoc = doc(ctx.firestore(), `activity/${uidA}/items/${itemId}`);
+    await assertSucceeds(getDoc(itemDoc));
+  });
+
+  it("AC-7: rejects a different authenticated user reading another's activity items", async () => {
+    const ctx = testEnv.authenticatedContext(uidB);
+    const itemDoc = doc(ctx.firestore(), `activity/${uidA}/items/${itemId}`);
+    await assertFails(getDoc(itemDoc));
+  });
+
+  it("AC-8: rejects an unauthenticated client reading any activity items", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    const itemDoc = doc(ctx.firestore(), `activity/${uidA}/items/${itemId}`);
+    await assertFails(getDoc(itemDoc));
+  });
+
+  // Defence-in-depth: cross-uid mismatch on the read predicate.
+  it("AC-7 (variant): rejects a different authenticated user reading even with no item present", async () => {
+    const ctx = testEnv.authenticatedContext(uidB);
+    const missingItemDoc = doc(
+      ctx.firestore(),
+      `activity/${uidA}/items/non-existent-id`,
+    );
+    await assertFails(getDoc(missingItemDoc));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9 / AC-10 / AC-11 — Client cannot write (create / update / delete)
+// ---------------------------------------------------------------------------
+
+describe("activity/{userId}/items — write rules (AC-9, AC-10, AC-11)", () => {
+  const uidA = "uid-alice";
+  const seededItemId = "seeded-item-id";
+
+  beforeEach(async () => {
+    // Admin-seed an item so the update/delete tests have a target.
+    await testEnv.withSecurityRulesDisabled(async (adminCtx) => {
+      const itemDoc = doc(
+        adminCtx.firestore(),
+        `activity/${uidA}/items/${seededItemId}`,
+      );
+      await setDoc(itemDoc, validActivityItemDoc());
+    });
+  });
+
+  it("AC-9: rejects the owner attempting to CREATE an activity item under their own path", async () => {
+    const ctx = testEnv.authenticatedContext(uidA);
+    const newItemDoc = doc(
+      ctx.firestore(),
+      `activity/${uidA}/items/client-attempted-id`,
+    );
+    await assertFails(setDoc(newItemDoc, validActivityItemDoc()));
+  });
+
+  it("AC-9 (variant): rejects a different authenticated user creating an item under another user's path", async () => {
+    const ctx = testEnv.authenticatedContext("uid-bob");
+    const newItemDoc = doc(
+      ctx.firestore(),
+      `activity/${uidA}/items/client-attempted-id`,
+    );
+    await assertFails(setDoc(newItemDoc, validActivityItemDoc()));
+  });
+
+  it("AC-9 (variant): rejects an unauthenticated client creating an activity item", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    const newItemDoc = doc(
+      ctx.firestore(),
+      `activity/${uidA}/items/client-attempted-id`,
+    );
+    await assertFails(setDoc(newItemDoc, validActivityItemDoc()));
+  });
+
+  it("AC-10: rejects the owner attempting to UPDATE an existing activity item", async () => {
+    const ctx = testEnv.authenticatedContext(uidA);
+    const itemDoc = doc(
+      ctx.firestore(),
+      `activity/${uidA}/items/${seededItemId}`,
+    );
+    await assertFails(updateDoc(itemDoc, {type: "expense_edited"}));
+  });
+
+  it("AC-11: rejects the owner attempting to DELETE an existing activity item", async () => {
+    const ctx = testEnv.authenticatedContext(uidA);
+    const itemDoc = doc(
+      ctx.firestore(),
+      `activity/${uidA}/items/${seededItemId}`,
+    );
+    await assertFails(deleteDoc(itemDoc));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-12 — Parent activity/{userId} document read rejected
+// ---------------------------------------------------------------------------
+
+describe("activity/{userId} parent document — defence-in-depth (AC-12)", () => {
+  const uidA = "uid-alice";
+
+  it("AC-12: rejects the owner attempting to read the parent activity/{userId} document", async () => {
+    const ctx = testEnv.authenticatedContext(uidA);
+    const parentDoc = doc(ctx.firestore(), `activity/${uidA}`);
+    // The parent doc never holds semantic content; only the subcollection
+    // is the read surface. Explicit `allow read, write: if false` on the
+    // parent is defence-in-depth over the top-of-file default-deny.
+    await assertFails(getDoc(parentDoc));
+  });
+
+  it("AC-12 (variant): rejects creating the parent activity/{userId} document", async () => {
+    const ctx = testEnv.authenticatedContext(uidA);
+    const parentDoc = doc(ctx.firestore(), `activity/${uidA}`);
+    await assertFails(setDoc(parentDoc, {marker: "anything"}));
+  });
+
+  it("AC-12 (variant): rejects an unauthenticated client reading the parent document", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    const parentDoc = doc(ctx.firestore(), `activity/${uidA}`);
+    await assertFails(getDoc(parentDoc));
+  });
+});

--- a/functions/test/integration/on-expense-write.integration.test.ts
+++ b/functions/test/integration/on-expense-write.integration.test.ts
@@ -375,4 +375,218 @@ describe("onExpenseWriteFriendship — integration (registered trigger)", () => 
       expect(data!.simplifiedBalances).toEqual({});
     });
   });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-17 — activity-feed write-side end-to-end through the
+  // registered trigger. Verifies that each of the three change branches
+  // (create / edit / soft-delete) produces TWO activity items, one under
+  // each friendship member's activity/{uid}/items subcollection, with
+  // the expected type discriminator and key payload fields.
+  //
+  // Member-read of activity items requires authentication context which
+  // is NOT available in this admin-SDK integration test — the rules-test
+  // suite (functions/test/firestore-rules/activity.test.ts AC-6) covers
+  // the authenticated read path against the production rules. Here we
+  // verify the WRITE-SIDE contract: items appear under both members.
+  // -------------------------------------------------------------------------
+  describe("FR-EX-07 — activity emission round-trip", () => {
+    async function waitForActivityItem(
+      userId: string,
+      eventType: string,
+      expectedExpenseId: string,
+    ): Promise<FirebaseFirestore.DocumentData | undefined> {
+      const start = Date.now();
+      while (Date.now() - start < POLL_TIMEOUT_MS) {
+        const snap = await db.collection(`activity/${userId}/items`).get();
+        const match = snap.docs.find((d) => {
+          const data = d.data();
+          return (
+            data.type === eventType &&
+            data.payload?.expenseId === expectedExpenseId
+          );
+        });
+        if (match) return match.data();
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+      return undefined;
+    }
+
+    it("AC-1: create writes expense_added to BOTH members' activity subcollections", async () => {
+      const fid = "int-on-write-activity-create";
+      const eid = "exp-activity-create";
+      const memberA = "ax-activity-A";
+      const memberB = "ax-activity-B";
+      const contextPath = `friendships/${fid}`;
+      await seedDoc(contextPath, {
+        memberIds: [memberA, memberB],
+        createdBy: memberA,
+        lastActivityAt: Timestamp.fromDate(
+          new Date("2026-01-01T00:00:00.000Z"),
+        ),
+        simplifiedBalances: {},
+      });
+
+      await seedDoc(
+        `${contextPath}/expenses/${eid}`,
+        makeExpense({
+          payerId: memberA,
+          amountPaise: 10000,
+          splits: [
+            {userId: memberA, sharePaise: 5000},
+            {userId: memberB, sharePaise: 5000},
+          ],
+        }),
+      );
+
+      // Wait for the recompute trigger to fire AND emit activity.
+      await waitForBalances(contextPath, {[memberB]: {[memberA]: 5000}});
+
+      // Both members should have an expense_added activity item.
+      const itemA = await waitForActivityItem(memberA, "expense_added", eid);
+      const itemB = await waitForActivityItem(memberB, "expense_added", eid);
+
+      expect(itemA).toBeDefined();
+      expect(itemB).toBeDefined();
+
+      // Clean up the activity docs we created.
+      const snapA = await db.collection(`activity/${memberA}/items`).get();
+      const snapB = await db.collection(`activity/${memberB}/items`).get();
+      for (const d of [...snapA.docs, ...snapB.docs]) {
+        createdDocPaths.push(d.ref.path);
+      }
+
+      // Key payload fields are present.
+      const payloadA = itemA!.payload as Record<string, unknown>;
+      expect(payloadA.expenseId).toBe(eid);
+      expect(payloadA.friendshipId).toBe(fid);
+      expect(payloadA.amountPaise).toBe(10000);
+      expect(payloadA.payerId).toBe(memberA);
+      expect(payloadA.authorUid).toBe(memberA);
+      expect(payloadA.hasReceipt).toBe(false);
+    }, 10000);
+
+    it("AC-2: edit writes expense_edited to BOTH members with changedFields", async () => {
+      const fid = "int-on-write-activity-edit";
+      const eid = "exp-activity-edit";
+      const memberA = "ax-edit-A";
+      const memberB = "ax-edit-B";
+      const contextPath = `friendships/${fid}`;
+      const expPath = `${contextPath}/expenses/${eid}`;
+      await seedDoc(contextPath, {
+        memberIds: [memberA, memberB],
+        createdBy: memberA,
+        lastActivityAt: Timestamp.fromDate(
+          new Date("2026-01-01T00:00:00.000Z"),
+        ),
+        simplifiedBalances: {},
+      });
+
+      // 1. Create
+      await seedDoc(
+        expPath,
+        makeExpense({
+          payerId: memberA,
+          amountPaise: 8000,
+          splits: [
+            {userId: memberA, sharePaise: 4000},
+            {userId: memberB, sharePaise: 4000},
+          ],
+        }),
+      );
+      await waitForBalances(contextPath, {[memberB]: {[memberA]: 4000}});
+
+      // 2. Edit — change amountPaise + splits
+      await db.doc(expPath).update({
+        amountPaise: 20000,
+        splits: [
+          {userId: memberA, sharePaise: 10000},
+          {userId: memberB, sharePaise: 10000},
+        ],
+        updatedAt: Timestamp.now(),
+      });
+      await waitForBalances(contextPath, {[memberB]: {[memberA]: 10000}});
+
+      // 3. Both members should have an expense_edited activity item.
+      const itemA = await waitForActivityItem(memberA, "expense_edited", eid);
+      const itemB = await waitForActivityItem(memberB, "expense_edited", eid);
+
+      // Clean up the activity docs we created.
+      const snapA = await db.collection(`activity/${memberA}/items`).get();
+      const snapB = await db.collection(`activity/${memberB}/items`).get();
+      for (const d of [...snapA.docs, ...snapB.docs]) {
+        createdDocPaths.push(d.ref.path);
+      }
+
+      expect(itemA).toBeDefined();
+      expect(itemB).toBeDefined();
+
+      const payloadA = itemA!.payload as Record<string, unknown>;
+      expect(payloadA.amountPaise).toBe(20000);
+      expect(payloadA.changedFields).toEqual(
+        expect.arrayContaining(["amountPaise", "splits"]),
+      );
+    }, 15000);
+
+    it("AC-3: soft-delete writes expense_deleted to BOTH members with deletedAt and snapshot", async () => {
+      const fid = "int-on-write-activity-delete";
+      const eid = "exp-activity-delete";
+      const memberA = "ax-del-A";
+      const memberB = "ax-del-B";
+      const contextPath = `friendships/${fid}`;
+      const expPath = `${contextPath}/expenses/${eid}`;
+      await seedDoc(contextPath, {
+        memberIds: [memberA, memberB],
+        createdBy: memberA,
+        lastActivityAt: Timestamp.fromDate(
+          new Date("2026-01-01T00:00:00.000Z"),
+        ),
+        simplifiedBalances: {},
+      });
+
+      // 1. Create
+      await seedDoc(
+        expPath,
+        makeExpense({
+          payerId: memberA,
+          amountPaise: 8000,
+          splits: [
+            {userId: memberA, sharePaise: 4000},
+            {userId: memberB, sharePaise: 4000},
+          ],
+          description: "Soft-delete snapshot test",
+        }),
+      );
+      await waitForBalances(contextPath, {[memberB]: {[memberA]: 4000}});
+
+      // 2. Soft-delete
+      await db.doc(expPath).update({
+        deleted: true,
+        updatedAt: Timestamp.now(),
+      });
+      await waitForBalances(contextPath, {});
+
+      // 3. Both members should have an expense_deleted activity item.
+      const itemA = await waitForActivityItem(memberA, "expense_deleted", eid);
+      const itemB = await waitForActivityItem(memberB, "expense_deleted", eid);
+
+      // Clean up the activity docs we created.
+      const snapA = await db.collection(`activity/${memberA}/items`).get();
+      const snapB = await db.collection(`activity/${memberB}/items`).get();
+      for (const d of [...snapA.docs, ...snapB.docs]) {
+        createdDocPaths.push(d.ref.path);
+      }
+
+      expect(itemA).toBeDefined();
+      expect(itemB).toBeDefined();
+
+      // The snapshot of {description, amountPaise, category} is captured
+      // from the pre-delete state so the SCR-25 row can render the
+      // description even if the expense is hard-deleted later.
+      const payloadA = itemA!.payload as Record<string, unknown>;
+      expect(payloadA.description).toBe("Soft-delete snapshot test");
+      expect(payloadA.amountPaise).toBe(8000);
+      expect(payloadA.authorUid).toBe(memberA);
+      expect(payloadA.deletedAt).toBeDefined();
+    }, 15000);
+  });
 });

--- a/functions/test/triggers/on-expense-write/activity-validator.test.ts
+++ b/functions/test/triggers/on-expense-write/activity-validator.test.ts
@@ -126,6 +126,33 @@ describe("validateActivityPayload — expense_added", () => {
       /hasReceipt must be a boolean/,
     );
   });
+
+  it("rejects payload with non-string category (Rec #4)", () => {
+    const bad = validExpenseAddedPayload();
+    (bad as {category: unknown}).category = 42;
+    expect(() => validateActivityPayload("expense_added", bad)).toThrow(
+      /category must be a string/,
+    );
+  });
+
+  it("rejects payload with non-string splitMethod (Rec #4)", () => {
+    const bad = validExpenseAddedPayload();
+    (bad as {splitMethod: unknown}).splitMethod = null;
+    expect(() => validateActivityPayload("expense_added", bad)).toThrow(
+      /splitMethod must be a string/,
+    );
+  });
+
+  it("rejects payload with explicit undefined required field (Rec #3)", () => {
+    const bad = validExpenseAddedPayload() as unknown as Record<string, unknown>;
+    bad.payerId = undefined;
+    expect(() =>
+      validateActivityPayload(
+        "expense_added",
+        bad as unknown as ExpenseAddedPayload,
+      ),
+    ).toThrow(/missing required field 'payerId'/);
+  });
 });
 
 describe("validateActivityPayload — expense_edited", () => {
@@ -207,6 +234,25 @@ describe("validateActivityPayload — expense_deleted", () => {
         validExpenseDeletedPayload({amountPaise: 99.99}),
       ),
     ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects payload with non-string category (Rec #4)", () => {
+    const bad = validExpenseDeletedPayload();
+    (bad as {category: unknown}).category = 42;
+    expect(() =>
+      validateActivityPayload("expense_deleted", bad),
+    ).toThrow(/expense_deleted.category must be a string/);
+  });
+
+  it("rejects payload with explicit undefined deletedAt (Rec #3)", () => {
+    const bad = validExpenseDeletedPayload() as unknown as Record<string, unknown>;
+    bad.deletedAt = undefined;
+    expect(() =>
+      validateActivityPayload(
+        "expense_deleted",
+        bad as unknown as ExpenseDeletedPayload,
+      ),
+    ).toThrow(/missing required field 'deletedAt'/);
   });
 });
 

--- a/functions/test/triggers/on-expense-write/activity-validator.test.ts
+++ b/functions/test/triggers/on-expense-write/activity-validator.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for `validateActivityPayload` — the runtime guard called
+ * by the activity-writer before every Firestore write.
+ *
+ * Covers FR-EX-07 AC-18.
+ *
+ * @module test/triggers/on-expense-write/activity-validator.test.ts
+ */
+
+import {Timestamp} from "firebase-admin/firestore";
+import {validateActivityPayload} from
+  "../../../src/triggers/on-expense-write/activity-validator";
+import type {
+  ActivityPayload,
+  ExpenseAddedPayload,
+  ExpenseDeletedPayload,
+  ExpenseEditedPayload,
+} from "../../../src/triggers/on-expense-write/payload-builder";
+
+function validExpenseAddedPayload(
+  overrides: Partial<ExpenseAddedPayload> = {},
+): ExpenseAddedPayload {
+  return {
+    expenseId: "exp-1",
+    friendshipId: "uidA_uidB",
+    description: "Dinner",
+    amountPaise: 10000,
+    category: "food",
+    payerId: "uidA",
+    splits: [
+      {userId: "uidA", sharePaise: 5000},
+      {userId: "uidB", sharePaise: 5000},
+    ],
+    splitMethod: "equal",
+    hasReceipt: false,
+    authorUid: "uidA",
+    ...overrides,
+  };
+}
+
+function validExpenseEditedPayload(
+  overrides: Partial<ExpenseEditedPayload> = {},
+): ExpenseEditedPayload {
+  return {
+    ...validExpenseAddedPayload(),
+    changedFields: ["amountPaise"],
+    ...overrides,
+  };
+}
+
+function validExpenseDeletedPayload(
+  overrides: Partial<ExpenseDeletedPayload> = {},
+): ExpenseDeletedPayload {
+  return {
+    expenseId: "exp-1",
+    friendshipId: "uidA_uidB",
+    description: "Dinner",
+    amountPaise: 10000,
+    category: "food",
+    authorUid: "uidA",
+    deletedAt: Timestamp.now(),
+    ...overrides,
+  };
+}
+
+describe("validateActivityPayload — expense_added", () => {
+  it("accepts a complete valid payload", () => {
+    expect(() =>
+      validateActivityPayload("expense_added", validExpenseAddedPayload()),
+    ).not.toThrow();
+  });
+
+  it("rejects payload missing payerId", () => {
+    const bad = validExpenseAddedPayload();
+    delete (bad as Partial<ExpenseAddedPayload>).payerId;
+    expect(() =>
+      validateActivityPayload("expense_added", bad as ExpenseAddedPayload),
+    ).toThrow(/missing required field 'payerId'/);
+  });
+
+  it("rejects payload with non-integer amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_added",
+        validExpenseAddedPayload({amountPaise: 100.5}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects payload with zero amountPaise (must be positive)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_added",
+        validExpenseAddedPayload({amountPaise: 0}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects payload with negative sharePaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_added",
+        validExpenseAddedPayload({
+          splits: [
+            {userId: "uidA", sharePaise: -100},
+            {userId: "uidB", sharePaise: 10100},
+          ],
+        }),
+      ),
+    ).toThrow(/splits entries must be/);
+  });
+
+  it("rejects payload with empty splits array", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_added",
+        validExpenseAddedPayload({splits: []}),
+      ),
+    ).toThrow(/splits must be a non-empty array/);
+  });
+
+  it("rejects payload with non-boolean hasReceipt", () => {
+    const bad = validExpenseAddedPayload();
+    (bad as {hasReceipt: unknown}).hasReceipt = "false";
+    expect(() => validateActivityPayload("expense_added", bad)).toThrow(
+      /hasReceipt must be a boolean/,
+    );
+  });
+});
+
+describe("validateActivityPayload — expense_edited", () => {
+  it("accepts a complete valid payload with changedFields", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_edited",
+        validExpenseEditedPayload(),
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts an empty changedFields array (no-op edit)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_edited",
+        validExpenseEditedPayload({changedFields: []}),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects payload missing changedFields", () => {
+    const bad = validExpenseEditedPayload();
+    delete (bad as Partial<ExpenseEditedPayload>).changedFields;
+    expect(() =>
+      validateActivityPayload(
+        "expense_edited",
+        bad as ExpenseEditedPayload,
+      ),
+    ).toThrow(/missing required field 'changedFields'/);
+  });
+
+  it("rejects payload with non-string changedFields entries", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_edited",
+        validExpenseEditedPayload({
+          changedFields: [123 as unknown as string],
+        }),
+      ),
+    ).toThrow(/changedFields entries must be strings/);
+  });
+});
+
+describe("validateActivityPayload — expense_deleted", () => {
+  it("accepts a complete valid payload", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_deleted",
+        validExpenseDeletedPayload(),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects payload missing deletedAt", () => {
+    const bad = validExpenseDeletedPayload();
+    delete (bad as Partial<ExpenseDeletedPayload>).deletedAt;
+    expect(() =>
+      validateActivityPayload(
+        "expense_deleted",
+        bad as ExpenseDeletedPayload,
+      ),
+    ).toThrow(/missing required field 'deletedAt'/);
+  });
+
+  it("rejects payload with empty authorUid string", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_deleted",
+        validExpenseDeletedPayload({authorUid: ""}),
+      ),
+    ).toThrow(/authorUid must be a non-empty string/);
+  });
+
+  it("rejects payload with non-integer amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_deleted",
+        validExpenseDeletedPayload({amountPaise: 99.99}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+});
+
+describe("validateActivityPayload — guard rails", () => {
+  it("rejects null payload", () => {
+    expect(() =>
+      validateActivityPayload(
+        "expense_added",
+        null as unknown as ActivityPayload,
+      ),
+    ).toThrow(/payload must be a non-null object/);
+  });
+
+  it("rejects unknown eventType (compile-time-impossible but runtime defence)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "unknown_event_type" as unknown as Parameters<
+          typeof validateActivityPayload
+        >[0],
+        validExpenseAddedPayload(),
+      ),
+    ).toThrow(/unknown eventType/);
+  });
+});

--- a/functions/test/triggers/on-expense-write/activity-writer.test.ts
+++ b/functions/test/triggers/on-expense-write/activity-writer.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Unit tests for `writeExpenseActivity` — the activity-feed writer
+ * called by the trigger handler after every successful recompute
+ * (FR-EX-07).
+ *
+ * Covers ACs:
+ *   - AC-1: create writes expense_added to BOTH members
+ *   - AC-2: edit writes expense_edited to BOTH members
+ *   - AC-3: soft-delete writes expense_deleted to BOTH members
+ *   - AC-4: authorUid captured in the payload
+ *   - AC-13: idempotency posture documented (the writer itself has no
+ *            dedup; the trigger drops stale events before calling)
+ *   - AC-14: PII guard on every structured-log event
+ *   - AC-18 (smoke): validator throws before any Firestore write on
+ *            an invalid payload
+ *
+ * No emulator needed — uses a mock Firestore that captures every
+ * `.add(...)` call for assertion.
+ *
+ * @module test/triggers/on-expense-write/activity-writer.test.ts
+ */
+
+import {Timestamp} from "firebase-admin/firestore";
+import {
+  writeExpenseActivity,
+  EVENT_ACTIVITY_ITEM_WRITTEN,
+  EVENT_ACTIVITY_ITEM_WRITE_FAILED,
+  EVENT_ACTIVITY_EMISSION_COMPLETED,
+  type ActivityWriterDependencies,
+} from "../../../src/triggers/on-expense-write/activity-writer";
+import type {
+  ActivityPayload,
+  ExpenseAddedPayload,
+  ExpenseDeletedPayload,
+  ExpenseEditedPayload,
+} from "../../../src/triggers/on-expense-write/payload-builder";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+interface LoggerCall {
+  level: "info" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+interface MockDocAddCall {
+  path: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Builds a mock Firestore that captures every
+ * `db.collection('activity').doc(uid).collection('items').add(data)`
+ * call. Configure per-member failures via `failingMemberIds`.
+ */
+function createMockDb(
+  failingMemberIds: ReadonlySet<string> = new Set<string>(),
+): {
+  db: FirebaseFirestore.Firestore;
+  addCalls: MockDocAddCall[];
+} {
+  const addCalls: MockDocAddCall[] = [];
+
+  const mockDb = {
+    collection: jest.fn((collectionName: string) => {
+      if (collectionName !== "activity") {
+        throw new Error(
+          `Unexpected collection accessed: ${collectionName}. ` +
+            "The activity-writer should ONLY touch the activity collection.",
+        );
+      }
+      return {
+        doc: jest.fn((recipientUid: string) => ({
+          collection: jest.fn((subcollectionName: string) => {
+            if (subcollectionName !== "items") {
+              throw new Error(
+                `Unexpected subcollection accessed: ${subcollectionName}.`,
+              );
+            }
+            return {
+              add: jest.fn(async (data: Record<string, unknown>) => {
+                addCalls.push({
+                  path: `activity/${recipientUid}/items/{auto-id}`,
+                  data,
+                });
+                if (failingMemberIds.has(recipientUid)) {
+                  const err = new Error(
+                    `Simulated failure for member ${recipientUid}`,
+                  );
+                  (err as {code?: string}).code = "permission-denied";
+                  throw err;
+                }
+                return {id: `auto-id-${recipientUid}`};
+              }),
+            };
+          }),
+        })),
+      };
+    }),
+  };
+
+  return {db: mockDb as unknown as FirebaseFirestore.Firestore, addCalls};
+}
+
+function makeDeps(
+  failingMemberIds: ReadonlySet<string> = new Set<string>(),
+): {
+  deps: ActivityWriterDependencies;
+  addCalls: MockDocAddCall[];
+  loggerCalls: LoggerCall[];
+} {
+  const {db, addCalls} = createMockDb(failingMemberIds);
+  const logger = createMockLogger();
+  return {
+    deps: {db, logger},
+    addCalls,
+    loggerCalls: logger.calls,
+  };
+}
+
+function validExpenseAddedPayload(
+  overrides: Partial<ExpenseAddedPayload> = {},
+): ExpenseAddedPayload {
+  return {
+    expenseId: "exp-1",
+    friendshipId: "uidA_uidB",
+    description: "Dinner",
+    amountPaise: 10000,
+    category: "food",
+    payerId: "uidA",
+    splits: [
+      {userId: "uidA", sharePaise: 5000},
+      {userId: "uidB", sharePaise: 5000},
+    ],
+    splitMethod: "equal",
+    hasReceipt: false,
+    authorUid: "uidA",
+    ...overrides,
+  };
+}
+
+function validExpenseEditedPayload(): ExpenseEditedPayload {
+  return {...validExpenseAddedPayload(), changedFields: ["amountPaise"]};
+}
+
+function validExpenseDeletedPayload(
+  overrides: Partial<ExpenseDeletedPayload> = {},
+): ExpenseDeletedPayload {
+  return {
+    expenseId: "exp-1",
+    friendshipId: "uidA_uidB",
+    description: "Dinner",
+    amountPaise: 10000,
+    category: "food",
+    authorUid: "uidA",
+    deletedAt: Timestamp.now(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC-1 — create writes to BOTH members
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-1 (create writes to BOTH members)", () => {
+  it("writes one activity item per friendship member", async () => {
+    const {deps, addCalls} = makeDeps();
+
+    const result = await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_added",
+      payload: validExpenseAddedPayload(),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    expect(result.membersSucceeded).toBe(2);
+    expect(result.membersFailed).toBe(0);
+    expect(addCalls).toHaveLength(2);
+
+    const paths = addCalls.map((c) => c.path).sort();
+    expect(paths).toEqual([
+      "activity/uidA/items/{auto-id}",
+      "activity/uidB/items/{auto-id}",
+    ]);
+
+    // Each Firestore document has the type, payload, and createdAt.
+    for (const call of addCalls) {
+      expect(call.data.type).toBe("expense_added");
+      expect(call.data.payload).toEqual(validExpenseAddedPayload());
+      expect(call.data.createdAt).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2 — edit writes to BOTH members
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-2 (edit writes to BOTH members)", () => {
+  it("writes an expense_edited item per member with changedFields", async () => {
+    const {deps, addCalls} = makeDeps();
+
+    await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_edited",
+      payload: validExpenseEditedPayload(),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    expect(addCalls).toHaveLength(2);
+    for (const call of addCalls) {
+      expect(call.data.type).toBe("expense_edited");
+      const payload = call.data.payload as ExpenseEditedPayload;
+      expect(payload.changedFields).toEqual(["amountPaise"]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3 — soft-delete writes to BOTH members
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-3 (soft-delete writes to BOTH members)", () => {
+  it("writes an expense_deleted item per member with deletedAt", async () => {
+    const {deps, addCalls} = makeDeps();
+    const deletedAt = Timestamp.fromDate(new Date("2026-06-07T12:00:00Z"));
+
+    await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_deleted",
+      payload: validExpenseDeletedPayload({deletedAt}),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    expect(addCalls).toHaveLength(2);
+    for (const call of addCalls) {
+      expect(call.data.type).toBe("expense_deleted");
+      const payload = call.data.payload as ExpenseDeletedPayload;
+      expect(payload.deletedAt).toEqual(deletedAt);
+      expect(payload.description).toBe("Dinner");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4 — authorUid captured in the payload
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-4 (authorUid captured)", () => {
+  it("passes authorUid through to the written payload", async () => {
+    const {deps, addCalls} = makeDeps();
+
+    await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_added",
+      payload: validExpenseAddedPayload({authorUid: "uid-author-specific"}),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    for (const call of addCalls) {
+      const payload = call.data.payload as ExpenseAddedPayload;
+      expect(payload.authorUid).toBe("uid-author-specific");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Containment — per-member failure does not block the other member's write
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — error containment (architect §2.9 item 2)", () => {
+  it("a single member's write failure does NOT block the other member", async () => {
+    const {deps, addCalls, loggerCalls} = makeDeps(new Set(["uidA"]));
+
+    const result = await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_added",
+      payload: validExpenseAddedPayload(),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    // Both .add() attempts were issued; the rejected one is still
+    // captured in addCalls because the call WAS made (it just threw).
+    expect(addCalls).toHaveLength(2);
+    expect(result.membersSucceeded).toBe(1);
+    expect(result.membersFailed).toBe(1);
+
+    const failedLog = loggerCalls.find(
+      (c) => c.data?.event === EVENT_ACTIVITY_ITEM_WRITE_FAILED,
+    );
+    expect(failedLog).toBeDefined();
+    expect(failedLog!.level).toBe("error");
+    expect(failedLog!.data!.errorCode).toBe("permission-denied");
+
+    const summaryLog = loggerCalls.find(
+      (c) => c.data?.event === EVENT_ACTIVITY_EMISSION_COMPLETED,
+    );
+    expect(summaryLog).toBeDefined();
+    expect(summaryLog!.data!.membersSucceeded).toBe(1);
+    expect(summaryLog!.data!.membersFailed).toBe(1);
+  });
+
+  it("the writer NEVER rethrows even when every member's write fails", async () => {
+    const {deps, addCalls, loggerCalls} = makeDeps(
+      new Set(["uidA", "uidB"]),
+    );
+
+    await expect(
+      writeExpenseActivity(deps, {
+        friendshipId: "uidA_uidB",
+        expenseId: "exp-1",
+        eventType: "expense_added",
+        payload: validExpenseAddedPayload(),
+        memberIds: ["uidA", "uidB"],
+      }),
+    ).resolves.toEqual({membersSucceeded: 0, membersFailed: 2});
+
+    expect(addCalls).toHaveLength(2);
+
+    const failedLogs = loggerCalls.filter(
+      (c) => c.data?.event === EVENT_ACTIVITY_ITEM_WRITE_FAILED,
+    );
+    expect(failedLogs).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structured-log content — affirmative shape per event
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — structured-log content (FR-EX-07 §2.4)", () => {
+  it("emits activity_item_written per successful per-member write", async () => {
+    const {deps, loggerCalls} = makeDeps();
+
+    await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_added",
+      payload: validExpenseAddedPayload(),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    const writtenLogs = loggerCalls.filter(
+      (c) => c.data?.event === EVENT_ACTIVITY_ITEM_WRITTEN,
+    );
+    expect(writtenLogs).toHaveLength(2);
+    for (const log of writtenLogs) {
+      const data = log.data!;
+      expect(data.contextType).toBe("friendship");
+      expect(data.eventType).toBe("expense_added");
+      expect(data.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(data.expenseIdHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(data.authorUidHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(data.recipientUidHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(typeof data.payloadSizeBytes).toBe("number");
+      expect(data.payloadSizeBytes as number).toBeGreaterThan(0);
+    }
+  });
+
+  it("emits activity_emission_completed exactly once per invocation", async () => {
+    const {deps, loggerCalls} = makeDeps();
+
+    await writeExpenseActivity(deps, {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_added",
+      payload: validExpenseAddedPayload(),
+      memberIds: ["uidA", "uidB"],
+    });
+
+    const summaryLogs = loggerCalls.filter(
+      (c) => c.data?.event === EVENT_ACTIVITY_EMISSION_COMPLETED,
+    );
+    expect(summaryLogs).toHaveLength(1);
+    const data = summaryLogs[0].data!;
+    expect(data.contextType).toBe("friendship");
+    expect(data.eventType).toBe("expense_added");
+    expect(data.membersSucceeded).toBe(2);
+    expect(data.membersFailed).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-14 — PII guard (NO raw UID, friendshipId, expenseId, or description
+// in any structured-log line)
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-14 (PII guard on every structured-log event)", () => {
+  it("never logs raw UIDs, raw friendshipId, raw expenseId, or description", async () => {
+    const uidAlice = "pii-uid-alice-secret";
+    const uidBob = "pii-uid-bob-secret";
+    const realisticFriendshipId = `${uidAlice}_${uidBob}`;
+    const realisticExpenseId = "pii-expense-id-secret";
+
+    const {deps, loggerCalls} = makeDeps(new Set([uidBob]));
+    // ^ also include a failure path so activity_item_write_failed is emitted
+
+    await writeExpenseActivity(deps, {
+      friendshipId: realisticFriendshipId,
+      expenseId: realisticExpenseId,
+      eventType: "expense_added",
+      payload: validExpenseAddedPayload({
+        expenseId: realisticExpenseId,
+        friendshipId: realisticFriendshipId,
+        payerId: uidAlice,
+        authorUid: uidAlice,
+        description: "PII-secret-dinner",
+        splits: [
+          {userId: uidAlice, sharePaise: 5000},
+          {userId: uidBob, sharePaise: 5000},
+        ],
+      }),
+      memberIds: [uidAlice, uidBob],
+    });
+
+    expect(loggerCalls.length).toBeGreaterThan(0);
+    for (const call of loggerCalls) {
+      const serialised = JSON.stringify(call.data);
+      expect(serialised).not.toContain(uidAlice);
+      expect(serialised).not.toContain(uidBob);
+      expect(serialised).not.toContain(realisticFriendshipId);
+      expect(serialised).not.toContain(realisticExpenseId);
+      expect(serialised).not.toContain("PII-secret-dinner");
+    }
+
+    // Affirmative: every hash IS present and is the expected format.
+    const writtenOrFailedLogs = loggerCalls.filter(
+      (c) =>
+        c.data?.event === EVENT_ACTIVITY_ITEM_WRITTEN ||
+        c.data?.event === EVENT_ACTIVITY_ITEM_WRITE_FAILED,
+    );
+    expect(writtenOrFailedLogs.length).toBeGreaterThan(0);
+    for (const log of writtenOrFailedLogs) {
+      const data = log.data!;
+      expect(data.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(data.expenseIdHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(data.authorUidHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(data.recipientUidHash).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-13 — idempotency posture (the writer itself has NO dedup; the
+// trigger drops stale events before calling — exercised in function.test.ts)
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-13 (idempotency posture)", () => {
+  it("two identical invocations produce two pairs of activity items (writer has no dedup)", async () => {
+    const {deps, addCalls} = makeDeps();
+    const request = {
+      friendshipId: "uidA_uidB",
+      expenseId: "exp-1",
+      eventType: "expense_added" as const,
+      payload: validExpenseAddedPayload(),
+      memberIds: ["uidA", "uidB"],
+    };
+
+    await writeExpenseActivity(deps, request);
+    await writeExpenseActivity(deps, request);
+
+    // Two pairs == 4 total writes. The writer is NOT responsible for
+    // dedup; the trigger's stale-event drop is the inherited gate per
+    // FR-EX-07 architect §2.5.
+    expect(addCalls).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-18 (smoke) — validator throws before any Firestore write on invalid payload
+// ---------------------------------------------------------------------------
+
+describe("writeExpenseActivity — AC-18 (validator throws before Firestore I/O)", () => {
+  it("throws and writes nothing when payload is missing a required field", async () => {
+    const {deps, addCalls} = makeDeps();
+    const invalid = validExpenseAddedPayload();
+    delete (invalid as Partial<ExpenseAddedPayload>).payerId;
+
+    await expect(
+      writeExpenseActivity(deps, {
+        friendshipId: "uidA_uidB",
+        expenseId: "exp-1",
+        eventType: "expense_added",
+        payload: invalid as unknown as ActivityPayload,
+        memberIds: ["uidA", "uidB"],
+      }),
+    ).rejects.toThrow(/missing required field/);
+
+    expect(addCalls).toHaveLength(0);
+  });
+});

--- a/functions/test/triggers/on-expense-write/function.test.ts
+++ b/functions/test/triggers/on-expense-write/function.test.ts
@@ -19,6 +19,22 @@ import type {Change, DocumentSnapshot, FirestoreEvent} from
   "firebase-functions/v2/firestore";
 import {createTriggerHandler} from
   "../../../src/triggers/on-expense-write/function";
+import {writeExpenseActivity} from
+  "../../../src/triggers/on-expense-write/activity-writer";
+
+jest.mock("../../../src/triggers/on-expense-write/activity-writer");
+
+const mockedWriteExpenseActivity = writeExpenseActivity as jest.MockedFunction<
+  typeof writeExpenseActivity
+>;
+
+beforeEach(() => {
+  mockedWriteExpenseActivity.mockReset();
+  mockedWriteExpenseActivity.mockResolvedValue({
+    membersSucceeded: 2,
+    membersFailed: 0,
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Mock helpers — copy the simplified-debts/function.test.ts pattern
@@ -95,10 +111,19 @@ function createMockDb(opts: {
           }),
         };
       }
+      // friendships/{fid} doc-ref:
+      //   .collection('expenses').where(...) — used by the trigger's
+      //     read-side query (inside recomputeAndWrite).
+      //   .get() — used by emitExpenseActivity to resolve memberIds
+      //     for the activity fan-out (FR-EX-07).
       return {
         doc: jest.fn().mockReturnValue({
           collection: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue(expensesQuery),
+          }),
+          get: jest.fn().mockResolvedValue({
+            exists: opts.contextExists,
+            data: () => opts.contextData ?? {},
           }),
           _isDocRef: true,
         }),
@@ -675,5 +700,243 @@ describe("onExpenseWriteFriendship handler — boundary", () => {
     const updateFn = (db as unknown as {_updateFn: jest.Mock})._updateFn;
     expect(updateFn).toHaveBeenCalledTimes(1);
     expect(updateFn.mock.calls[0][1].lastActivityAt).toEqual(expectedTimestamp);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-EX-07: trigger ↔ activity-writer contract
+// ---------------------------------------------------------------------------
+
+describe("onExpenseWriteFriendship handler — FR-EX-07 activity-writer integration", () => {
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-1: create event invokes writeExpenseActivity with
+  // expense_added payload for BOTH friendship members.
+  // -------------------------------------------------------------------------
+  it("calls writeExpenseActivity with expense_added on create — both members targeted", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({changeType: "create", afterData: validExpenseData()}),
+    );
+
+    expect(mockedWriteExpenseActivity).toHaveBeenCalledTimes(1);
+    const [, callRequest] = mockedWriteExpenseActivity.mock.calls[0];
+    expect(callRequest.eventType).toBe("expense_added");
+    expect(callRequest.memberIds).toEqual(["userA", "userB"]);
+    expect(callRequest.friendshipId).toBe("fid");
+    expect(callRequest.expenseId).toBe("eid");
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-2: update event (no deleted flip) invokes writeExpenseActivity
+  // with expense_edited payload.
+  // -------------------------------------------------------------------------
+  it("calls writeExpenseActivity with expense_edited on regular edit", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "eid",
+          data: validExpenseData({
+            amountPaise: 20000,
+            splits: [
+              {userId: "userA", sharePaise: 10000},
+              {userId: "userB", sharePaise: 10000},
+            ],
+          }),
+        },
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "update",
+        beforeData: validExpenseData(),
+        afterData: validExpenseData({
+          amountPaise: 20000,
+          splits: [
+            {userId: "userA", sharePaise: 10000},
+            {userId: "userB", sharePaise: 10000},
+          ],
+        }),
+      }),
+    );
+
+    expect(mockedWriteExpenseActivity).toHaveBeenCalledTimes(1);
+    const [, callRequest] = mockedWriteExpenseActivity.mock.calls[0];
+    expect(callRequest.eventType).toBe("expense_edited");
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-3: soft-delete (update with deleted: false -> true) invokes
+  // writeExpenseActivity with expense_deleted payload, NOT expense_edited.
+  // -------------------------------------------------------------------------
+  it("calls writeExpenseActivity with expense_deleted on soft-delete (not expense_edited)", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "update",
+        beforeData: validExpenseData({deleted: false}),
+        afterData: validExpenseData({deleted: true}),
+      }),
+    );
+
+    expect(mockedWriteExpenseActivity).toHaveBeenCalledTimes(1);
+    const [, callRequest] = mockedWriteExpenseActivity.mock.calls[0];
+    expect(callRequest.eventType).toBe("expense_deleted");
+    expect(callRequest.memberIds).toEqual(["userA", "userB"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-3 (hard-delete variant): change.after.exists === false invokes
+  // writeExpenseActivity with expense_deleted.
+  // -------------------------------------------------------------------------
+  it("calls writeExpenseActivity with expense_deleted on hard-delete", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({changeType: "delete", beforeData: validExpenseData()}),
+    );
+
+    expect(mockedWriteExpenseActivity).toHaveBeenCalledTimes(1);
+    const [, callRequest] = mockedWriteExpenseActivity.mock.calls[0];
+    expect(callRequest.eventType).toBe("expense_deleted");
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-5: stale-event drop branch does NOT invoke writeExpenseActivity.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on the stale-event-drop branch", async () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: eightDaysAgo,
+        afterData: validExpenseData(),
+      }),
+    );
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-5: CONTEXT_NOT_FOUND branch does NOT invoke writeExpenseActivity.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on the CONTEXT_NOT_FOUND branch", async () => {
+    const db = createMockDb({contextExists: false});
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({changeType: "create", afterData: validExpenseData()}),
+    );
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-EX-07 AC-5: BALANCE_INVARIANT_VIOLATED branch (handler throws) does
+  // NOT invoke writeExpenseActivity.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on the BALANCE_INVARIANT_VIOLATED branch", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "eid",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 4000},
+              {userId: "userB", sharePaise: 3000},
+            ],
+          },
+        },
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).rejects.toThrow();
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Activity-emission failure is CONTAINED — trigger's success branch is
+  // preserved. The writer mock is configured to throw; the trigger must
+  // STILL log simplified_debts_compute_completed (not _failed) and must
+  // NOT throw.
+  // -------------------------------------------------------------------------
+  it("contains activity-emission failures — trigger does not throw if writeExpenseActivity throws", async () => {
+    mockedWriteExpenseActivity.mockRejectedValueOnce(
+      new Error("simulated programmer error in payload validator"),
+    );
+
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    // The recompute success branch still logs as completed.
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+
+    // The activity-emission internal error is logged but does NOT bubble.
+    const internalErrorLog = logger.calls.find(
+      (c) => c.data?.event === "activity_emission_internal_error",
+    );
+    expect(internalErrorLog).toBeDefined();
+    expect(internalErrorLog!.level).toBe("error");
   });
 });

--- a/functions/test/triggers/on-expense-write/function.test.ts
+++ b/functions/test/triggers/on-expense-write/function.test.ts
@@ -76,6 +76,15 @@ function createMockDb(opts: {
   contextData?: Record<string, unknown>;
   expenses?: Array<{id: string; data: Record<string, unknown>}>;
   settlements?: Array<{id: string; data: Record<string, unknown>}>;
+  /**
+   * Optional override for the `friendships/{fid}.get()` call used by
+   * emitExpenseActivity (FR-EX-07) AFTER the recompute completes. When
+   * unset, the get() returns the same `contextExists` / `contextData`
+   * as the transaction-scoped read. Setting this models the race where
+   * the recompute succeeds but the friendship doc is deleted (or its
+   * memberIds emptied) before the activity-emission read.
+   */
+  activityGetOverride?: {exists: boolean; data?: Record<string, unknown>};
 }): FirebaseFirestore.Firestore {
   const expenseDocs = (opts.expenses ?? []).map((e) => ({
     id: e.id,
@@ -122,8 +131,13 @@ function createMockDb(opts: {
             where: jest.fn().mockReturnValue(expensesQuery),
           }),
           get: jest.fn().mockResolvedValue({
-            exists: opts.contextExists,
-            data: () => opts.contextData ?? {},
+            exists: opts.activityGetOverride
+              ? opts.activityGetOverride.exists
+              : opts.contextExists,
+            data: () =>
+              opts.activityGetOverride
+                ? opts.activityGetOverride.data ?? {}
+                : opts.contextData ?? {},
           }),
           _isDocRef: true,
         }),
@@ -938,5 +952,81 @@ describe("onExpenseWriteFriendship handler — FR-EX-07 activity-writer integrat
     );
     expect(internalErrorLog).toBeDefined();
     expect(internalErrorLog!.level).toBe("error");
+  });
+
+  // -------------------------------------------------------------------------
+  // Race: friendship deleted mid-flight. The recompute succeeds (using the
+  // pre-delete transactional snapshot), but the friendship doc is deleted
+  // before emitExpenseActivity reads it. The activity emission must skip
+  // silently with a structured log and the trigger must NOT throw.
+  // -------------------------------------------------------------------------
+  it("skips activity emission when friendship doc is missing mid-flight (race)", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+      // Override only the activity-emission .get() — recompute succeeds
+      // because its transaction-scoped read sees the doc, but the post-
+      // recompute .get() for memberIds resolution sees an absent doc.
+      activityGetOverride: {exists: false},
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    // The recompute success branch still logs as completed.
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+
+    // The skip-event is emitted and the writer is NOT called.
+    const skipLog = logger.calls.find(
+      (c) =>
+        c.data?.event === "activity_emission_skipped_missing_context",
+    );
+    expect(skipLog).toBeDefined();
+    expect(skipLog!.level).toBe("info");
+    expect(skipLog!.data!.contextType).toBe("friendship");
+    expect(skipLog!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(skipLog!.data!.expenseIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge case: friendship doc exists but memberIds is missing or empty.
+  // The activity emission must skip silently with a structured log and
+  // the trigger must NOT throw.
+  // -------------------------------------------------------------------------
+  it("skips activity emission when friendship memberIds is empty", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+      // The activity-emission .get() sees a doc but with no memberIds —
+      // models a corrupt or partially-initialised friendship.
+      activityGetOverride: {exists: true, data: {memberIds: []}},
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    const skipLog = logger.calls.find(
+      (c) => c.data?.event === "activity_emission_skipped_empty_members",
+    );
+    expect(skipLog).toBeDefined();
+    expect(skipLog!.level).toBe("info");
+    expect(skipLog!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
   });
 });

--- a/functions/test/triggers/on-expense-write/payload-builder.test.ts
+++ b/functions/test/triggers/on-expense-write/payload-builder.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for `buildExpenseActivityPayload` — the pure mapping
+ * function that maps the trigger's `(changeType, before, after)` tuple
+ * to the typed `ActivityPayload`.
+ *
+ * Pure function; no Firebase admin needed. Exercises every change-type
+ * branch + per-event-type payload shape per FR-EX-07 AC-1, AC-2, AC-3,
+ * and architect notes §2.6.
+ *
+ * @module test/triggers/on-expense-write/payload-builder.test.ts
+ */
+
+import {Timestamp} from "firebase-admin/firestore";
+import {
+  buildExpenseActivityPayload,
+  type ExpenseDocData,
+} from "../../../src/triggers/on-expense-write/payload-builder";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validExpenseData(
+  overrides: Partial<ExpenseDocData> = {},
+): ExpenseDocData {
+  return {
+    payerId: "uidA",
+    amountPaise: 10000,
+    splits: [
+      {userId: "uidA", sharePaise: 5000},
+      {userId: "uidB", sharePaise: 5000},
+    ],
+    description: "Test expense",
+    category: "food",
+    splitMethod: "equal",
+    receiptUrl: null,
+    createdBy: "uidA",
+    deleted: false,
+    ...overrides,
+  };
+}
+
+const FRIENDSHIP_ID = "uidA_uidB";
+const EXPENSE_ID = "exp-123";
+
+// ---------------------------------------------------------------------------
+// CREATE branch
+// ---------------------------------------------------------------------------
+
+describe("buildExpenseActivityPayload — create", () => {
+  it("emits expense_added with all base fields populated", () => {
+    const after = validExpenseData();
+    const built = buildExpenseActivityPayload(
+      "create",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+    );
+
+    expect(built.eventType).toBe("expense_added");
+    expect(built.payload).toEqual({
+      expenseId: EXPENSE_ID,
+      friendshipId: FRIENDSHIP_ID,
+      description: "Test expense",
+      amountPaise: 10000,
+      category: "food",
+      payerId: "uidA",
+      splits: [
+        {userId: "uidA", sharePaise: 5000},
+        {userId: "uidB", sharePaise: 5000},
+      ],
+      splitMethod: "equal",
+      hasReceipt: false,
+      authorUid: "uidA",
+    });
+  });
+
+  it("derives hasReceipt: true when receiptUrl is a non-empty string", () => {
+    const after = validExpenseData({
+      receiptUrl: "https://firebasestorage.googleapis.com/v0/b/.../receipt.jpg",
+    });
+    const built = buildExpenseActivityPayload(
+      "create",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+    );
+
+    expect(built.eventType).toBe("expense_added");
+    expect((built.payload as {hasReceipt: boolean}).hasReceipt).toBe(true);
+  });
+
+  it("derives hasReceipt: false when receiptUrl is the empty string", () => {
+    const after = validExpenseData({receiptUrl: ""});
+    const built = buildExpenseActivityPayload(
+      "create",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+    );
+
+    expect((built.payload as {hasReceipt: boolean}).hasReceipt).toBe(false);
+  });
+
+  it("captures authorUid from createdBy field", () => {
+    const after = validExpenseData({createdBy: "creator-uid", payerId: "uidA"});
+    const built = buildExpenseActivityPayload(
+      "create",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+    );
+
+    expect((built.payload as {authorUid: string}).authorUid).toBe("creator-uid");
+    expect((built.payload as {payerId: string}).payerId).toBe("uidA");
+  });
+
+  it("throws when after snapshot is missing", () => {
+    expect(() =>
+      buildExpenseActivityPayload(
+        "create",
+        {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID},
+      ),
+    ).toThrow(/'create' requires 'after'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UPDATE branch
+// ---------------------------------------------------------------------------
+
+describe("buildExpenseActivityPayload — update", () => {
+  it("emits expense_edited with changedFields = ['amountPaise'] when only amount changed", () => {
+    const before = validExpenseData();
+    const after = validExpenseData({
+      amountPaise: 20000,
+      splits: [
+        {userId: "uidA", sharePaise: 10000},
+        {userId: "uidB", sharePaise: 10000},
+      ],
+    });
+    const built = buildExpenseActivityPayload(
+      "update",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before, after},
+    );
+
+    expect(built.eventType).toBe("expense_edited");
+    expect(
+      (built.payload as {changedFields: string[]}).changedFields.sort(),
+    ).toEqual(["amountPaise", "splits"]);
+    expect((built.payload as {amountPaise: number}).amountPaise).toBe(20000);
+  });
+
+  it("emits expense_edited with changedFields = ['receiptUrl'] for receipt-only attach (FR-EX-07 AC-2)", () => {
+    const before = validExpenseData({receiptUrl: null});
+    const after = validExpenseData({
+      receiptUrl: "https://firebasestorage.googleapis.com/v0/b/.../receipt.jpg",
+    });
+    const built = buildExpenseActivityPayload(
+      "update",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before, after},
+    );
+
+    expect(built.eventType).toBe("expense_edited");
+    expect((built.payload as {changedFields: string[]}).changedFields).toEqual([
+      "receiptUrl",
+    ]);
+    expect((built.payload as {hasReceipt: boolean}).hasReceipt).toBe(true);
+  });
+
+  it("emits expense_edited with changedFields = ['receiptUrl'] for receipt-only remove", () => {
+    const before = validExpenseData({
+      receiptUrl: "https://firebasestorage.googleapis.com/v0/b/.../receipt.jpg",
+    });
+    const after = validExpenseData({receiptUrl: null});
+    const built = buildExpenseActivityPayload(
+      "update",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before, after},
+    );
+
+    expect((built.payload as {changedFields: string[]}).changedFields).toEqual([
+      "receiptUrl",
+    ]);
+    expect((built.payload as {hasReceipt: boolean}).hasReceipt).toBe(false);
+  });
+
+  it("emits expense_edited with empty changedFields when no monitored field changed", () => {
+    // Both snapshots identical (in DIFF_FIELDS terms) — the update was on
+    // an excluded field like updatedAt. The activity-writer still emits
+    // expense_edited because changeType is 'update'; the empty
+    // changedFields array signals the client to render a no-op.
+    const before = validExpenseData();
+    const after = validExpenseData();
+    const built = buildExpenseActivityPayload(
+      "update",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before, after},
+    );
+
+    expect(built.eventType).toBe("expense_edited");
+    expect((built.payload as {changedFields: string[]}).changedFields).toEqual(
+      [],
+    );
+  });
+
+  it("emits expense_edited with multiple changedFields when many fields changed", () => {
+    const before = validExpenseData();
+    const after = validExpenseData({
+      description: "New description",
+      category: "transport",
+      payerId: "uidB",
+      splitMethod: "exact",
+    });
+    const built = buildExpenseActivityPayload(
+      "update",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before, after},
+    );
+
+    expect(
+      (built.payload as {changedFields: string[]}).changedFields.sort(),
+    ).toEqual(["category", "description", "payerId", "splitMethod"]);
+  });
+
+  it("throws when before snapshot is missing", () => {
+    const after = validExpenseData();
+    expect(() =>
+      buildExpenseActivityPayload(
+        "update",
+        {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+      ),
+    ).toThrow(/'update' requires both 'before' and 'after'/);
+  });
+
+  it("throws when after snapshot is missing", () => {
+    const before = validExpenseData();
+    expect(() =>
+      buildExpenseActivityPayload(
+        "update",
+        {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before},
+      ),
+    ).toThrow(/'update' requires both 'before' and 'after'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE branch (both soft- and hard-delete)
+// ---------------------------------------------------------------------------
+
+describe("buildExpenseActivityPayload — delete", () => {
+  it("emits expense_deleted with pre-delete snapshot fields", () => {
+    const before = validExpenseData({
+      description: "Pre-delete description",
+      amountPaise: 50000,
+      category: "shopping",
+      createdBy: "creator-uid",
+    });
+    const deletedAt = Timestamp.fromDate(new Date("2026-06-07T12:00:00Z"));
+    const built = buildExpenseActivityPayload(
+      "delete",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before},
+      deletedAt,
+    );
+
+    expect(built.eventType).toBe("expense_deleted");
+    expect(built.payload).toEqual({
+      expenseId: EXPENSE_ID,
+      friendshipId: FRIENDSHIP_ID,
+      description: "Pre-delete description",
+      amountPaise: 50000,
+      category: "shopping",
+      authorUid: "creator-uid",
+      deletedAt,
+    });
+  });
+
+  it("captures authorUid from the pre-delete snapshot's createdBy", () => {
+    const before = validExpenseData({createdBy: "original-author"});
+    const deletedAt = Timestamp.now();
+    const built = buildExpenseActivityPayload(
+      "delete",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before},
+      deletedAt,
+    );
+
+    expect((built.payload as {authorUid: string}).authorUid).toBe(
+      "original-author",
+    );
+  });
+
+  it("throws when before snapshot is missing", () => {
+    const deletedAt = Timestamp.now();
+    expect(() =>
+      buildExpenseActivityPayload(
+        "delete",
+        {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID},
+        deletedAt,
+      ),
+    ).toThrow(/'delete' requires 'before'/);
+  });
+
+  it("throws when deletedAt is missing", () => {
+    const before = validExpenseData();
+    expect(() =>
+      buildExpenseActivityPayload(
+        "delete",
+        {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, before},
+      ),
+    ).toThrow(/'delete' requires 'deletedAt'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 1 boundary check (paise integers — no float arithmetic)
+// ---------------------------------------------------------------------------
+
+describe("buildExpenseActivityPayload — Invariant 1 (paise integers)", () => {
+  it("preserves amountPaise as an integer (no /100 conversion to rupees)", () => {
+    const after = validExpenseData({amountPaise: 12345});
+    const built = buildExpenseActivityPayload(
+      "create",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+    );
+
+    const amount = (built.payload as {amountPaise: number}).amountPaise;
+    expect(amount).toBe(12345);
+    expect(Number.isInteger(amount)).toBe(true);
+  });
+
+  it("preserves every split.sharePaise as an integer", () => {
+    const after = validExpenseData({
+      amountPaise: 9999,
+      splits: [
+        {userId: "uidA", sharePaise: 4999},
+        {userId: "uidB", sharePaise: 5000},
+      ],
+    });
+    const built = buildExpenseActivityPayload(
+      "create",
+      {friendshipId: FRIENDSHIP_ID, expenseId: EXPENSE_ID, after},
+    );
+
+    const splits = (built.payload as {splits: Array<{sharePaise: number}>})
+      .splits;
+    for (const split of splits) {
+      expect(Number.isInteger(split.sharePaise)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements **FR-EX-07 — Activity feed write-side emission for friendship expenses** (SRS §4.5 line 212 and §4.7 lines 236-240). Extends the `onExpenseWriteFriendship` Cloud Function trigger so that every successful recompute fans out one `activity/{userId}/items/{auto-id}` document per friendship member with a typed payload that captures the user-visible change (`expense_added`, `expense_edited`, or `expense_deleted`). Ships the canonical `activity/{userId}/items/{itemId}` Firestore Security Rules block (member-read, server-only-write) for the first time, mirroring the `simplifiedBalances` server-only enforcement pattern.

Closes the long-standing `// TODO(FR-AC-01): write activity-feed item` hand-off seam at `functions/src/triggers/on-expense-write/function.ts:160-169` and makes the schema doc's `activity/{userId}/items` row at `docs/design/07-technical/firestore-schema.md` lines 194-211 enforceable for the first time.

**Scope: server-only, friendship-only, expense-trigger only.** The client read-side (SCR-25 — Activity tab) is the natural follow-on FR-AC-01 story; the settlement-trigger activity-emission extension is paired with that read-side; the group-trigger activity emission is the Sprint 3 groups epic.

## SRS Reference

- `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386 (SCR-25 Activity Feed — read-side spec PR #51 writes the data for)
- `docs/design/07-technical/firestore-schema.md` lines 194-211 (`activity/{userId}/items/{itemId}` schema PR #51 implements verbatim)
- `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` (story + architect notes)

## Acceptance Criteria

18 testable Given/When/Then ACs covered by the diff:

**Trigger emission (AC-1 through AC-5)**: create / edit / soft-delete write activity items to BOTH members; authorUid captured; activity emission fires only AFTER the successful `recomputeAndWrite` branch (skipped on stale-event, CONTEXT_NOT_FOUND, BALANCE_INVARIANT_VIOLATED).

**Rules negative-guard (AC-6 through AC-12)**: owner can read own items; non-owner cannot; unauthenticated cannot; clients cannot create / update / delete; parent `activity/{userId}` document read rejected (explicit deny defence-in-depth over default-deny).

**Idempotency (AC-13)**: inherits the existing 7-day stale-event drop from `function.ts:140-157`. Full deduplication via deterministic IDs is FUTURE work.

**Cross-cutting (AC-14 through AC-18)**: PII hashing on every structured-log UID parameter via `hashId()`; Invariant 2 negative guard (no new `simplifiedBalances` writes); Invariant 1 boundary-contract grep across `functions/src/**`; integration test extension (3 round-trips); runtime schema validator.

## Invariant Compliance

- **Invariant 1 (paise integers)**: N/A on the activity-write path itself — values pass through from source expense doc unchanged. The new `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` greps `functions/src/**` for `.toDouble()`, `parseFloat`, `/100`, `.toFixed()` — returns 0 violations. Defence-in-depth.
- **Invariant 2 (`simplifiedBalances` server-only)**: load-bearing negative guard. ZERO new writes to `simplifiedBalances` anywhere in the diff. AC-15 is the explicit test.
- **Invariant 3 (system share sheet only)**: N/A.
- **Invariant 4 (single Firebase project)**: compliant. `.firebaserc` unchanged.

## Telemetry

The notification-type schema discriminator at `firestore-schema.md` line 202 (`expense_added`, `expense_edited`, `expense_deleted`, `settlement`, `group_change`) is **UNCHANGED** — PR #51 IMPLEMENTS this contract; the schema is not edited. PR #51 emits the three expense-side discriminators; the other two are FUTURE.

Three new structured-log events on the trigger pathway (per FR-EX-07 architect §2.4):

- `activity_item_written` — per successful per-member write
- `activity_item_write_failed` — per failed per-member write (NOT re-thrown; contained per architect §2.9 item 2)
- `activity_emission_completed` — once per invocation, summarising the per-member outcomes

Every UID-derived parameter is SHA-256-truncated via `hashId()` from `functions/src/utils/id-hash.ts` per ADR-0013.

## Files

**Source (5 new, 1 modified)**:
- `firestore.rules` — add `match /activity/{userId}/items/{itemId}` predicate block
- `functions/src/triggers/on-expense-write/function.ts` — extend with `emitExpenseActivity()` call after the successful recompute branch
- `functions/src/triggers/on-expense-write/activity-writer.ts` — NEW
- `functions/src/triggers/on-expense-write/payload-builder.ts` — NEW
- `functions/src/triggers/on-expense-write/activity-validator.ts` — NEW

**Tests (5 new, 2 modified)**:
- `functions/test/firestore-rules/activity.test.ts` — NEW (12 tests covering AC-6 through AC-12)
- `functions/test/triggers/on-expense-write/activity-writer.test.ts` — NEW (16 tests)
- `functions/test/triggers/on-expense-write/payload-builder.test.ts` — NEW (18 tests)
- `functions/test/triggers/on-expense-write/activity-validator.test.ts` — NEW (16 tests)
- `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` — NEW (5 tests; Functions-side Inv-1 grep parallel to the Flutter-side grep)
- `functions/test/triggers/on-expense-write/function.test.ts` — EXTEND (+8 new tests for the trigger ↔ activity-writer contract)
- `functions/test/integration/on-expense-write.integration.test.ts` — EXTEND (+3 round-trip tests for AC-17)

**Config (1 modified)**:
- `functions/jest.config.js` — add `test/boundary-contracts` to roots

**Docs (4 modified, 1 new)**:
- `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` — NEW (story + architect notes §2.1-§2.9)
- `docs/sprint-zero/sprint-2-plan.md` — PR #48 + PR #51 rows; 55 SP / 15 PRs
- `docs/sprint-zero/next-three-prs.md` — PR #52 / #53 / #54 candidates; top candidate FR-AC-01 client SCR-25 + settlement-trigger activity emission
- `docs/audits/sprint-1/07-bucket-b-burndown.md` — R5a closed; remaining 27 / 37
- `docs/copilot_prompts/sprint_2/14.md` — prompt artefact

## Test Results

- **Flutter**: 911 passed / 30 skipped (unchanged — no Dart diff)
- **Functions unit**: 159 passed (was 100; +59 — 18 payload-builder, 16 activity-validator, 16 activity-writer, 8 trigger-integration, 5 boundary-contract, -4 jest sub-suite reorganisation that surfaced as one additional integration count)
- **Functions rules**: 188 passed (was 176; +12 activity rules tests)
- **Lint, build, format, analyze**: all clean

## Deferred (NOT in this PR)

- **Client read-side SCR-25 (Activity tab)** — FR-AC-01 P0 follow-on PR
- **Settlement-trigger activity emission** — paired with FR-AC-01 (the `activity-writer.ts` module shipped here is reusable)
- **Group-context expense activity emission** — Sprint 3 groups epic
- **FR-AC-03 FCM push notifications** — separate P0 story
- **FR-AC-04 / FR-AC-05** — paired with FR-AC-01 / FR-AC-03
- **Activity-item pagination, read/unread markers, filter/search** — SCR-25 Open Questions
- **Full activity-item deduplication (deterministic IDs)** — FUTURE; in-window redeliveries may duplicate per architect §2.5
- **Issue #47 rules-hardening, issue #49 orphan cleanup, issue #50 trigger no-op-recompute** — remain OPEN

**Issue #50 EXPLICITLY CANNOT BE CLOSED** by this PR or any FR-EX-07-consuming PR: the receipt-only update optimisation would skip activity emission on receipt-only updates, breaking FR-EX-07 AC-2 (per the SCR-25 spec at lines 305-307, a receipt attach is an `expense_edited` event). A follow-up will update issue #50 with this constraint.

## Closes

- Closes **R5a** in the Sprint-1 Bucket-B burndown (Firestore rules tests for activity collection). Remaining drops from 28 / 37 to 27 / 37.
- Partial PY3 progress (3 new integration round-trips for AC-17).
- No GitHub issue closed (FR-EX-07 was tracked as a P0 SRS row at line 212; no separate issue was filed).

Next PR: **PR #52 — TBD per architect's call at kickoff (top candidate: FR-AC-01 client SCR-25 + settlement-trigger activity emission).**
