### PR TITLE
feat(activity): FR-AC-01 activity feed read-side + settlement-trigger emission

### DIFF
--- a/docs/audits/sprint-1/07-bucket-b-burndown.md
+++ b/docs/audits/sprint-1/07-bucket-b-burndown.md
@@ -6,7 +6,7 @@
 > Source: `docs/audits/sprint-1/00-triage-summary.md` (Bucket B section).
 > Detail: `docs/audits/sprint-1/06-deferred-to-sprint-2.md`.
 >
-> Last updated: PR #51.
+> Last updated: PR #52.
 
 ---
 
@@ -550,3 +550,38 @@ closes **R5a** and makes partial progress on **PY3**:
 
 Net contribution of PR #51 to Bucket-B totals: **+1**. R5a closes.
 The remaining count drops to **27 / 37**.
+
+PR #52 (FR-AC-01 activity feed read-side + settlement-trigger
+activity emission) makes partial progress on **PY3** and does NOT
+close any Bucket-B items directly:
+
+- **PY3 — Expand integration tests for Sprint 2 flows:** PR #52
+  extends `functions/test/integration/on-settlement-write.integration.test.ts`
+  with two new round-trip tests for FR-AC-01 AC-18 (settlement
+  create → both parties' activity subcollections written;
+  settlement soft-delete → no new activity item per architect §2.2
+  v1.0 decision). PR #52 also adds 60+ new Flutter widget /
+  domain / formatter / provider tests across the new
+  `lib/features/activity/**` feature folder + the `OBTActivityRow`
+  widget primitive. Partial credit only; PY3 remains open pending
+  broader Flutter integration harness coverage.
+
+  Note: the existing integration tests under
+  `functions/test/integration/on-settlement-write.integration.test.ts`
+  currently fail locally with a pre-existing Functions emulator
+  load error (`functions.config() has been removed in firebase-
+  functions v7`). Verified by reproducing on `main` with PR #52
+  stashed — the failure is NOT caused by PR #52. A separate
+  infrastructure chore PR (TBD) will investigate; CI may have a
+  workaround that local runs do not.
+
+- **No Bucket-B items closed by PR #52.** The read-side is not a
+  separately tracked Bucket-B item; the rules block was already
+  shipped in PR #51 (closing R5a).
+- **No new Bucket-B items filed by PR #52.** The pre-existing
+  integration-test infrastructure issue noted above is tracked in
+  `docs/sprint-zero/next-three-prs.md` as a Sprint-3 candidate;
+  it is not a regression introduced by PR #52.
+
+Net contribution of PR #52 to Bucket-B totals: **0**. The
+remaining count stays at **27 / 37**.

--- a/docs/copilot_prompts/sprint_2/15.md
+++ b/docs/copilot_prompts/sprint_2/15.md
@@ -1,0 +1,389 @@
+1. You are the OneByTwo orchestrator agent. PR #51 (FR-EX-07 — activity feed write-side, friendship expenses) has merged (squash commit `d2302b9`) and the **write-side** of the activity-feed is now live in production: the `onExpenseWriteFriendship` trigger emits one `activity/{userId}/items/{auto-id}` document per friendship member on every create / edit / soft-delete, the `firestore.rules` block at `match /activity/{userId}/items/{itemId}` enforces member-read / server-only-write, and the reusable `activity-writer.ts` + `payload-builder.ts` + `activity-validator.ts` modules sit at `functions/src/triggers/on-expense-write/` waiting for the symmetric settlement-trigger consumer. Sprint 2 velocity through end of PR #51: **55 SP across 15 PRs**. We now implement **PR #52: FR-AC-01 — Activity tab (SCR-25) client read-side + settlement-trigger activity-emission extension**. This is the natural P0 follow-on: PR #51 wrote the data; PR #52 renders it. The settlement-trigger half is bundled because the settlement leg of SCR-25 cannot render anything until the symmetric TODO at `functions/src/triggers/on-settlement-write/function.ts:231` is closed — and the activity-writer module shipped in PR #51 is directly reusable, so the server half is small (~1-2 SP). The client half is the bulk: new `lib/features/activity/**` folder, real-time `activity/{currentUid}/items` snapshot listener, the `OBTActivityRow` widget per `docs/design/02-design-system/components.md` section 14, the `/activity` route, the FR-AC-02 deep-link routing per SCR-25 lines 328-341, the empty / error / refreshing states per SCR-25 lines 290-299, the relative-timestamp formatter per SCR-25 lines 314-326 (IST per SRS section 5.9), and the four `activity_*` telemetry events per SCR-25 lines 347-354. Story points: **8** (5 client + 1 settlement-trigger server + 1 widget + 1 routing/telemetry); escalate to 10 only if the architect bundles the cold-start-deep-link FR-AC-05 work in (NOT recommended — FCM dependency is FR-AC-03 and that's a separate P0 story).
+
+2. The numbering continues from PR #51 — **PR #52 is the next FEATURE PR.** The post-PR-#51 sequence so far: #51 (PR — feat, merged `d2302b9`), no new issues filed during PR #51 review. Issues #47 (rules-hardening), #49 (orphan-cleanup), #50 (trigger no-op optimisation — **EXPLICITLY CONSTRAINED** by FR-EX-07 AC-2: cannot close because optimisation would break activity emission on receipt-only updates) remain OPEN and are NOT touched by PR #52. The orchestrator should not assume PR #53 == GitHub issue 53 — issues and PRs share the same sequential namespace, so any new issues filed during PR #52 will consume intermediate numbers. **Pre-merge CI title-lint gotcha (verified PR #45, #46, #48, #51):** the workflow regex `[a-z0-9_-]+` rejects comma-separated scopes — use a single-token scope (e.g. `feat(activity)` or `feat(functions)`), not `feat(functions,activity)`. Since this PR spans both client (`feat(activity)`) and server (`feat(functions)`), the architect picks ONE scope for the squash-merge commit title; recommend `feat(activity)` because the client surface is the load-bearing half.
+
+3. PR #52 is the **first PR that reads from the `activity/{userId}/items` collection** and the **first PR that introduces the `lib/features/activity/**` feature folder**. The seams are already in place:
+   - **Server side (consumer of PR #51's writes):** `functions/src/triggers/on-expense-write/activity-writer.ts` exports `writeExpenseActivity(deps, request)` + the three structured-log event constants (`EVENT_ACTIVITY_ITEM_WRITTEN`, `EVENT_ACTIVITY_ITEM_WRITE_FAILED`, `EVENT_ACTIVITY_EMISSION_COMPLETED`). The settlement-trigger extension imports this module verbatim — only a sibling `settlement-payload-builder.ts` and a `validateSettlementActivityPayload` validator extension are new. The activity-payload `ActivityItemType` discriminator extends with `'settlement'` per the schema doc line 202 enumeration (currently the writer ships only the three expense-side discriminators).
+   - **Trigger side:** `functions/src/triggers/on-settlement-write/function.ts:229-242` reads verbatim:
+     ```
+     // 3. Hand-off seams for downstream stories (placement parity with
+     //    the expense trigger):
+     //    TODO(FR-AC-01): write activity-feed items to both parties'
+     //      activity/{userId}/items subcollection after successful
+     //      recompute.
+     //    TODO(FR-AC-03): send FCM push notification to the toUserId
+     //      respecting notificationPrefs.settlement.
+     //    Placement note: both seams must execute ONLY after a
+     //    successful recompute (i.e. inside or just below the success
+     //    branch at the bottom of this handler) to keep retry semantics
+     //    clean — a retryable transient failure must not duplicate
+     //    activity items or notifications. Today they are deferred
+     //    entirely; the actual placement decision lives with the story
+     //    that implements them.
+     ```
+     PR #52 closes the FR-AC-01 half of this seam (verbatim mirror of PR #51's expense-trigger extension at `function.ts:264-291`). The FR-AC-03 FCM half remains a TODO for a future P0 PR.
+   - **Client side:** `lib/features/activity/**` does NOT exist today. PR #52 creates the standard feature-first layout (data / domain / application / presentation). The `friends` and `expenses` features at `lib/features/friends/**` and `lib/features/expenses/**` are the architectural blueprints — particularly the friendsListProvider pattern (`StreamProvider` over a Firestore snapshot query). The new `activityFeedProvider` uses the same `StreamProvider<List<ActivityFeedItem>>` shape over `FirebaseFirestore.collection('activity').doc(currentUid).collection('items').orderBy('createdAt', descending: true).snapshots()`.
+   - **Routing:** Currently `lib/main.dart` routes the authenticated state to `HomePlaceholderScreen` (a bare placeholder). SCR-25 line 273 expects the Activity tab to be reachable via `OBTBottomNav` tab index 3 — but `OBTBottomNav` does NOT exist today (the component catalogue declares it but no Dart implementation ships). **Architect's call at §2.x** on whether PR #52 ships the bottom-nav shell along with the Activity tab, OR just ships the Activity screen as a standalone route pushed from a temporary entry point on the home placeholder (e.g. an "Activity" AppBar action mirroring the existing "Profile" action at `home_placeholder_screen.dart:21-31`). **Recommend Option B** (standalone route + AppBar action on HomePlaceholderScreen): the bottom-nav infrastructure is a significant UX surface that warrants its own PR (along with the Friends and Groups tabs which also don't have routes yet), and bundling it would push this PR well past 10 SP into scope creep. The standalone `/activity` route is the canonical SCR-25 contract; the bottom-nav binding is a presentational concern that lands when the tab shell ships.
+   - **OBTActivityRow widget:** declared in the component catalogue at `docs/design/02-design-system/components.md` section 14 (line 489+) but NOT implemented as a Dart widget. PR #52 ships the first implementation at `lib/core/widgets/lists/obt_activity_row.dart` (following the existing `lib/core/widgets/inputs/obt_amount_input.dart` + `lib/core/widgets/dialogs/obt_confirmation_dialog.dart` placement convention for cross-feature OBT primitives).
+   - **Deep-link routing:** SCR-25 lines 328-341 specify the per-event-type targets (`expenseAdded` / `expenseEdited` → Expense Detail; `expenseDeleted` → snackbar fallback; `settlementRecorded` → Friend Detail; group events → Group Detail; `friendAdded` → Friend Detail). PR #52 ships the routing for the expense and settlement targets (Group Detail is Sprint 3; `friendAdded` is FR-FR-01 follow-up and currently has no producer). The "this item is no longer available" snackbar fallback (per SCR-25 line 341) handles the `expenseDeleted` case AND any other "target entity no longer exists" failure.
+   - **Telemetry:** the four `activity_*` events per SCR-25 lines 347-354 (`activity_feed_viewed`, `activity_item_tapped`, `activity_feed_refreshed`, `activity_feed_error`) are new client-side analytics events. Naming follows the verb-past pattern from the Camp B decision ratified in PR #38 chore #25.
+
+4. PR #52 has **one mandatory cross-PR bundle**: the **settlement-trigger activity-emission extension**. Without it, the settlement leg of SCR-25 ("You settled up with Rahul" rows) cannot render anything — every settlement that's been recorded since PR #43 shipped has produced ZERO activity items, so the feed would only show expense rows on day one. The bundle is small (~1-2 SP): import `writeExpenseActivity` (consider renaming to `writeContextActivity` once both expense and settlement consumers exist; architect's call at §2.x) into `functions/src/triggers/on-settlement-write/function.ts`, add a `buildSettlementActivityPayload` pure function next to the existing payload-builder (or extract a sibling `settlement-payload-builder.ts`), extend the `ActivityItemType` discriminator with `'settlement'`, extend the `validateActivityPayload` switch with a new `validateSettlementPayload` branch, write the unit tests, write the integration test extension, and that's it. PR #52 must NOT bundle FR-AC-03 (FCM push notifications — separate P0 story; introduces the FCM dependency + `notificationPrefs` schema), FR-AC-04 (notification preferences — paired with FR-AC-03), FR-AC-05 (cold-start deep-link — paired with FCM since that's where the cold-start signal originates), the group-trigger activity emission (Sprint 3 groups epic), the `OBTBottomNav` shell (deferred per §3 above), or any FR-EX-09 / FR-SR-01 / FR-SR-02 related work (search / filter is SCR-25 Open Question 3 — deferred).
+
+5. Read before starting:
+   - `.github/copilot-instructions.md`
+   - `.github/shared/invariants.md` — invariant 1 (paise integers — applicable on the SCR-25 render path; the `OBTActivityRow` trailing amount MUST use `formatInrFromPaise()` per the existing boundary contract at `test/features/friends/friends_list_boundary_contract_test.dart`; ZERO inline `/100` arithmetic anywhere in `lib/features/activity/**`), invariant 2 (`simplifiedBalances` server-only — N/A on the activity-read path; PR #52 reads `activity/{uid}/items/{id}` not `simplifiedBalances`), invariant 3 (system share sheet — N/A; no sharing surface), invariant 4 (single Firebase project — defence-in-depth re-check).
+   - `.github/shared/coding-standards.md` — Dart, Riverpod, widget-test, and Conventional Commits rules. **Both the Dart section AND the Cloud Functions section are load-bearing for PR #52** — the bulk is client Dart, and the settlement-trigger extension is the symmetric mirror of the PR #51 expense-trigger extension.
+   - **Memory: PR# references in code/test files are forbidden.** Repository memory: "Do not include PR numbers (e.g. 'PR #36', 'PR #37') in comments or descriptions inside code or test files. PR references belong in docs and commit messages only." Use story IDs (FR-AC-01, FR-AC-02) in code comments instead.
+   - **Memory: money formatting via formatInrFromPaise().** Repository memory: "All paise→INR conversion goes through formatInrFromPaise(int) in lib/core/formatters/inr_formatter.dart. No inline /100 arithmetic anywhere. Boundary-contract grep enforces."
+   - **Memory: telemetry PII hashing.** Repository memory: "Use hashFriendshipId() in lib/core/telemetry/event_id_hash.dart for any telemetry parameter that would otherwise carry a deterministic friendshipId or other UID-composite identifier. SHA-256 truncated to 16 hex chars." The `activity_item_tapped` event's `entity_id` parameter MUST be hashed if the entity is a friendship (composite UID) — single-UID and expense-ID entities are NOT subject to ADR-0013.
+   - **Memory: dart format.** Repository memory: "CI runs Flutter 3.44.1 and gates on `dart format --set-exit-if-changed .`. Always run `dart format .` locally before pushing — `flutter analyze` alone does not catch formatter drift."
+   - `.github/shared/decision-log.md` — ADR-0002 (paise integers; applicable on the SCR-25 amount render), ADR-0006 (Riverpod state management — `StreamProvider` for the snapshot listener), ADR-0007 (feature-first folder layout; `lib/features/activity/**` follows the standard data / domain / application / presentation split), ADR-0013 (PII / telemetry hashing — see memory above; the `activity_item_tapped` event's entity_id is subject to ADR-0013 if it's a friendship composite UID), ADR-0014 (rules-readable user collection — the SCR-25 row may need to display the author's display name; the existing `userProfileProvider` from `lib/features/friends/application/user_profile_provider.dart` is the canonical accessor and IS rules-readable for friendship members per PR #35).
+   - `docs/patterns/feature-pr-conventions.md` — Feature-First Folder Layout, Boundary-Contract Discipline (the FR-EX-07 architect §2.9 item 7 ratified the Functions-side boundary-contract grep; PR #52 SHOULD parallel that with a `test/features/activity/activity_boundary_contract_test.dart` for the new feature folder), Telemetry-Event Discipline (verb-past pattern; `activity_feed_viewed` / `activity_item_tapped` / `activity_feed_refreshed` / `activity_feed_error` follow Camp B).
+   - `docs/OneByTwo_Requirements_Spec.md` — section 4.7 lines 236-240 (FR-AC-01 = P0, FR-AC-02 = P0; the read-side surfaces this PR implements; FR-AC-03 = P0 FCM is the natural follow-on for PR #53; FR-AC-04 = P1 notification prefs is paired with FR-AC-03; FR-AC-05 = P0 cold-start deep-link is paired with FCM), section 5.9 (timezone — IST `Asia/Kolkata` for the relative-timestamp formatter), section 5.10 (telemetry funnel — extends with the four new client-side events).
+   - `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386 — **SCR-25 Activity Feed** is the authoritative spec. PR #52 implements verbatim. Special attention: the Event Type Mapping table (lines 301-313) defines the **UI-side camelCase** discriminators (`expenseAdded`, `expenseEdited`, `expenseDeleted`, `settlementRecorded`, etc.) while the schema doc at `firestore-schema.md:202` defines the **Firestore-side snake_case** discriminators (`expense_added`, `expense_edited`, `expense_deleted`, `settlement`, `group_change`). The client mapper at `lib/features/activity/data/activity_feed_repository.dart` (or wherever the architect places it at §2.x) converts snake_case → camelCase on read; the SCR-25 spec is the camelCase contract.
+   - `docs/design/07-technical/firestore-schema.md` lines 194-211 — `activity/{userId}/items/{itemId}` document schema (`type`, `payload`, `createdAt`). The single-field descending index on `createdAt` is auto-created by Firestore on first query per line 266 — PR #52 does NOT touch `firestore.indexes.json`.
+   - `docs/design/02-design-system/components.md` section 14 (line 489+) — **OBTActivityRow** widget contract (visual description, props, states, accessibility, recommended build order). The "Recommended build order" at line 980 lists `OBTActivityRow` among the composed components — it depends on `OBTRupeeText` (`OBTActivityRow` row 974). `OBTRupeeText` does NOT exist today either; PR #52 may need to ship it as well, OR the architect at §2.x decides to inline the `formatInrFromPaise()` + `Text` widget directly into `OBTActivityRow` and defer `OBTRupeeText` to a separate OBT-primitives PR (recommend the latter — `OBTRupeeText` is a 5-line wrapper around `Text(formatInrFromPaise(paise))` that adds no semantic value beyond what `OBTActivityRow` itself needs).
+   - `docs/design/07-technical/accessibility-spec.md` — SCR-25 accessibility table at lines 358-371 of the spec. Live-region for skeleton loader. `listItem` role for activity rows. `header` for the app bar title.
+   - `docs/design/07-technical/error-and-empty-state-taxonomy.md` — error-state copy ("Something went wrong" / "We could not load your activity. Please try again."), empty-state copy ("All quiet here" / "Your activity will show up as you add expenses and settle up."), refresh-failure snackbar ("Could not refresh. Check your connection and try again.").
+   - `lib/features/friends/application/friends_list_provider.dart` — the StreamProvider blueprint PR #52's `activityFeedProvider` mirrors. Same `FirebaseFirestore.snapshots()` + map-to-domain pattern.
+   - `lib/features/friends/domain/friendship_doc.dart` — the strict-parsing precedent (drop malformed entries, report via `onParseFailure` callback). PR #52's `ActivityFeedItem.fromFirestore` follows the same pattern — malformed payloads are dropped silently with a structured-log entry (NOT exposed to the UI as an error state; the SCR-25 spec doesn't list "malformed payload" as a state, so the row simply doesn't render).
+   - `functions/src/triggers/on-settlement-write/function.ts` — extend in place per architect §2.x. Mirror the PR #51 expense-trigger extension at `function.ts:264-291` verbatim: add `emitSettlementActivity()` helper after the successful `recomputeAndWrite` branch; resolve `fromUserId` + `toUserId` from the settlement doc (which the trigger already reads — no second `.get()` needed because the change snapshot has both UIDs as required fields per the rules at `firestore.rules:445-455`); call `writeExpenseActivity` (or its renamed sibling) with `memberIds: [fromUserId, toUserId]`.
+   - **NEW** `functions/src/triggers/on-settlement-write/settlement-payload-builder.ts` — pure function `buildSettlementActivityPayload(changeType, before, after)` returning the typed `ActivityPayload` for the `settlement` event type. The settlement payload shape per the SCR-25 contract: `{ settlementId, fromUserId, toUserId, amountPaise, contextType, contextId, note?, authorUid }`. Architect ratifies the exact fields at §2.x.
+   - **NEW** `functions/src/triggers/on-expense-write/activity-validator.ts` — EXTEND with `validateSettlementPayload(payload)` per the existing per-event-type pattern. The architect's call at §2.x is whether to extend the existing file or extract a sibling — recommend extend (the validator is small and per-event-type assertions are co-located by design).
+   - `functions/test/triggers/on-settlement-write/function.test.ts` — EXTEND with the mirror of the PR #51 `function.test.ts` activity-writer tests (mock writeExpenseActivity, assert called on success branch + NOT called on stale-event / CONTEXT_NOT_FOUND / BALANCE_INVARIANT_VIOLATED / friendship-deleted-mid-flight branches).
+   - `functions/test/integration/on-settlement-write.integration.test.ts` — EXTEND with 2 round-trip tests: create-then-read for both parties; soft-delete-then-read for both parties (settlements don't have an "edit" branch per the rules at `firestore.rules:461-469` — only `deleted: false → true` is permitted; the architect at §2.x confirms this means the settlement-trigger emits ONLY `'settlement'` on create and `'settlement_deleted'` (NEW discriminator) on soft-delete, OR omits the soft-delete activity entirely. **Recommend the latter** — settlement deletion is an extremely rare operation per the FR-SE-07 contract and the SCR-25 Event Type Mapping at line 308 only lists `settlementRecorded`; there is no `settlementDeleted` row type, so the v1.0 contract is "settlement deletion does not emit an activity item". Document explicitly in architect §2.x.).
+   - **NEW** `lib/features/activity/` — feature folder per ADR-0007:
+     - `data/activity_feed_repository.dart` — Firestore snapshot listener; maps snake_case `type` → camelCase enum.
+     - `domain/activity_feed_item.dart` — sealed-class hierarchy or single class with discriminated union; one variant per `ActivityEventType` (`expenseAdded`, `expenseEdited`, `expenseDeleted`, `settlementRecorded`).
+     - `domain/activity_event_type.dart` — the camelCase enum + snake_case parser.
+     - `application/activity_feed_provider.dart` — Riverpod `StreamProvider<List<ActivityFeedItem>>`.
+     - `application/relative_timestamp_formatter.dart` — the per-SCR-25-lines-314-326 formatter (IST per SRS 5.9).
+     - `presentation/activity_feed_screen.dart` — the SCR-25 screen.
+     - `presentation/widgets/activity_feed_skeleton.dart` — the 5-row skeleton loader per SCR-25 Loading state.
+   - **NEW** `lib/core/widgets/lists/obt_activity_row.dart` — the OBTActivityRow widget (per components.md section 14).
+   - `lib/main.dart` — route the new `/activity` screen. **Architect's call at §2.x** on whether to use a Navigator-pushed `MaterialPageRoute` (canonical with PR #46 Expense Detail) or to add a `Navigator.pushNamed` registration (no current route table exists in `main.dart`). Recommend MaterialPageRoute for consistency.
+   - `lib/features/auth/presentation/home_placeholder_screen.dart` — EXTEND with an "Activity" AppBar action (mirror of the existing "Profile" action at lines 21-31). This is the temporary entry point until the bottom-nav shell ships in a future PR.
+   - `lib/core/formatters/inr_formatter.dart` — UNCHANGED. The OBTActivityRow's trailing amount uses the existing `formatInrFromPaise(int)` helper. Invariant 1 boundary-contract grep auto-covers.
+   - `lib/core/telemetry/event_id_hash.dart` — UNCHANGED. The new `activity_item_tapped` telemetry event uses `hashFriendshipId()` for `entity_id` if the entity is a friendship.
+   - `test/features/activity/**` — NEW test folder mirroring the production layout:
+     - `domain/activity_feed_item_test.dart` — `fromFirestore` parsing tests, malformed-payload drop tests.
+     - `application/activity_feed_provider_test.dart` — provider tests using `ProviderContainer` + a fake Firestore.
+     - `application/relative_timestamp_formatter_test.dart` — every SCR-25 boundary case.
+     - `presentation/activity_feed_screen_test.dart` — widget tests for Loading / Populated / Empty / Error / Refreshing states.
+     - `activity_boundary_contract_test.dart` — Inv-1 grep over `lib/features/activity/**` (no `/100`, no `.toDouble()`, etc.; mirrors `test/features/expenses/expense_creation_boundary_contract_test.dart`).
+   - `test/core/widgets/lists/obt_activity_row_test.dart` — widget tests for the OBTActivityRow primitive across all 8 event types from SCR-25 table.
+   - `docs/sprint-zero/sprint-2-plan.md` — add PR #52 row (8 SP; cumulative 63 SP / 16 PRs).
+   - `docs/sprint-zero/next-three-prs.md` — roll PR #52 to merged; PR #53 / #54 / #55 candidates (top: FR-AC-03 FCM push notifications, since it depends on the FR-AC-01 deep-link surface this PR ships).
+   - `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #52 contributes nothing new directly to Bucket B (R5a was closed by PR #51); PY3 gets partial credit for the 2 new settlement-trigger integration tests + the widget-test extensions.
+   - `scripts/dev/start-emulators.sh` — UNCHANGED. The settlement-trigger extension runs in the existing dedicated `firebase emulators:exec --only firestore,storage` session for rules tests and the existing full-emulator session for integration tests.
+   - `.github/workflows/pr.yml` — UNCHANGED. No new CI surface.
+   - **CI hygiene** — `dart format .` MUST be run before push because CI runs Flutter 3.44.1 while local toolchains may be older. Run `dart format .` as the final pre-push gate after `flutter analyze --fatal-infos`. **Functions hygiene** — `npm run lint && npm run build && npm test && npm run test:rules` MUST be green; both gates have been load-bearing on every recent PR.
+
+6. Honour the four invariants. Invariant 1 (paise integers) is **applicable on the SCR-25 render path**: the trailing amount on `OBTActivityRow` MUST use `formatInrFromPaise(int)` from `lib/core/formatters/inr_formatter.dart`; ZERO inline `/100` arithmetic anywhere in `lib/features/activity/**` or `lib/core/widgets/lists/obt_activity_row.dart`. The new `test/features/activity/activity_boundary_contract_test.dart` grep is the affirmative test. The Functions-side settlement-payload-builder also preserves the integer invariant — `amountPaise` is passed through unchanged from the source settlement doc; the existing Functions-side boundary-contract grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new files. Invariant 2 (`simplifiedBalances` server-only) — N/A on the activity-read path; the client reads `activity/{uid}/items` not `simplifiedBalances`. The settlement-trigger extension does NOT touch `simplifiedBalances` either — the existing `recomputeAndWrite` is unchanged. Invariant 3 N/A. Invariant 4: no second Firebase project — the new client surface targets the single production project; the settlement-trigger deployment is an in-place handler update.
+
+────────────────────────────────────────
+PHASE 0 — DEPENDENCY-DAG CHECK
+────────────────────────────────────────
+
+0.1  Confirm PR #51 has merged to main and the post-merge state is clean:
+     - `git log --oneline -1` on `main` shows `d2302b9 feat(functions): FR-EX-07 activity feed emission (friendship) (#51)`.
+     - `functions/src/triggers/on-expense-write/activity-writer.ts` exists (PR #51 surface — the module PR #52 consumes for the settlement half).
+     - `functions/src/triggers/on-expense-write/payload-builder.ts` exists.
+     - `functions/src/triggers/on-expense-write/activity-validator.ts` exists.
+     - `firestore.rules` has the `match /activity/{userId}/items/{itemId}` block (PR #51 closure of R5a).
+     - `functions/src/triggers/on-settlement-write/function.ts:231` still has the FR-AC-01 TODO comment — PR #51 did NOT touch the settlement trigger.
+     - `lib/features/activity/` does NOT exist.
+     - `flutter analyze --fatal-infos` + `flutter test` exit 0 (911 pass / 30 skipped post-PR-#51).
+     - `cd functions && npm run lint && npm run build && npm test` exit 0 (13 suites / 166 tests pass).
+     - `cd functions && npm run test:rules` exit 0 (9 suites / 188 tests pass).
+     - `dart format --set-exit-if-changed .` exits 0.
+     - `.firebaserc` contains exactly one project (Invariant 4 CI gate green).
+     - Issues #47 (rules-hardening), #49 (orphan-cleanup), #50 (trigger no-op optimisation) are OPEN and unchanged — PR #52 does NOT close any of them.
+
+0.2  Walk the dependency DAG for FR-AC-01 + settlement-trigger activity emission:
+     - **Firestore side (consumer of PR #51's writes + this PR's settlement writes):** the `activity/{userId}/items/{itemId}` collection. PR #52 is the first **reader** of this path tree (server is the only writer). The single-field descending index on `createdAt` auto-creates on first query.
+     - **Functions side (settlement half):** `onSettlementWrite` at `functions/src/triggers/on-settlement-write/function.ts` is the second producer of activity items (after the expense trigger from PR #51). Mirror the PR #51 architecture verbatim: success-branch emission, error containment (Promise.allSettled, no rethrow), structured-log events with PII hashing, sibling payload-builder, validator extension.
+     - **Client read side:** new `lib/features/activity/**` feature folder; new `OBTActivityRow` widget at `lib/core/widgets/lists/`; new `/activity` route; temporary entry point on `HomePlaceholderScreen`. Real-time `StreamProvider` over the Firestore snapshot listener.
+     - **Telemetry side:** four new client-side events per SCR-25 lines 347-354; one new server-side event for the settlement-activity emission (`settlement_activity_item_written` or reuse the existing `activity_item_written` with `contextType: 'friendship'` and `eventType: 'settlement'`; architect's call at §2.x — recommend REUSE).
+     - **Boundary contracts:** the existing Flutter-side grep at `test/features/expenses/expense_creation_boundary_contract_test.dart` does NOT cover `lib/features/activity/**`. PR #52 ships the parallel grep at `test/features/activity/activity_boundary_contract_test.dart`. The Functions-side grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` (shipped in PR #51) auto-covers the new settlement-payload-builder.
+
+0.3  Confirm DoR for the feature story:
+     - **No story file exists yet** for FR-AC-01 — `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md` must be created by the PM in Phase 1.
+     - Story points: **8 SP** (justification: 5 client + 1 settlement-trigger server + 1 OBTActivityRow widget + 1 routing/telemetry). Escalate to 10 only if the architect bundles `OBTBottomNav` shell (NOT recommended; deferred per §3).
+     - The story must explicitly enumerate: (a) the GitHub issue this PR closes — **none** (FR-AC-01/02 are P0 SRS rows; no separate GitHub issue exists), (b) the four-invariant applicability assessment (Inv-1 applicable on render path; Inv-2 N/A; Inv-4 defence-in-depth), (c) the cross-cutting telemetry contract (four client events + one server event), (d) the explicit decision on the soft-delete-settlement activity emission (architect §2.x ratifies "no activity item on settlement soft-delete" per the SCR-25 Event Type Mapping omission).
+
+0.4  Cross-reference the burndown:
+     - PR #52 closes **no Bucket-B items directly**. R5a (activity rules) was closed by PR #51; the read-side is not a separately-tracked Bucket-B item.
+     - PR #52 makes partial progress on **PY3** (Expand integration tests for Sprint 2 flows) — 2 new settlement-trigger integration tests + the widget tests for the activity feature.
+     - Issues #47, #49, #50 remain OPEN and are NOT touched by PR #52.
+
+────────────────────────────────────────
+PHASE 1 — STORY READINESS (PM)
+────────────────────────────────────────
+
+PM agent creates the feature story `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md` using the SRS §13.2 feature format. Story points: **8** (per §0.3).
+
+Required Given/When/Then ACs (each MUST be testable):
+
+  **Client read-side (positive ACs)**
+
+  - **AC-1 — Activity tab renders chronological feed of friendship-expense events.** Given a signed-in user is a member of friendships with at least one create / edit / soft-delete activity item each in `activity/{currentUid}/items`, when the user navigates to `/activity` (via the temporary AppBar action on HomePlaceholderScreen), then the screen displays an `OBTActivityRow` per item in reverse-chronological order (by `createdAt` desc) with the correct icon, colour, primary text, secondary text (relative timestamp), and trailing amount per the SCR-25 Event Type Mapping at lines 301-313.
+  - **AC-2 — Settlement-recorded rows render after PR #52's settlement-trigger extension.** Given a settlement is recorded between two friends, when the new `onSettlementWrite` activity emission writes one item per party, then the SCR-25 row renders with the `check_circle` icon (`success` colour) and primary text "You settled up with [other party]" (or "[other party] settled up with you" — architect's call at §2.x on the directional copy).
+  - **AC-3 — Real-time updates via snapshot listener.** Given the screen is open in Populated state, when a new activity item is written (e.g. by a friend adding an expense in another session), then the row appears at the top of the feed within the StreamProvider's next emission (no manual refresh required).
+  - **AC-4 — FR-AC-02 deep-link routing.** Given the user taps an activity row, when the event type is `expenseAdded` or `expenseEdited`, then the app navigates to the Expense Detail screen for `payload.expenseId` within `payload.friendshipId` (uses the existing route shipped in PR #46); when the event type is `settlementRecorded`, navigates to the Friend Detail screen for the other party; when the event type is `expenseDeleted` (the target no longer exists), displays `OBTSnackbar(message: "This item is no longer available.", type: info)` and remains on the Activity feed.
+  - **AC-5 — Relative timestamp format per SCR-25 lines 314-326.** Given any `createdAt` timestamp, when rendered, then the relative-timestamp string matches the SCR-25 table exactly (e.g. "Just now" < 1 min; "X min ago" 1-59 min; "X hours ago" or "1 hour ago" 1-23 hours; "Yesterday" 1 day; "X days ago" 2-6 days; "dd MMM" 7+ days same year; "dd MMM yyyy" previous year). All timestamps rendered in IST (`Asia/Kolkata`) per SRS section 5.9.
+  - **AC-6 — Empty state.** Given the `activity/{currentUid}/items` collection has zero documents, when the screen loads, then `OBTEmptyState` displays with title "All quiet here" and subtitle "Your activity will show up as you add expenses and settle up." plus the "Add Expense" CTA (which opens the existing Add Expense flow shipped in PR #38).
+  - **AC-7 — Loading state.** Given the screen first opens with no cached data, when the snapshot listener is still resolving, then `OBTSkeletonLoader` displays 5 skeleton rows with shimmer animation (suppressed to static grey if `MediaQuery.disableAnimations` is true per SRS section 5.6 reduce-motion accommodation).
+  - **AC-8 — Error state.** Given the snapshot listener errors (e.g. permission-denied if the rules block is somehow violated — defence-in-depth), when the screen renders, then `OBTErrorState` displays with title "Something went wrong", subtitle "We could not load your activity. Please try again.", and a "Retry" button that re-establishes the listener.
+  - **AC-9 — Pull-to-refresh.** Given the Populated state, when the user pulls to refresh, then the `RefreshIndicator` animates and the snapshot listener re-subscribes; on success, the indicator dismisses; on failure, `OBTSnackbar(message: "Could not refresh. Check your connection and try again.", type: error)` displays.
+
+  **Server-side settlement-trigger extension (positive ACs)**
+
+  - **AC-10 — Settlement create writes a `settlement` activity item to BOTH parties.** Given a `settlements/{settlementId}` document is created with `fromUserId: uidA, toUserId: uidB, amountPaise: N, contextType: 'friendship', contextId: 'uidA_uidB'`, when the `onSettlementWrite` trigger handles the event AFTER successful recompute, then TWO activity items are written — one at `activity/{uidA}/items/{auto-id}` and one at `activity/{uidB}/items/{auto-id}` — each with `type: 'settlement'`, payload including `{settlementId, fromUserId, toUserId, amountPaise, contextType, contextId, note?, authorUid}`, and `createdAt: <server timestamp>`.
+  - **AC-11 — Settlement soft-delete does NOT emit an activity item (v1.0 decision).** Given a settlement is soft-deleted, when the `onSettlementWrite` trigger handles the update, then NO activity item is written. Rationale: the SCR-25 Event Type Mapping does not include a `settlementDeleted` row type; settlement deletion is extremely rare per FR-SE-07; the v1.0 contract is "no activity item on settlement soft-delete". (Architect §2.x ratifies.)
+  - **AC-12 — Settlement activity emission happens AFTER the recomputeAndWrite success branch.** Given a transient recompute failure on the settlement-write path, when the trigger handler runs, then NO activity items are written. The retry on the next invocation handles both. Symmetric with the expense-trigger contract from PR #51.
+  - **AC-13 — Settlement payload validator rejects malformed inputs.** Given a programmatically-malformed payload (e.g. missing `fromUserId`), when `validateActivityPayload('settlement', payload)` is called, then it throws BEFORE any Firestore I/O. Mirrors the PR #51 AC-18 contract.
+
+  **Cross-cutting and negative ACs**
+
+  - **AC-14 — Telemetry events fire correctly.** Given the four client-side events (`activity_feed_viewed`, `activity_item_tapped`, `activity_feed_refreshed`, `activity_feed_error`), when each is emitted, then the parameters match SCR-25 lines 347-354 exactly. The `activity_item_tapped` event's `entity_id` parameter is hashed via `hashFriendshipId()` if the entity is a friendship composite UID; single-UID and expense-ID entities are NOT hashed.
+  - **AC-15 — Invariant 1 boundary contract (client).** Given the PR diff, when scanned for `.toDouble()`, `parseFloat`, `/100`, `.toFixed`, or `double` declarations on monetary fields, then ZERO violations exist anywhere in `lib/features/activity/**` or `lib/core/widgets/lists/obt_activity_row.dart`. The new `test/features/activity/activity_boundary_contract_test.dart` grep is the affirmative test.
+  - **AC-16 — Invariant 2 negative guard.** Given the PR diff, when scanned, then ZERO new writes to `simplifiedBalances` exist anywhere; the client surface is read-only on `activity/{uid}/items`; the settlement-trigger extension touches only `activity/**`, not `simplifiedBalances`.
+  - **AC-17 — PII hashing on telemetry.** Given the `activity_item_tapped` event fires with a friendship `entity_id`, when the event parameters are inspected, then the `entity_id` is the SHA-256-truncated hash via `hashFriendshipId()` from `lib/core/telemetry/event_id_hash.dart` (16 hex chars). Affirmative test in `activity_feed_screen_test.dart`.
+  - **AC-18 — Integration test extension (settlement-trigger).** Given the PR diff, when `functions/test/integration/on-settlement-write.integration.test.ts` is inspected, then 2 new round-trip tests exist: (a) settlement create-then-read for both parties asserting per-party activity-item count + type + payload; (b) settlement soft-delete asserts NO new activity item appears (per AC-11).
+
+────────────────────────────────────────
+PHASE 2 — ARCHITECT HAND-OFF
+────────────────────────────────────────
+
+Architect agent appends `## Architect Notes` to the feature story ratifying:
+
+2.1  **Bottom-nav shell deferral.** RATIFY: PR #52 does NOT ship `OBTBottomNav`; the `/activity` route is reachable via a temporary "Activity" AppBar action on `HomePlaceholderScreen` (mirror of the existing "Profile" action). The bottom-nav shell is a separate UX PR that lands when Friends + Groups + Activity + Profile tabs are all needed simultaneously (likely Sprint 3 alongside the groups epic).
+
+2.2  **Settlement soft-delete activity decision.** RATIFY: settlement soft-delete does NOT emit an activity item. The SCR-25 Event Type Mapping at line 308 only lists `settlementRecorded` (not `settlementDeleted`); settlement deletion is extremely rare per FR-SE-07 contract; v1.0 decision is "no activity item on settlement soft-delete". Document explicitly so the settlement-trigger handler's update-branch logic short-circuits cleanly.
+
+2.3  **Activity-writer reuse vs rename.** Architect's call: leave the module named `activity-writer.ts` and its public export named `writeExpenseActivity`, OR rename to `writeContextActivity` since both expense and settlement consumers now exist. **Recommend RENAME** to `writeContextActivity` — the function is generic over the context type already (the `request.eventType` parameter carries the discriminator); the "Expense" in the name is now misleading. Update all call sites (PR #51's expense-trigger handler at `function.ts:340` and the new settlement-trigger handler) and re-export with a deprecation alias for one release if needed.
+
+2.4  **Settlement payload schema.** RATIFY: `settlement` payload shape:
+     ```typescript
+     {
+       settlementId: string;
+       fromUserId: string;
+       toUserId: string;
+       amountPaise: number;       // integer (Inv-1)
+       contextType: 'friendship' | 'group';
+       contextId: string;
+       note?: string;
+       authorUid: string;          // == fromUserId per the rules at firestore.rules:445-455
+     }
+     ```
+     The validator's per-event-type required-field check enforces `settlementId, fromUserId, toUserId, amountPaise, contextType, contextId, authorUid`; `note` is optional.
+
+2.5  **Riverpod provider granularity.** RATIFY: use a single `StreamProvider<List<ActivityFeedItem>>` named `activityFeedProvider`. NO `family` parameter — the provider is per-user and the current UID is read from the existing `authStateProvider`. Mirrors the `friendsListProvider` blueprint.
+
+2.6  **OBTActivityRow widget API.** RATIFY: the widget consumes a single typed `ActivityFeedItem` (the domain model); the icon / colour / primary-text / amount derivation lives inside the widget per the SCR-25 Event Type Mapping table. The widget is placed at `lib/core/widgets/lists/obt_activity_row.dart` (matches the OBT cross-feature primitives convention). `OBTRupeeText` is NOT shipped — the trailing amount uses `Text(formatInrFromPaise(item.amountPaise))` inline (5-line wrapper deferred to a future OBT-primitives PR).
+
+2.7  **Files to touch (exhaustive — anything outside this set is scope creep):**
+     - **NEW** `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md` — story (Phase 1).
+     - `functions/src/triggers/on-settlement-write/function.ts` — extend with the activity-emission call.
+     - **NEW** `functions/src/triggers/on-settlement-write/settlement-payload-builder.ts` — pure function `buildSettlementActivityPayload`.
+     - `functions/src/triggers/on-expense-write/activity-validator.ts` — EXTEND with `validateSettlementPayload` branch.
+     - `functions/src/triggers/on-expense-write/activity-writer.ts` — EXTEND `ActivityItemType` to include `'settlement'`; OPTIONAL rename per §2.3.
+     - `functions/src/triggers/on-expense-write/payload-builder.ts` — EXTEND the `ActivityPayload` discriminated union with the new settlement payload variant (or split the union types into a sibling file at architect's call).
+     - `functions/test/triggers/on-settlement-write/function.test.ts` — EXTEND with activity-writer integration assertions (mirror of PR #51 function.test.ts).
+     - **NEW** `functions/test/triggers/on-settlement-write/settlement-payload-builder.test.ts` — per-change-type mapping tests.
+     - `functions/test/triggers/on-expense-write/activity-validator.test.ts` — EXTEND with settlement-payload validation tests.
+     - `functions/test/integration/on-settlement-write.integration.test.ts` — EXTEND with 2 round-trip tests per AC-18.
+     - **NEW** `lib/features/activity/data/activity_feed_repository.dart`
+     - **NEW** `lib/features/activity/domain/activity_feed_item.dart`
+     - **NEW** `lib/features/activity/domain/activity_event_type.dart`
+     - **NEW** `lib/features/activity/application/activity_feed_provider.dart`
+     - **NEW** `lib/features/activity/application/relative_timestamp_formatter.dart`
+     - **NEW** `lib/features/activity/presentation/activity_feed_screen.dart`
+     - **NEW** `lib/features/activity/presentation/widgets/activity_feed_skeleton.dart`
+     - **NEW** `lib/core/widgets/lists/obt_activity_row.dart`
+     - `lib/features/auth/presentation/home_placeholder_screen.dart` — add "Activity" AppBar action.
+     - **NEW** `test/features/activity/domain/activity_feed_item_test.dart`
+     - **NEW** `test/features/activity/application/activity_feed_provider_test.dart`
+     - **NEW** `test/features/activity/application/relative_timestamp_formatter_test.dart`
+     - **NEW** `test/features/activity/presentation/activity_feed_screen_test.dart`
+     - **NEW** `test/features/activity/activity_boundary_contract_test.dart`
+     - **NEW** `test/core/widgets/lists/obt_activity_row_test.dart`
+     - `docs/sprint-zero/sprint-2-plan.md` — PR #52 row (8 SP; cumulative 63 SP / 16 PRs).
+     - `docs/sprint-zero/next-three-prs.md` — roll PR #52 to merged; PR #53 / #54 / #55 candidates.
+     - `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #52 entry (no items closed; partial PY3 progress).
+
+2.8  **Files explicitly NOT to touch (negative scope guardrails):**
+     - `firestore.rules` — UNCHANGED. PR #51 shipped the activity rules block; PR #52 only reads (rules grant member-read).
+     - `firestore.indexes.json` — UNCHANGED. Single-field descending index on `createdAt` auto-creates.
+     - `storage.rules` — UNCHANGED. No Storage surface.
+     - `pubspec.yaml` / `functions/package.json` — UNCHANGED. No new dependencies.
+     - `lib/features/expenses/**`, `lib/features/friends/**`, `lib/features/settlements/**` — UNCHANGED (the new activity feature reads its own data; no edits to existing features).
+     - `functions/src/triggers/on-expense-write/function.ts` — UNCHANGED (PR #51's expense-trigger emission is already correct).
+     - `.github/workflows/*.yml` — UNCHANGED.
+     - `lib/core/widgets/dialogs/obt_confirmation_dialog.dart`, `lib/core/widgets/inputs/obt_amount_input.dart` — UNCHANGED (the new OBTActivityRow is a sibling primitive).
+
+2.9  **Anticipated reconciliations.** Document EXACTLY:
+     1. **Snake_case vs camelCase event-type discriminators.** The Firestore document stores `type: 'expense_added'` (snake_case per schema doc line 202); the SCR-25 spec uses `expenseAdded` (camelCase per lines 305-307). The client mapper in `activity_feed_repository.dart` converts on read. Unknown types are dropped (mirrors the PR #51 strict-parsing precedent for `simplifiedBalances`).
+     2. **OBTRupeeText deferral.** The components catalogue declares `OBTRupeeText` but PR #52 does not implement it (inline `Text(formatInrFromPaise(...))` instead). Future OBT-primitives PR ships the wrapper. NOT a Bucket-B item.
+     3. **OBTBottomNav deferral.** Same as §2.1. The temporary AppBar action on HomePlaceholderScreen is the v1.0 entry point until the bottom-nav shell lands.
+     4. **Activity emission on settlement soft-delete.** v1.0 decision per §2.2: no activity item. Documented in code as a comment in the settlement-trigger handler's update branch.
+     5. **Settlement activity directional copy.** Architect §2.x ratifies the primary-text copy: "You settled up with [other party]" when `currentUid === fromUserId`; "[other party] settled up with you" when `currentUid === toUserId`. The other-party display name is resolved via the existing `userProfileProvider` from PR #35.
+     6. **Cold-start deep-link (FR-AC-05) deferral.** PR #52 ships the FR-AC-02 in-app deep-link routing. The FR-AC-05 cold-start deep-link (from a tapped push notification when the app is not running) is paired with FR-AC-03 FCM (the push notification IS the trigger for the cold-start signal). Separate P0 story.
+     7. **Read/unread markers deferral.** SCR-25 Open Question 1: the components catalogue defines an `Unread` state for `OBTActivityRow` (3 dp `primary` left-edge bar). v1.1 candidate per SCR; PR #52 does NOT ship this — every row is rendered as "read".
+     8. **Pagination deferral.** SCR-25 Open Question 2: cursor-based pagination for users with extensive history. v1.0 loads all activity items via the single snapshot listener; the architect at §2.x flags the cutoff at which performance degrades (rough estimate: ~1000 items before frame budget is exceeded). FUTURE work.
+
+────────────────────────────────────────
+PHASE 3 — SCOPE GUARDRAILS
+────────────────────────────────────────
+
+WHAT GOES IN PR #52:
+
+  - All files listed in §2.7.
+  - The FR-AC-02 in-app deep-link routing for `expenseAdded` / `expenseEdited` / `settlementRecorded`.
+  - The settlement-trigger activity emission for `'settlement'` event type.
+  - The four client-side telemetry events per SCR-25 lines 347-354.
+  - The temporary "Activity" AppBar action on `HomePlaceholderScreen`.
+  - The story + Architect Notes.
+  - Plan + burndown roll-ups (Phase 7).
+
+WHAT DOES NOT GO IN PR #52:
+
+  - **`OBTBottomNav` shell** — deferred per §2.1; v1.0 uses the AppBar-action entry point.
+  - **`OBTRupeeText`** — deferred per §2.6; inline `formatInrFromPaise` usage.
+  - **FR-AC-03 FCM push notifications** — separate P0 story.
+  - **FR-AC-04 notification preferences** — paired with FR-AC-03.
+  - **FR-AC-05 cold-start deep-link** — paired with FR-AC-03 (FCM is the cold-start trigger).
+  - **Group-context activity emission** — Sprint 3 groups epic.
+  - **Read/unread markers** — SCR-25 Open Question 1; v1.1 candidate.
+  - **Pagination / cursor-based read** — SCR-25 Open Question 2; FUTURE.
+  - **Filter / search within activity** — SCR-25 Open Question 3; deferred.
+  - **Settlement soft-delete activity** — v1.0 "no emission" per §2.2.
+  - **Issue #47 rules-hardening** — separate small chore PR.
+  - **Issue #49 orphan-cleanup** — FUTURE.
+  - **Issue #50 trigger no-op-recompute** — EXPLICITLY CONSTRAINED by FR-EX-07 AC-2.
+  - **Concurrent-edit detection for FR-EX-06** — still deferred.
+  - **Rate-limit transaction race refactor** — still deferred.
+
+If an agent suggests any of: "while we're shipping the Activity tab, let's ship the full bottom-nav shell", "let's add FCM push notifications since the SCR-25 spec mentions them", "let's defensively add the unread-marker schema field", "let's implement cursor-based pagination now", "let's also emit settlementDeleted activity items" — REFUSE. These are scope creep.
+
+────────────────────────────────────────
+PHASE 4 — TEST-FIRST DISCIPLINE
+────────────────────────────────────────
+
+PR #52 follows the standard test-first cadence:
+
+1. Snapshot the pre-fix baseline: 911 Flutter / 30 skipped; 166 functions / 13 suites; 188 rules / 9 suites.
+2. Write the failing widget tests first: `obt_activity_row_test.dart` (all 8 event types from SCR-25 table; loading / populated / empty states); `activity_feed_screen_test.dart` (all SCR-25 states).
+3. Write the failing domain tests: `activity_feed_item_test.dart` (parser + drop-malformed); `relative_timestamp_formatter_test.dart` (every SCR-25 boundary case).
+4. Write the failing settlement-trigger tests: `settlement-payload-builder.test.ts` (create + soft-delete branches); extend `function.test.ts` with activity-writer integration; extend `activity-validator.test.ts` with settlement-payload validation; extend `integration/on-settlement-write.integration.test.ts` with the 2 round-trips.
+5. Implement source per §2.7: domain → application → presentation (Flutter); payload-builder → validator → trigger handler (Functions). Settlement-trigger source extension flips its tests green; Flutter source flips its tests green.
+6. Re-run `dart format --set-exit-if-changed .` — 0 changes.
+7. Re-run `flutter analyze --fatal-infos` — "No issues found".
+8. Re-run `flutter test` — expected 911 + ~25 new = ~936 tests pass (architect at §2.x confirms the exact count target).
+9. Re-run `cd functions && npm run lint && npm run build && npm test` — 166 + ~10 new = ~176 tests pass across ~14 suites.
+10. Re-run `cd functions && npm run test:rules` — 188 unchanged (no rules diff).
+11. Re-run `cd functions && npm run test:integration` — 2 new round-trip tests pass under emulators.
+
+**Combined CI dry-run:** all jobs must be green.
+
+────────────────────────────────────────
+PHASE 5 — EXECUTION PROTOCOL
+────────────────────────────────────────
+
+Mirror the PR #51 commit cadence (10 commits):
+
+ 1. PM creates story `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md`. Commits as `docs(stories): FR-AC-01 activity-feed read-side story`.
+ 2. Architect appends `## Architect Notes` (§2.1–§2.9). Commits as `docs(stories): FR-AC-01 architect notes`.
+ 3. QA writes the failing widget + domain tests (Flutter side). Commits as `test(activity): FR-AC-01 widget + domain tests`.
+ 4. Functions-dev writes failing settlement-trigger tests. Commits as `test(functions): FR-AC-01 settlement-trigger activity tests`.
+ 5. Functions-dev adds settlement-payload-builder + validator extension + ActivityItemType extension. Commits as `feat(functions): settlement-payload builder for activity emission (FR-AC-01)`.
+ 6. Functions-dev extends the settlement-trigger handler. Commits as `feat(functions): emit settlement activity items (FR-AC-01)`.
+ 7. Functions-dev extends the integration test. Commits as `test(integration): FR-AC-01 settlement-activity round-trip`.
+ 8. Flutter-dev ships the OBTActivityRow + domain + provider + repository. Commits as `feat(activity): activity-feed core (OBTActivityRow, provider, repository) (FR-AC-01)`.
+ 9. Flutter-dev ships the screen + skeleton + deep-link routing + HomePlaceholderScreen entry point. Commits as `feat(activity): SCR-25 Activity tab screen + FR-AC-02 deep-links`.
+10. Flutter-dev adds the boundary-contract grep. Commits as `test(activity): boundary-contract grep against monetary float drift`.
+11. QA runs the manual smoke matrix (emulators):
+    - Start emulators; admin-seed a friendship A↔B; create an expense as user A; verify the row appears in user A's Activity tab AND in user B's (real-time).
+    - Edit + soft-delete the expense; verify the new rows appear.
+    - Record a settlement; verify the `settlementRecorded` row appears for both parties.
+    - Soft-delete the settlement; verify NO new activity row appears (per AC-11).
+    - Tap each row type; verify deep-link routing per the SCR-25 Deep-Link Behaviour table.
+    - Pull-to-refresh; verify behaviour per AC-9.
+12. Docs hand updates plan + roll-forward:
+    - `docs/sprint-zero/sprint-2-plan.md` (PR #52 row; 8 SP; cumulative 63 SP / 16 PRs).
+    - `docs/sprint-zero/next-three-prs.md` (PR #53 / #54 / #55 candidates — top is FR-AC-03 FCM push notifications now that the FR-AC-01 deep-link surface exists).
+    - `docs/audits/sprint-1/07-bucket-b-burndown.md` (PR #52 entry; no items closed; partial PY3 progress).
+    - Commits as `docs(plan): PR #52 shipped, prep PR #53`.
+13. PR opened. Title: `feat(activity): FR-AC-01 activity feed read-side + FR-AC-02 deep-links + settlement-trigger emission`. Body must:
+    - Cite SCR-25 + the schema doc lines 194-211 contract.
+    - Confirm Invariants 1 / 2 / 4 (Inv-3 N/A).
+    - State explicitly the deferred items: OBTBottomNav, OBTRupeeText, FR-AC-03 FCM, FR-AC-04 prefs, FR-AC-05 cold-start, group emission, unread markers, pagination, filter/search, settlement-deleted activity.
+    - End with `Next PR: PR #53 — TBD per architect's call at kickoff (top candidate: FR-AC-03 FCM push notifications + FR-AC-05 cold-start deep-link).`
+
+────────────────────────────────────────
+PHASE 6 — DEFINITION OF DONE GATE
+────────────────────────────────────────
+
+Walk the DoD checklist. Particular emphasis:
+
+  - DoD §2: every layer green (Flutter / Functions / Rules unchanged / format / analyze).
+  - DoD §3: QA sign-off with evidence for cross-user real-time activity-feed render (member can read own items; non-member cannot — defence-in-depth via the rules block already shipped; deep-link routing works per SCR-25 table).
+  - DoD §7: invariant compliance.
+    * Inv-1: applicable on render path. `lib/features/activity/**` boundary-contract grep returns 0 violations. Functions-side grep auto-covers the new payload-builder.
+    * Inv-2: ZERO new writes to `simplifiedBalances`; client surface is read-only; settlement-trigger extension touches only `activity/**`.
+    * Inv-3: N/A.
+    * Inv-4: `.firebaserc` unchanged; single project targeted in both production and emulator.
+  - DoD §8: documentation updated (story + architect notes + sprint-2-plan + next-three-prs + burndown).
+  - DoD §9: deploy verification. The settlement-trigger code deploys via `firebase deploy --only functions:onSettlementWrite` on tag (the trigger is already live; the deploy is an in-place update). The Flutter client surface ships in the next mobile build. QA verifies the activity-tab render end-to-end in production post-deploy on the canary device.
+
+QA posts the explicit DoD §3 sign-off, including the negative-scope greps from AC-15 (no `/100` in `lib/features/activity/**`) and AC-16 (no new `simplifiedBalances` writes).
+
+**Pre-push CI hygiene:** run `dart format .` AND all test layers BEFORE `git push`.
+
+────────────────────────────────────────
+PHASE 7 — UPDATE THE ROLLING PLAN AND BURNDOWN
+────────────────────────────────────────
+
+PM agent updates:
+  - `docs/sprint-zero/sprint-2-plan.md` — PR #52 status (merged), velocity #16 (8 SP, total now 63 SP across 16 PRs).
+  - `docs/sprint-zero/next-three-prs.md`:
+      * PR #52 row marked merged; numbering note updated.
+      * PR #53: **TBD** per architect's call at kickoff. Top candidates (in rough priority order):
+          - **FR-AC-03 — FCM push notifications + FR-AC-05 cold-start deep-link** (P0; introduces FCM dependency + `notificationPrefs` schema + per-user `fcmTokens` plumbing; the cold-start deep-link consumes the FR-AC-01 deep-link routing this PR ships). 8-10 SP.
+          - **FR-SE-09 — Send Reminder** (P1; FCM dependency overlaps with FR-AC-03; consider bundling).
+          - **FR-SE-08 dedicated `/settlements/history` screen** (P0; PR #42's in-timeline rows satisfy v1.0 but a dedicated screen remains).
+          - **Issue #47 rules-hardening** (chore; 2 SP).
+          - **OBTBottomNav shell** (UX foundation; needed for Sprint 3 groups epic anyway).
+          - **OBTRupeeText primitive** (UX foundation; deferred from PR #52).
+          - **`emitExpenseActivity` memberIds re-read cleanup** (chore; 1 SP).
+          - **Concurrent-edit detection for FR-EX-06** (chore).
+          - **Rate-limit transaction race refactor** (chore).
+      * PR #54 / #55: TBD per PR #53 outcome.
+  - `docs/audits/sprint-1/07-bucket-b-burndown.md`:
+      * Header timestamp: PR #51 → PR #52.
+      * Append a PR #52 section: closes NO Bucket-B items directly (read-side is not a tracked item). Partial PY3 progress: 2 new settlement-trigger integration tests + the widget tests for the activity feature.
+
+Commits as `docs(plan): PR #52 shipped, prep PR #53`.
+
+────────────────────────────────────────
+GUARDRAILS
+────────────────────────────────────────
+
+If during this PR an agent proposes:
+  - "While we're shipping the Activity tab, let's ship the full OBTBottomNav shell" → REFUSE. Separate UX PR; deferred per §2.1.
+  - "Let's add FCM push notifications since SCR-25 mentions them" → REFUSE. FR-AC-03 introduces the FCM dependency + `notificationPrefs` schema; separate P0 story.
+  - "Let's add the FR-AC-05 cold-start deep-link defensively" → REFUSE. Paired with FR-AC-03; the cold-start signal comes from FCM.
+  - "Let's defensively add the unread-marker schema field" → REFUSE. SCR-25 Open Question 1; v1.1 candidate.
+  - "Let's implement cursor-based pagination now" → REFUSE. SCR-25 Open Question 2; FUTURE.
+  - "Let's also emit `settlementDeleted` activity items so deletions are auditable" → REFUSE. v1.0 decision per §2.2; settlement deletion is extremely rare per FR-SE-07 and the SCR-25 Event Type Mapping omits it.
+  - "Let's close issue #47 (rules-hardening) at the same time" → REFUSE. Separate small chore PR.
+  - "Let's close issue #49 (orphan-cleanup) at the same time" → REFUSE. FUTURE.
+  - "Let's close issue #50 (trigger no-op-recompute optimisation)" → **EXPLICITLY REFUSE** — closing it would BREAK FR-EX-07 AC-2.
+  - "Let's wire the group-trigger activity emission" → REFUSE. Sprint 3 groups epic.
+  - "Let's ship OBTRupeeText along with OBTActivityRow" → REFUSE per §2.6. The trailing amount uses inline `Text(formatInrFromPaise(...))` to keep the OBT primitives PR focused.
+
+If something genuinely surprises (e.g. the StreamProvider snapshot listener fires before the user-profile cache is warm and causes a "Unknown" flash on the SettlementRecorded rows; or the OBTActivityRow's icon library doesn't include `check_circle` matching the SCR-25 spec; or the per-event-type discriminator mapping in `activity_event_type.dart` needs to handle `'group_change'` even though no producer ships in PR #52), STOP and surface the friction. PR #52 is the first reader of a production-critical collection that PR #51 just made writeable — get the SCR-25 contract right before shipping.
+
+Begin with Phase 0 — verify the dependency DAG (PR #51 merge state at `d2302b9`; baseline test counts; emulators reachable for the new integration tests) and re-read the three reference docs (SCR-25 in `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386, the activity-writer module shipped in PR #51 at `functions/src/triggers/on-expense-write/activity-writer.ts`, and the existing `functions/src/triggers/on-settlement-write/function.ts:229-242` TODO comment block that documents the canonical placement note) before kickoff.

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -1,11 +1,11 @@
 # Next Three PRs
 
 > Rolling roadmap. Updated at the end of every PR.
-> Last updated: PR #51 merged (FR-EX-07 — activity feed write-side, friendship expenses).
+> Last updated: PR #52 merged (FR-AC-01 — activity feed read-side + settlement-trigger activity emission).
 
 ---
 
-## GitHub issue / PR numbering note (post-PR #51)
+## GitHub issue / PR numbering note (post-PR #52)
 
 The numbering jumped because issues and PRs share the same sequential
 namespace on GitHub. The post-PR #48 sequence so far:
@@ -18,59 +18,56 @@ namespace on GitHub. The post-PR #48 sequence so far:
 | #49 | Issue | Orphan-cleanup Cloud Function for unreferenced receipts (90-day reaper) — OPEN (FUTURE-work chore, 2 SP) |
 | #50 | Issue | Trigger no-op-recompute optimisation when update touches only `receiptUrl` + `updatedAt` — OPEN (FUTURE-work chore, 1 SP). **EXPLICITLY CANNOT BE CLOSED** by any FR-EX-07-consuming PR — the optimisation would skip activity emission on receipt-only updates, breaking the FR-EX-07 contract (AC-2). |
 | #51 | PR | FR-EX-07 activity feed write-side, friendship expenses (merged 2026-06-07) |
-| **#52** | **PR** | **Next feature PR — see below** |
+| #52 | PR | FR-AC-01 activity feed read-side + settlement-trigger activity emission (merged 2026-06-08) |
+| **#53** | **PR** | **Next feature PR — see below** |
 
 The "Next three PRs" below refer to the next three FEATURE/CHORE
-**pull requests** — i.e. PR #52, PR #53, PR #54. Their issue-number
+**pull requests** — i.e. PR #53, PR #54, PR #55. Their issue-number
 counterparts (when filed) will consume intermediate numbers; the
-orchestrator should not assume PR #52 = number 52 on GitHub.
+orchestrator should not assume PR #53 = number 53 on GitHub.
 
 ---
 
-## PR #52 — TBD
+## PR #53 — TBD
 
-**Status:** Next up. Architect picks at PR #52 kickoff per Sprint 2 velocity.
+**Status:** Next up. Architect picks at PR #53 kickoff per Sprint 2 velocity.
 
-PR #51 shipped FR-EX-07 (activity-feed write-side for friendship
-expenses). The `onExpenseWriteFriendship` trigger now emits one
-`activity/{userId}/items/{auto-id}` document per friendship member
-on every create / edit / soft-delete. The new
-`activity-writer.ts` + `payload-builder.ts` + `activity-validator.ts`
-modules are reusable by the settlement-trigger activity-emission
-extension. The `firestore.rules` block at
-`match /activity/{userId}/items/{itemId}` enforces member-read /
-server-only-write, mirroring the `simplifiedBalances` posture.
-12 new rules tests (176 → 188) cover AC-6 through AC-12;
-41 new unit tests (100 → 141 boundary, plus 13 trigger-integration
-tests = 154 total); 5 boundary-contract tests guard against
-monetary float drift across `functions/src/**`. The
-client read-side (SCR-25 — Activity tab) is the natural
-follow-on story (FR-AC-01).
+PR #52 shipped FR-AC-01 / FR-AC-02 — the SCR-25 Activity tab is now
+live as a temporary route reachable from `HomePlaceholderScreen`'s
+AppBar action; the `OBTActivityRow` widget primitive is in the
+component catalogue; the settlement-trigger TODO at
+`functions/src/triggers/on-settlement-write/function.ts:231` is
+closed (settlement events now emit `'settlement'` activity items to
+both parties). The bottom-nav shell remains deferred (architect §2.1
+in `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md`).
+Cold-start deep-link (FR-AC-05) and FCM push notifications (FR-AC-03)
+remain the natural next P0 stories — the FR-AC-01 in-app deep-link
+routing surface this PR shipped is the prerequisite both stories
+consume.
 
 Candidates (in rough priority order):
 
-- **FR-AC-01 — Activity tab (SCR-25) + settlement-trigger
-  activity-emission extension.** The highest unplaced P0. PR #51
-  shipped the write-side schema and rules; FR-AC-01 ships the
-  client read-side (route `/activity`, `OBTActivityRow`, deep-link
-  routing for FR-AC-02). Pair with the symmetric settlement-trigger
-  activity emission (the TODO at
-  `functions/src/triggers/on-settlement-write/function.ts:231` is
-  ready to consume `writeExpenseActivity` from PR #51 with a sibling
-  settlement-payload builder) — both halves are needed for the
-  settlement leg of SCR-25 to render anything. 8-10 SP — may split
-  into two sub-PRs (client vs server) at architect's call.
+- **FR-AC-03 — FCM push notifications + FR-AC-05 cold-start deep-link.**
+  The highest unplaced P0 pair. Introduces the FCM dependency + the
+  `notificationPrefs` schema + per-user `fcmTokens` plumbing.
+  FR-AC-05 (cold-start deep-link from a tapped push notification when
+  the app is not running) is naturally paired since the cold-start
+  signal comes from the FCM tap event. 8-10 SP — may split into two
+  sub-PRs (FCM infrastructure vs cold-start handler) at architect's
+  call. The FR-AC-01 deep-link routing this PR shipped is the
+  in-app target both stories use.
 - **FR-SE-09 — Send Reminder.** Closes the receiving-direction
   branch of the OBTSettleUpCard (per PR #43 §2.5 default-omit).
-  Requires FCM dependency + 24-hour rate-limit subcollection.
-  Now the highest unplaced P1. Will exercise the
+  Requires FCM dependency + 24-hour rate-limit subcollection. Now
+  the highest unplaced P1. Will exercise the
   `_rateLimits/{uid}/sends/counter` subcollection pattern
-  established by PR #45 Architect Notes §2.9.
-- **FR-AC-03 — FCM push notifications.** Separate P0 story;
-  introduces the FCM dependency + the `notificationPrefs` schema +
-  per-user `fcmTokens` plumbing. Requires FR-AC-01 client deep-link
-  surface as a prerequisite (paired by FR-AC-05 cold-start
-  deep-link).
+  established by PR #45 Architect Notes §2.9. Naturally bundles
+  with FR-AC-03 if the FCM infrastructure ships in the same PR
+  (one FCM dependency add, two consumers).
+- **`OBTBottomNav` shell.** UX foundation deferred from PR #52 per
+  architect §2.1. Becomes the canonical entry point for the
+  Friends / Groups / Activity / Profile tab cluster — needed before
+  the Sprint 3 groups epic ships.
 - **FR-SE-08 dedicated full-history screen** at
   `/settlements/history` (P0 — PR #42's in-timeline rows satisfy
   v1.0 but the dedicated screen is still a backlog item).
@@ -78,9 +75,27 @@ Candidates (in rough priority order):
   (operational hardening; small standalone PR ~2 SP). Closes the
   defence-in-depth gap that the FR-EX-06 architect §2.9 item 5
   documented.
+- **`OBTRupeeText` primitive** (UX foundation; small PR ~1 SP).
+  Deferred from PR #52 per architect §2.6. The component catalogue
+  declares it; a future PR adds the 5-line wrapper around
+  `Text(formatInrFromPaise(...))` once a second use site needs it.
+- **Activity-writer rename cleanup** (cosmetic; small chore PR
+  ~1-2 SP). Per FR-AC-01 architect §2.3 the rename of
+  `writeExpenseActivity` → `writeContextActivity` (+ `friendshipId`
+  → `contextId`, `expenseId` → `entityId`, `expenseIdHash` →
+  `entityIdHash`) was DEFERRED to minimise blast radius. A future
+  cleanup PR can do the full rename + Cloud Logging dashboard
+  migration as one focused change.
 - **Concurrent-edit detection for FR-EX-06** (operational
-  hardening; small standalone PR). Explicitly deferred from
-  PR #46.
+  hardening; small standalone PR). Explicitly deferred from PR #46.
+- **Integration-test infrastructure fix** (operational chore;
+  ~1-2 SP). The Functions emulator currently fails to load
+  `onExpenseWriteFriendship` with the warning
+  `functions.config() has been removed in firebase-functions v7`
+  during integration runs; this is a pre-existing issue not
+  caused by PR #52 (verified by stashing PR #52 changes and
+  reproducing on `main`). Track as a Sprint-3 cleanup item; CI
+  may have a workaround that local runs do not — to investigate.
 - **Issue #49 — Orphan-cleanup Cloud Function for receipts**
   (FUTURE; filed during PR #48 per SRS schema doc line 312).
   Out of v1.0 unless required for compliance.
@@ -102,11 +117,11 @@ Candidates (in rough priority order):
 
 ---
 
-## PR #53 — TBD
+## PR #54 — TBD
 
-**Status:** Slot reserved. Architect picks at PR #52 kickoff.
+**Status:** Slot reserved. Architect picks at PR #53 kickoff.
 
-Candidates: whatever doesn't land in PR #52 from the list above, plus:
+Candidates: whatever doesn't land in PR #53 from the list above, plus:
 
 - A Bucket-B chore PR (remaining 27 / 37 items after PR #51 closed
   R5a — activity rules coverage).
@@ -118,11 +133,11 @@ Candidates: whatever doesn't land in PR #52 from the list above, plus:
 
 ---
 
-## PR #54 — TBD
+## PR #55 — TBD
 
-**Status:** Slot reserved. Architect picks at PR #53 kickoff.
+**Status:** Slot reserved. Architect picks at PR #54 kickoff.
 
-Candidates: whatever doesn't land in PR #52 / PR #53 from the lists
+Candidates: whatever doesn't land in PR #53 / PR #54 from the lists
 above.
 
 ---

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #51 (FR-EX-07 — activity feed write-side, friendship expenses) — 15th merged PR.
+> Last updated: PR #52 (FR-AC-01 — activity feed read-side + settlement-trigger activity emission) — 16th merged PR.
 
 ---
 
@@ -87,6 +87,7 @@ work until the decision is recorded in the story file's Architect Notes.
 | #46 | FR-EX-06 | Edit / delete expense (friendship) — bottom-sheet edit-mode + Expense Detail screen + soft-delete with confirmation | 5 | Merged |
 | #48 | FR-EX-05 | Receipt attachment (friendship) — Step 3 (SCR-21) + ReceiptStorageService + storage.rules friendship + group receipts predicates + Expense Detail thumbnail | 5 | Merged |
 | #51 | FR-EX-07 | Activity feed write-side (friendship) — activity-writer + payload-builder + activity-validator + activity/{userId}/items rules + trigger emission + 12 new rules tests + 41 new unit tests + 3 integration round-trips | 5 | Merged |
+| #52 | FR-AC-01 / FR-AC-02 | Activity feed read-side — SCR-25 ActivityFeedScreen + OBTActivityRow widget + activity feature folder + 4 telemetry events + settlement-trigger activity-emission extension (closes the on-settlement-write TODO) | 8 | Merged |
 
 ---
 
@@ -109,7 +110,8 @@ work until the decision is recorded in the story file's Architect Notes.
 | #46 | 5 | Merged |
 | #48 | 5 | Merged |
 | #51 | 5 | Merged |
-| **Total** | **55** | **15 PRs so far** |
+| #52 | 8 | Merged |
+| **Total** | **63** | **16 PRs so far** |
 
 Sprint 1 reference:
 

--- a/docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md
+++ b/docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md
@@ -607,3 +607,368 @@ Reference: `docs/design/08-plan/definition-of-ready-and-done.md`
   REFUSED for bundling — would BREAK FR-EX-07 AC-2.
 - **Concurrent-edit detection for FR-EX-06.** Still deferred.
 - **Rate-limit transaction race refactor.** Still deferred.
+
+---
+
+## Architect Notes
+
+> Appended for the FR-AC-01 activity-feed read-side PR. These notes
+> ratify the design decisions taken before implementation begins.
+> References: `docs/copilot_prompts/sprint_2/15.md`,
+> `.github/shared/invariants.md`, `.github/shared/decision-log.md`
+> (ADR-0002 paise integers; ADR-0006 Riverpod state management;
+> ADR-0007 feature-first folder layout; ADR-0013 PII / telemetry
+> hashing; ADR-0014 rules-readable user collection).
+
+### 2.1 — Bottom-nav shell deferral
+
+**RATIFY: PR #52 does NOT ship `OBTBottomNav`.**
+
+The `/activity` route is reachable via a temporary "Activity" AppBar
+action on `HomePlaceholderScreen` (mirror of the existing "Profile"
+action at `home_placeholder_screen.dart:21-31`). The bottom-nav
+shell is a separate UX PR that lands when Friends + Groups +
+Activity + Profile tabs are all needed simultaneously (likely Sprint
+3 alongside the groups epic).
+
+Rationale:
+
+- The bottom-nav infrastructure is a significant UX surface that
+  warrants its own PR. Bundling it would push this PR well past 10
+  SP into scope creep.
+- The standalone `/activity` route is the canonical SCR-25 contract
+  (line 265). The bottom-nav binding is a presentational concern
+  that lands when the tab shell ships.
+- Friends and Groups tabs also don't have routes yet. Shipping
+  bottom-nav with only an Activity tab wired in would leave it
+  visually broken.
+
+### 2.2 — Settlement soft-delete activity decision
+
+**RATIFY: settlement soft-delete does NOT emit an activity item.**
+
+Rationale:
+
+- The SCR-25 Event Type Mapping at line 308 only lists
+  `settlementRecorded`. There is NO `settlementDeleted` row type in
+  the spec.
+- Settlement deletion is extremely rare per the FR-SE-07 contract.
+- The v1.0 decision is "no activity item on settlement soft-delete".
+- The settlement-trigger update branch detects
+  `before.deleted === false && after.deleted === true` and SKIPS
+  the activity emission entirely. Documented in code as a comment.
+- Hard-delete (admin-only via admin SDK) is also a no-op for activity
+  emission — symmetric with the no-op posture for soft-delete.
+
+If observed as a UX gap in production, file an issue for v1.1
+consideration (would require both schema enumeration extension AND
+SCR-25 spec update — non-trivial).
+
+### 2.3 — Activity-writer reuse vs rename
+
+**RATIFY: keep the function name `writeExpenseActivity` (DEFER the
+rename to `writeContextActivity`).**
+
+The prompt §2.3 RECOMMENDED renaming to `writeContextActivity` on
+the grounds that the function is generic over the context type and
+the "Expense" prefix is now misleading. However, the prompt §2.7
+ratified the rename as "OPTIONAL".
+
+Rationale for deferral:
+
+- Minimises blast radius — the existing PR #51 tests
+  (`activity-writer.test.ts`, `function.test.ts`) stay untouched.
+  Renaming would require updating ~10+ assertion call sites and
+  introduces regression risk on a working ship.
+- The log key `expenseIdHash` would also rename to `entityIdHash`
+  in the existing `activity_item_written`,
+  `activity_item_write_failed`, and `activity_emission_completed`
+  events. Any Cloud Logging dashboards built post-PR-#51 that pivot
+  on `expenseIdHash` would break — and we cannot verify the
+  dashboard surface from here.
+- The settlement-trigger call site explicitly maps the misnomer in
+  a code comment:
+  ```typescript
+  // The activity-writer's WriteExpenseActivityRequest interface
+  // pre-dates the settlement consumer; the field names friendshipId
+  // and expenseId are misnomers when the source entity is a
+  // settlement. The architect deferred the rename to keep PR #51's
+  // tests and the Cloud Logging schema stable. FUTURE-work cleanup
+  // PR renames to writeContextActivity + contextId + entityId +
+  // entityIdHash.
+  await writeExpenseActivity(deps, {
+    friendshipId: contextId,    // misnomer: actually contextId
+    expenseId: settlementId,    // misnomer: actually entityId
+    eventType: "settlement",
+    payload,
+    memberIds,
+  });
+  ```
+- A follow-up cosmetic-rename PR (1-2 SP, separately filed) can do
+  the full rename + log-key migration as a single focused change with
+  paired dashboard updates.
+
+If a reviewer prefers the immediate rename, the architect is open to
+flipping this decision — the trade-off is well-bounded.
+
+### 2.4 — Settlement payload schema
+
+**RATIFY:** `settlement` payload shape:
+
+```typescript
+{
+  settlementId: string;
+  fromUserId: string;
+  toUserId: string;
+  amountPaise: number;         // integer (Invariant 1 preserved)
+  contextType: "friendship" | "group";
+  contextId: string;
+  note?: string;               // optional; nullable on the doc
+  authorUid: string;           // == fromUserId per the rules
+}
+```
+
+The validator's per-event-type required-field check enforces
+`settlementId`, `fromUserId`, `toUserId`, `amountPaise`,
+`contextType`, `contextId`, `authorUid`. The `note` field is
+optional (the rules at `firestore.rules:445-455` permit
+`note: null` and the schema marks it as optional per
+`docs/design/07-technical/firestore-schema.md`).
+
+Notes:
+
+- `authorUid` is canonically the `fromUserId` for v1.0 (settlements
+  are created by the payer, per the rules). Symmetric with FR-EX-07's
+  `authorUid` being the expense `createdBy`.
+- `contextType: 'group'` is permitted in the type union for forward-
+  compatibility with the Sprint 3 groups epic, but the settlement-
+  trigger handler's group-context path is NOT exercised in this PR
+  (no group settlements exist yet). The friendship-context path is
+  the only emission path PR #52 ships.
+- `amountPaise` is passed through unchanged from the source
+  settlement document — Invariant 1 is preserved by construction.
+
+### 2.5 — Riverpod provider granularity
+
+**RATIFY: single `StreamProvider<List<ActivityFeedItem>>` named
+`activityFeedProvider`. NO `family` parameter.**
+
+Rationale:
+
+- The provider is per-user. The current UID is read from the
+  existing `currentUserIdProvider` (shipped in FR-FR-03 at
+  `lib/features/friends/application/friends_list_provider.dart:15`).
+- Mirrors the `friendsListProvider` blueprint — same `StreamProvider`
+  shape over a Firestore snapshot listener.
+- A `family<List<ActivityFeedItem>, String>` would be over-
+  engineered: the only legitimate parameter would be `userId`, but
+  the entire activity feed is gated by the rules block to the
+  authenticated user's own subcollection, so per-user lookup is the
+  only legal access pattern.
+- `ref.invalidate(activityFeedProvider)` is the canonical re-subscribe
+  mechanism used by both the Retry button (AC-8) and the
+  pull-to-refresh handler (AC-9).
+
+The current UID is also passed to the `activityFeedRepository`
+constructor (which builds the Firestore query path) and to the row-
+tap handler (which derives the deep-link target — settlements need
+`currentUid` to disambiguate "you settled up with X" vs "X settled
+up with you").
+
+### 2.6 — OBTActivityRow widget API
+
+**RATIFY:** the widget consumes a single typed `ActivityFeedItem`
+(the domain model) PLUS the resolved other-party display name. The
+icon, colour, primary-text, and amount derivation lives inside the
+widget per the SCR-25 Event Type Mapping table (lines 301-313).
+
+Placement: `lib/core/widgets/lists/obt_activity_row.dart` — matches
+the OBT cross-feature primitive convention established by
+`lib/core/widgets/inputs/obt_amount_input.dart` (PR #38) and
+`lib/core/widgets/dialogs/obt_confirmation_dialog.dart` (PR #46).
+
+**`OBTRupeeText` is NOT shipped in PR #52.** The component catalogue
+declares it (section 5) but no Dart implementation exists today.
+The `OBTActivityRow` trailing amount uses
+`Text(formatInrFromPaise(item.amountPaise))` inline. A 5-line
+wrapper would add no semantic value beyond what `OBTActivityRow`
+itself already provides; a future OBT-primitives PR ships
+`OBTRupeeText` when a SECOND use site needs it (mirrors the
+`OBTAmountInput` precedent — the catalogue contract is locked the
+moment a second use site needs it).
+
+API surface:
+
+```dart
+class OBTActivityRow extends StatelessWidget {
+  const OBTActivityRow({
+    required this.item,
+    required this.currentUserUid,
+    required this.otherPartyDisplayName,
+    required this.onTap,
+    super.key,
+  });
+
+  final ActivityFeedItem item;
+  final String currentUserUid;
+  final String otherPartyDisplayName;
+  final VoidCallback onTap;
+  // ...
+}
+```
+
+The semantic label combines primary text + secondary text + amount
++ "Tap to view details" per SCR-25 line 361.
+
+### 2.7 — Files to touch (exhaustive — anything outside this set is scope creep)
+
+- **NEW** `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md`
+  (this file).
+- `functions/src/triggers/on-settlement-write/function.ts` — EXTEND
+  with the `emitSettlementActivity` helper call after the success-
+  branch log at line 315.
+- **NEW** `functions/src/triggers/on-settlement-write/settlement-payload-builder.ts`
+  — pure function `buildSettlementActivityPayload(changeType,
+  request)`.
+- `functions/src/triggers/on-expense-write/activity-validator.ts` —
+  EXTEND with `validateSettlementPayload` branch.
+- `functions/src/triggers/on-expense-write/payload-builder.ts` —
+  EXTEND the `ActivityItemType` union with `'settlement'` and the
+  `ActivityPayload` discriminated union with `SettlementPayload`.
+- `functions/test/triggers/on-settlement-write/function.test.ts` —
+  EXTEND with activity-writer integration assertions (mirror of PR
+  #51's `function.test.ts` extension at lines 720-1032).
+- **NEW** `functions/test/triggers/on-settlement-write/settlement-payload-builder.test.ts`
+  — per-change-type mapping tests.
+- `functions/test/triggers/on-expense-write/activity-validator.test.ts`
+  — EXTEND with settlement-payload validation tests.
+- `functions/test/integration/on-settlement-write.integration.test.ts`
+  — EXTEND with 2 round-trip tests per AC-18.
+- **NEW** `lib/features/activity/data/activity_feed_repository.dart`
+- **NEW** `lib/features/activity/domain/activity_feed_item.dart`
+- **NEW** `lib/features/activity/domain/activity_event_type.dart`
+- **NEW** `lib/features/activity/application/activity_feed_provider.dart`
+- **NEW** `lib/features/activity/application/relative_timestamp_formatter.dart`
+- **NEW** `lib/features/activity/presentation/activity_feed_screen.dart`
+- **NEW** `lib/features/activity/presentation/widgets/activity_feed_skeleton.dart`
+- **NEW** `lib/core/widgets/lists/obt_activity_row.dart`
+- `lib/features/auth/presentation/home_placeholder_screen.dart` —
+  ADD "Activity" AppBar action.
+- **NEW** `test/features/activity/domain/activity_feed_item_test.dart`
+- **NEW** `test/features/activity/application/activity_feed_provider_test.dart`
+- **NEW** `test/features/activity/application/relative_timestamp_formatter_test.dart`
+- **NEW** `test/features/activity/presentation/activity_feed_screen_test.dart`
+- **NEW** `test/features/activity/activity_boundary_contract_test.dart`
+- **NEW** `test/core/widgets/lists/obt_activity_row_test.dart`
+- `docs/sprint-zero/sprint-2-plan.md` — PR #52 row.
+- `docs/sprint-zero/next-three-prs.md` — roll-forward.
+- `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #52 entry.
+
+### 2.8 — Files explicitly NOT to touch (negative scope guardrails)
+
+- `firestore.rules` — UNCHANGED. FR-EX-07 shipped the activity rules
+  block; PR #52 only reads (rules grant member-read).
+- `firestore.indexes.json` — UNCHANGED. Single-field descending
+  index on `createdAt` auto-creates.
+- `storage.rules` — UNCHANGED. No Storage surface.
+- `pubspec.yaml` / `functions/package.json` — UNCHANGED. No new
+  dependencies.
+- `lib/features/expenses/**`, `lib/features/friends/**`,
+  `lib/features/settlements/**` — UNCHANGED. The new Activity feature
+  reads its own data; no edits to existing features.
+- `functions/src/triggers/on-expense-write/function.ts` — UNCHANGED.
+  FR-EX-07's expense-trigger emission is correct as-is.
+- `functions/src/triggers/on-expense-write/activity-writer.ts` —
+  EXTENDED ONLY to include `'settlement'` in the `ActivityItemType`
+  type re-export (a single character change). The function body,
+  field names, and log keys are UNCHANGED per §2.3.
+- `.github/workflows/*.yml` — UNCHANGED.
+- `lib/main.dart` — UNCHANGED. The `/activity` route is reachable
+  via the `HomePlaceholderScreen` AppBar action using
+  `Navigator.of(context).push(MaterialPageRoute(...))` (the
+  canonical pattern from FR-EX-06 and FR-FR-03).
+- `lib/core/widgets/dialogs/obt_confirmation_dialog.dart`,
+  `lib/core/widgets/inputs/obt_amount_input.dart` — UNCHANGED. The
+  new `OBTActivityRow` is a sibling primitive.
+
+### 2.9 — Anticipated reconciliations
+
+Document EXACTLY:
+
+1. **Snake_case vs camelCase event-type discriminators.** The
+   Firestore document stores `type: 'expense_added'` (snake_case per
+   schema doc line 202); the SCR-25 spec uses `expenseAdded`
+   (camelCase per lines 305-307). The client mapper in
+   `activity_feed_repository.dart` converts on read. Unknown types
+   are dropped (mirrors the strict-parsing precedent for
+   `simplifiedBalances`).
+
+2. **OBTRupeeText deferral.** The components catalogue declares
+   `OBTRupeeText` (section 5) but PR #52 does not implement it. The
+   `OBTActivityRow` trailing amount uses
+   `Text(formatInrFromPaise(...))` inline. Future OBT-primitives PR
+   ships the wrapper. NOT a Bucket-B item.
+
+3. **OBTBottomNav deferral.** Same as §2.1. The temporary
+   `HomePlaceholderScreen` AppBar action is the v1.0 entry point
+   until the bottom-nav shell lands.
+
+4. **Activity emission on settlement soft-delete.** Per §2.2: no
+   activity item. Documented in code as a comment in the settlement-
+   trigger handler's update branch.
+
+5. **Settlement activity directional copy.** The primary-text copy is:
+   - "You settled up with [other party]" when `currentUid ==
+     fromUserId`
+   - "[other party] settled up with you" when `currentUid ==
+     toUserId`
+   The other-party display name is resolved via the existing
+   `userProfileProvider` from FR-FR-03. If the profile resolution
+   fails (deleted account, transient permission glitch), the
+   fallback is "Unknown" — mirrors the FR-FR-03 friends-list
+   fallback.
+
+6. **Cold-start deep-link (FR-AC-05) deferral.** PR #52 ships the
+   FR-AC-02 in-app deep-link routing. The FR-AC-05 cold-start
+   deep-link (from a tapped push notification when the app is not
+   running) is paired with FR-AC-03 FCM. Separate P0 story.
+
+7. **Read/unread markers deferral.** SCR-25 Open Question 1. The
+   components catalogue defines an `Unread` state for
+   `OBTActivityRow` (3 dp `primary` left-edge bar) but PR #52 does
+   NOT ship this — every row is rendered as "read". v1.1 candidate
+   per the SCR.
+
+8. **Pagination deferral.** SCR-25 Open Question 2. v1.0 loads all
+   activity items via the single snapshot listener. Cutoff at which
+   performance degrades: rough estimate ~1000 items before the
+   frame budget is exceeded (each row is a lightweight
+   `OBTActivityRow` with no images beyond the leading icon). FUTURE
+   work.
+
+9. **Activity-writer reuse vs rename deferral.** Per §2.3. Future
+   cleanup PR may rename `writeExpenseActivity` →
+   `writeContextActivity` AND `friendshipId` → `contextId` AND
+   `expenseId` → `entityId` AND the log key `expenseIdHash` →
+   `entityIdHash` in one focused diff with paired Cloud Logging
+   dashboard updates.
+
+10. **Boundary-contract grep co-location.** The new
+    `test/features/activity/activity_boundary_contract_test.dart`
+    mirrors the existing
+    `test/features/expenses/expense_creation_boundary_contract_test.dart`
+    template — same `_isCommentLine` helper, same regex patterns,
+    same fail-loud assertion shape. Per
+    `docs/patterns/feature-pr-conventions.md` boundary-contract
+    discipline.
+
+11. **Currentuid for settlement directional copy — coupling to
+    OBTActivityRow.** The widget needs `currentUserUid` to render
+    the correct directional copy on `settlement` rows. Passing
+    `currentUserUid` as a widget prop is a small API surface
+    addition; the alternative (resolving via `ref.watch` inside the
+    widget) would force `OBTActivityRow` to become a
+    `ConsumerWidget`, breaking the OBT-primitive convention of pure
+    `StatelessWidget` reusability. Architect's call: prop-pass the
+    UID.
+

--- a/docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md
+++ b/docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md
@@ -1,0 +1,609 @@
+# FR-AC-01: Activity Feed Read-Side + Settlement-Trigger Activity Emission
+
+> Implementation-ready user story for the **first reader of the
+> `activity/{userId}/items/{itemId}` collection** in the OneByTwo
+> application. Ships the SCR-25 Activity Feed screen, the FR-AC-02
+> in-app deep-link routing, the four `activity_*` client-side
+> telemetry events, the `OBTActivityRow` widget primitive, and the
+> reusable `lib/features/activity/**` feature folder. Closes the
+> symmetric write-side TODO at
+> `functions/src/triggers/on-settlement-write/function.ts:231` by
+> extending the settlement trigger to emit `settlement` activity items
+> via the reusable `activity-writer.ts` module shipped in the
+> activity-feed write-side story (FR-EX-07). The settlement-trigger
+> extension is bundled because the settlement leg of SCR-25 cannot
+> render anything without it — every settlement recorded since the
+> settlement-trigger first shipped has produced ZERO activity items;
+> closing the seam now means the moment the read-side lands, the
+> settlement column of the feed has data.
+
+---
+
+## SRS Requirement ID(s)
+
+FR-AC-01 (SRS section 4.7 lines 236-240 — "Each user shall have an
+activity feed showing all events involving them. Items shall be
+ordered by recency"; P0), FR-AC-02 (SRS section 4.7 — "Tapping an
+activity item shall navigate to the relevant entity (expense, group,
+or friend) where the user can view full details"; P0). The story also
+satisfies the symmetric write-side requirement implicit in the SCR-25
+Event Type Mapping (line 308) for the `settlementRecorded` event type.
+
+## Relevant SRS Sections
+
+- Section 4.7 — Activity Feed (FR-AC-01, FR-AC-02)
+- Section 5.6 — Accessibility (reduce-motion accommodation; semantic
+  labels; live regions)
+- Section 5.9 — Localisation (IST timezone for relative timestamps)
+- Section 5.10 — Observability (four new client-side analytics events)
+- Section 6.3 — Core Screens (Activity feed is item 10)
+- Section 7.2 — Firestore schema (`activity/{userId}/items/{itemId}`)
+- Section 7.3 — Key architectural decisions (Invariants 1 + 2 on the
+  render path)
+- Section 7.5 — Security rules (member-read / server-only-write; the
+  read predicate is the load-bearing gate this story exercises)
+
+## Priority
+
+**P0 — Must have.** The activity feed is a Core Screen (SRS section
+6.3 item 10). FR-AC-01 and FR-AC-02 are both flagged P0 in SRS
+section 4.7. The write-side schema and rules block shipped in the
+FR-EX-07 story; this story is the read-side that surfaces the data
+to users. Without it the activity-write infrastructure has no
+consumer.
+
+## Story Points
+
+**8.** Decomposes as:
+
+- 5 SP — client read-side (feature folder, `OBTActivityRow` widget,
+  screen with 6 states, real-time `StreamProvider` snapshot listener,
+  deep-link routing, telemetry, relative-timestamp formatter).
+- 1 SP — settlement-trigger activity-emission extension (reuses
+  `activity-writer.ts` from FR-EX-07; new sibling
+  `settlement-payload-builder.ts`; validator extension).
+- 1 SP — `OBTActivityRow` widget (cross-feature OBT primitive).
+- 1 SP — routing wiring + temporary `HomePlaceholderScreen` AppBar
+  action + four `activity_*` telemetry events.
+
+Patterns from the FR-EX-07 settlement-trigger and FR-FR-03 friends-
+list ship-ratified architecture (`StreamProvider`, strict-parse,
+boundary-contract grep, telemetry hashing) are reused; this story
+does not re-derive them.
+
+## User Story
+
+As a **signed-in user**,
+I want **a chronological feed of all events involving me — expenses
+my friends and I have added, edited, or deleted, and settlements
+we have recorded** with **the ability to tap any row and navigate
+straight to the underlying entity**,
+so that **I always know what's happened on our shared finances
+without having to drill into each friendship individually, and so
+that I can quickly view full details on any change I see in the feed**.
+
+## Preconditions
+
+1. The signed-in user has at least one friendship with activity
+   items already written by the FR-EX-07 trigger extension OR by the
+   settlement-trigger activity emission this story ships.
+2. The `activity/{userId}/items/{itemId}` rules block exists in
+   `firestore.rules` (shipped with FR-EX-07; member-read /
+   server-only-write).
+3. The Firebase Emulator Suite is available for pre-merge integration
+   testing (Firestore on port 8181, Functions on port 5001 per
+   `firebase.json`).
+4. The `onSettlementWrite` trigger is deployed to `asia-south1`
+   (Mumbai) per SRS section 7.1 and is the sole producer of
+   `simplifiedBalances` for settlement events (FR-SE-05/06).
+5. The reusable `activity-writer.ts`, `payload-builder.ts`, and
+   `activity-validator.ts` modules from FR-EX-07 exist at
+   `functions/src/triggers/on-expense-write/` and are ready to be
+   reused by the settlement-trigger extension this story ships.
+
+---
+
+## Acceptance Criteria
+
+### Client read-side — positive ACs
+
+#### AC-1 — Activity tab renders chronological feed of friendship-expense events
+
+> Given a signed-in user is a member of friendships with at least one
+> create / edit / soft-delete activity item each in
+> `activity/{currentUid}/items`
+> When the user navigates to `/activity` (via the temporary
+> `HomePlaceholderScreen` AppBar action that ships in this story)
+> Then the screen displays an `OBTActivityRow` per item in reverse-
+> chronological order (by `createdAt` desc) with the correct icon,
+> colour, primary text, secondary text (relative timestamp), and
+> trailing amount per the SCR-25 Event Type Mapping at lines 301-313
+> And the per-row primary text resolves the OTHER party's display
+> name via the existing `userProfileProvider` (e.g. "Priya added
+> 'Dinner at Dosa Plaza'" — NOT "uidA added 'Dinner at Dosa Plaza'").
+
+#### AC-2 — Settlement-recorded rows render after the settlement-trigger extension lands
+
+> Given a settlement is recorded between two friends
+> When the new `onSettlementWrite` activity emission writes one item
+> per party to `activity/{fromUserId}/items` AND
+> `activity/{toUserId}/items`
+> Then the SCR-25 row renders with the `check_circle` icon (`success`
+> colour) and primary text:
+> - "You settled up with [other party]" when `currentUid ==
+>   fromUserId`
+> - "[other party] settled up with you" when `currentUid == toUserId`
+> And the trailing amount is the settlement amount formatted via
+> `formatInrFromPaise(amountPaise)`.
+
+#### AC-3 — Real-time updates via snapshot listener
+
+> Given the Activity screen is open in Populated state
+> When a new activity item is written to `activity/{currentUid}/items`
+> (e.g. by a friend adding an expense in another session, or by the
+> settlement-trigger after a settlement is recorded)
+> Then the row appears at the top of the feed within the
+> `StreamProvider`'s next emission
+> And no manual refresh is required.
+
+#### AC-4 — FR-AC-02 deep-link routing
+
+> Given the user taps an activity row
+> When the event type is `expenseAdded` or `expenseEdited`
+> Then the app navigates to the Expense Detail screen for
+> `payload.expenseId` within `payload.friendshipId` (uses the existing
+> `ExpenseDetailScreen` route shipped in FR-EX-06)
+> And when the event type is `settlementRecorded`, navigates to the
+> Friend Detail screen for the other party
+> And when the event type is `expenseDeleted` (the target no longer
+> exists), displays an info snackbar with the copy "This item is no
+> longer available." per the SCR-25 line 341 contract and remains on
+> the Activity feed.
+
+#### AC-5 — Relative timestamp format per SCR-25 lines 314-326
+
+> Given any `createdAt` timestamp
+> When rendered
+> Then the relative-timestamp string matches the SCR-25 table exactly:
+> - `< 1 min` → "Just now"
+> - `1-59 min` → "X min ago"
+> - `1 hour` → "1 hour ago"
+> - `2-23 hours` → "X hours ago"
+> - `1 day` → "Yesterday"
+> - `2-6 days` → "X days ago"
+> - `7+ days, same year` → "dd MMM" (e.g. "14 Mar")
+> - `previous year` → "dd MMM yyyy" (e.g. "28 Dec 2024")
+> And all timestamps are rendered in IST (`Asia/Kolkata`) per SRS
+> section 5.9.
+
+#### AC-6 — Empty state
+
+> Given the `activity/{currentUid}/items` collection has zero
+> non-malformed documents
+> When the screen loads
+> Then the empty state displays with title "All quiet here" and
+> subtitle "Your activity will show up as you add expenses and settle
+> up."
+> And the SCR-25 "Add Expense" CTA is rendered (deferred to a
+> future PR when the multi-context FAB chooser ships; for v1.0 the
+> CTA is a placeholder button that surfaces an info snackbar).
+
+#### AC-7 — Loading state
+
+> Given the screen first opens with no cached data
+> When the snapshot listener is still resolving
+> Then a 5-row skeleton loader displays with a shimmer animation
+> (suppressed to static grey if `MediaQuery.disableAnimations` is
+> `true` per SRS section 5.6 reduce-motion accommodation).
+
+#### AC-8 — Error state
+
+> Given the snapshot listener errors (e.g. `permission-denied` if the
+> rules block is somehow violated — defence-in-depth)
+> When the screen renders
+> Then the error state displays with title "Something went wrong",
+> subtitle "We could not load your activity. Please try again.", and
+> a "Retry" button that re-establishes the listener via
+> `ref.invalidate(activityFeedProvider)`.
+
+#### AC-9 — Pull-to-refresh
+
+> Given the Populated state
+> When the user pulls to refresh
+> Then the platform-native `RefreshIndicator` animates and the
+> snapshot listener re-subscribes via `ref.invalidate(activityFeedProvider)`
+> And on success the indicator dismisses
+> And on failure an error snackbar displays with the copy "Could not
+> refresh. Check your connection and try again."
+
+### Server-side settlement-trigger extension — positive ACs
+
+#### AC-10 — Settlement create writes a `settlement` activity item to BOTH parties
+
+> Given a `settlements/{settlementId}` document is created with
+> `fromUserId: uidA, toUserId: uidB, amountPaise: N,
+> contextType: 'friendship', contextId: 'uidA_uidB'`
+> When the `onSettlementWrite` trigger handles the event AFTER the
+> successful `recomputeAndWrite` branch
+> Then TWO activity items are written — one at
+> `activity/{uidA}/items/{auto-id}` and one at
+> `activity/{uidB}/items/{auto-id}`
+> And each has `type: 'settlement'`
+> And each has `payload: { settlementId, fromUserId, toUserId,
+> amountPaise, contextType, contextId, note?, authorUid }`
+> And each has `createdAt: <server timestamp>` (Firestore-side
+> `FieldValue.serverTimestamp()`, symmetric with the FR-EX-07 contract).
+
+#### AC-11 — Settlement soft-delete does NOT emit an activity item (v1.0 decision)
+
+> Given a settlement is soft-deleted (`deleted: false -> true`)
+> When the `onSettlementWrite` trigger handles the update
+> Then NO activity item is written
+> Rationale: the SCR-25 Event Type Mapping at line 308 does not
+> include a `settlementDeleted` row type; settlement deletion is
+> extremely rare per FR-SE-07; the v1.0 contract is "no activity item
+> on settlement soft-delete". Documented in code as a comment in the
+> settlement-trigger handler's update branch. (Architect Notes §2.2
+> ratifies.)
+
+#### AC-12 — Settlement activity emission happens AFTER the recomputeAndWrite success branch
+
+> Given a transient `recomputeAndWrite` failure (network error,
+> transaction abort, BALANCE_INVARIANT_VIOLATED, INTERNAL,
+> CONTEXT_NOT_FOUND, or stale-event drop)
+> When the trigger handler runs
+> Then NO activity items are written for the failed branch
+> And the retry on the next trigger invocation handles both the
+> recompute AND the activity emission together
+> Symmetric with the FR-EX-07 AC-5 contract.
+
+#### AC-13 — Settlement payload validator rejects malformed inputs
+
+> Given a programmatically-malformed payload (e.g. missing
+> `fromUserId`, missing `toUserId`, non-integer `amountPaise`, or
+> missing `contextType`)
+> When `validateActivityPayload('settlement', payload)` is called
+> Then it throws BEFORE any Firestore I/O
+> And the trigger's outer try/catch contains the throw, logs
+> `activity_emission_internal_error`, and does NOT propagate the
+> failure to the trigger's success branch
+> Mirrors the FR-EX-07 AC-18 contract.
+
+### Cross-cutting and negative ACs
+
+#### AC-14 — Telemetry events fire correctly
+
+> Given the four new client-side events
+> (`activity_feed_viewed`, `activity_item_tapped`,
+> `activity_feed_refreshed`, `activity_feed_error`)
+> When each is emitted
+> Then the parameters match SCR-25 lines 347-354 exactly:
+> - `activity_feed_viewed`: `item_count: int`
+> - `activity_item_tapped`: `event_type: string`, `entity_id: string`
+> - `activity_feed_refreshed`: `success: bool`
+> - `activity_feed_error`: `error_code: string`
+> And the `activity_item_tapped` event's `entity_id` parameter is
+> hashed via `hashFriendshipId()` from
+> `lib/core/telemetry/event_id_hash.dart` (ADR-0013, 16 hex chars)
+> WHEN the entity is a friendship composite UID; single-UID and
+> expense-ID entities are NOT subject to ADR-0013 hashing per the
+> memory ratified in FR-FR-03 (the friendship composite is the
+> sensitive identifier — opaque scalar IDs are not).
+
+#### AC-15 — Invariant 1 boundary contract (client)
+
+> Given the PR diff
+> When scanned for `.toDouble()`, `parseFloat`, `/ 100`, `.toFixed`,
+> or `double ` declarations on monetary fields
+> Then ZERO violations exist anywhere in `lib/features/activity/**`
+> or `lib/core/widgets/lists/obt_activity_row.dart`
+> And the new boundary-contract grep at
+> `test/features/activity/activity_boundary_contract_test.dart` is
+> the affirmative test (mirrors
+> `test/features/expenses/expense_creation_boundary_contract_test.dart`).
+
+#### AC-16 — Invariant 2 negative guard
+
+> Given the PR diff
+> When scanned
+> Then ZERO new writes to `simplifiedBalances` exist anywhere
+> And the client surface is read-only on `activity/{currentUid}/items`
+> And the settlement-trigger extension touches only `activity/**`,
+> NOT `simplifiedBalances` (the existing `recomputeAndWrite` is
+> unchanged).
+
+#### AC-17 — PII hashing on telemetry
+
+> Given the `activity_item_tapped` event fires for a row whose
+> deep-link target is a friendship composite UID
+> When the event parameters are inspected
+> Then the `entity_id` is the SHA-256-truncated hash via
+> `hashFriendshipId()` from `lib/core/telemetry/event_id_hash.dart`
+> (16 hex chars)
+> And the affirmative test lives in
+> `test/features/activity/presentation/activity_feed_screen_test.dart`.
+
+#### AC-18 — Integration test extension (settlement-trigger)
+
+> Given the PR diff
+> When `functions/test/integration/on-settlement-write.integration.test.ts`
+> is inspected
+> Then TWO new round-trip tests exist:
+> 1. Settlement create-then-read for both parties asserting per-party
+>    activity-item count == 1, `type == 'settlement'`, and key
+>    payload fields (`fromUserId`, `toUserId`, `amountPaise`,
+>    `contextType`, `contextId`).
+> 2. Settlement soft-delete asserts NO new activity item appears for
+>    either party after the delete (per AC-11).
+
+---
+
+## Telemetry Events
+
+Client-side Firebase Analytics events via the existing
+`analyticsServiceProvider` abstraction. All events are PII-free per
+SRS section 5.4 and ADR-0013. Friendship IDs are hashed via
+`hashFriendshipId()` from `lib/core/telemetry/event_id_hash.dart`
+(SHA-256 truncated to 16 hex chars). Single-UID and expense-ID
+entities are NOT hashed (opaque scalar IDs are not the ADR-0013
+target).
+
+| Event name | Parameters | Trigger | SRS Reference |
+|---|---|---|---|
+| `activity_feed_viewed` | `item_count: int` | Screen opens in Populated or Empty state (fired ONCE per session per SCR-25 telemetry contract) | SRS section 5.10 |
+| `activity_item_tapped` | `event_type: string`, `entity_id: string` | User taps an activity row. `entity_id` is hashed via `hashFriendshipId()` when the deep-link target is a friendship composite UID; otherwise the raw opaque ID is used. | SRS section 5.10 |
+| `activity_feed_refreshed` | `success: bool` | Pull-to-refresh completes (success or failure) | SRS section 5.10 |
+| `activity_feed_error` | `error_code: string` | The snapshot listener emits an `AsyncError` | SRS section 5.10 |
+
+Naming follows the verb-past pattern (Camp B) ratified in PR #38
+chore #25 (`expense_save_succeeded`, `expense_save_failed` etc.).
+`activity_feed_viewed` parallels `friends_list_viewed`;
+`activity_item_tapped` parallels `friend_row_tapped`.
+
+**Server-side structured-log events** (settlement-trigger extension):
+the same three event constants from FR-EX-07
+(`activity_item_written`, `activity_item_write_failed`,
+`activity_emission_completed`) are reused with `eventType: 'settlement'`
+discriminator; no new event names are introduced server-side. The
+existing PII guard applies — every UID-derived parameter is hashed
+via `hashId()`.
+
+---
+
+## Invariant Applicability Assessment
+
+| # | Invariant | Applicability |
+|---|---|---|
+| 1 | Money is integer paise | **Applicable on the SCR-25 render path.** The trailing amount on `OBTActivityRow` MUST use `formatInrFromPaise(int)` from `lib/core/formatters/inr_formatter.dart`. ZERO inline `/100` arithmetic anywhere in `lib/features/activity/**` or `lib/core/widgets/lists/obt_activity_row.dart`. The new boundary-contract grep at `test/features/activity/activity_boundary_contract_test.dart` is the affirmative test. The Functions-side settlement-payload builder preserves the integer invariant — `amountPaise` is passed through unchanged from the source settlement doc; the existing Functions-side boundary-contract grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new file. |
+| 2 | `simplifiedBalances` server-maintained | **N/A on the activity-read path.** The client reads `activity/{currentUid}/items`, NOT `simplifiedBalances`. The settlement-trigger extension touches only `activity/**`; the existing `recomputeAndWrite` is unchanged. AC-16 is the explicit negative-guard test. |
+| 3 | System share sheet only | N/A. The activity-feed screen has no outbound sharing surface. |
+| 4 | Single Firebase project | **Applicable — defence-in-depth.** The new client surface targets the single production project; the settlement-trigger deployment is an in-place handler update; `.firebaserc` is unchanged. |
+
+PII / ADR-0013 compliance: the `activity_item_tapped` event hashes
+the `entity_id` parameter via `hashFriendshipId()` when the entity is
+a friendship composite UID. Other entity types (`expenseId`,
+`settlementId`) are opaque auto-generated Firestore IDs and are NOT
+subject to ADR-0013 per the memory ratified by FR-FR-03 architect
+notes (the friendship composite is the sensitive identifier; opaque
+scalar IDs are not). The server-side structured-log events
+(`activity_item_written` etc.) continue to hash every UID-derived
+parameter per the existing FR-EX-07 contract — no change to the
+server-side PII posture.
+
+---
+
+## Definition of Done
+
+Reference: `docs/design/08-plan/definition-of-ready-and-done.md`
+
+- [ ] Code merged to `main` via approved PR.
+- [ ] Cloud Functions settlement-trigger handler deployed in-place to
+      `asia-south1` (Mumbai) — verified via the manual smoke matrix
+      in the PR body.
+- [ ] Flutter widget tests pass (the new Activity-feature widget
+      tests + the OBTActivityRow widget tests).
+- [ ] Cloud Functions unit tests pass — at least 10 new tests
+      across `settlement-payload-builder.test.ts`,
+      `activity-validator.test.ts` (extended), and
+      `function.test.ts` (extended).
+- [ ] Security-rules unit tests pass UNCHANGED at 188 (no rules
+      diff in this PR).
+- [ ] Integration tests pass — 2 new round-trip tests per AC-18 in
+      `on-settlement-write.integration.test.ts`.
+- [ ] Boundary-contract grep at
+      `test/features/activity/activity_boundary_contract_test.dart`
+      returns 0 violations.
+- [ ] Functions-side boundary-contract grep at
+      `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+      returns 0 violations (auto-covers the new payload-builder).
+- [ ] `dart format --set-exit-if-changed .` exits 0.
+- [ ] `flutter analyze --fatal-infos` returns "No issues found".
+- [ ] QA manual smoke matrix completed and signed off (Phase 5 step
+      11 of `docs/copilot_prompts/sprint_2/15.md`).
+- [ ] Telemetry events in place; PII hashing verified by the screen
+      widget test affirmative assertion (AC-17).
+- [ ] Invariant compliance confirmed (Invariants 1 + 4 applicable;
+      Invariant 2 negative-guard test green; Invariant 3 N/A).
+- [ ] Coverage gate green (Flutter overall ≥ 50% on changed lines;
+      new Activity feature folder ≥ 70%).
+- [ ] Documentation updated: `sprint-2-plan.md` (PR #52 row, 8 SP,
+      cumulative 63 SP / 16 PRs); `next-three-prs.md` (PR #53 / #54 /
+      #55 candidates); `07-bucket-b-burndown.md` (PR #52 entry).
+- [ ] No open S1 or S2 bugs.
+
+---
+
+## Invariant Compliance
+
+- [ ] Invariant 1 (paise): applicable on the SCR-25 render path. The
+      `OBTActivityRow` trailing amount uses `formatInrFromPaise(int)`;
+      ZERO inline `/100` arithmetic anywhere in
+      `lib/features/activity/**`. The new boundary-contract grep is
+      the affirmative test. The Functions-side payload builder
+      preserves the integer invariant (passes `amountPaise` through
+      unchanged); the existing Functions-side boundary-contract grep
+      auto-covers.
+- [ ] Invariant 2 (`simplifiedBalances` server-only): the existing
+      single-writer enforcement is unchanged. ZERO new writes to
+      `simplifiedBalances` in the PR diff (AC-16 is the explicit
+      negative-guard test). The client reads `activity/{uid}/items`,
+      NOT `simplifiedBalances`.
+- [ ] Invariant 3 (system share sheet only): N/A in this story.
+- [ ] Invariant 4 (single Firebase project): compliant — production
+      only, with emulator-backed pre-merge verification.
+
+---
+
+## Design Artefact References
+
+| Artefact | Path |
+|---|---|
+| Screen spec — Activity Feed (SCR-25) | `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386 |
+| Firestore schema (`activity/{userId}/items/{itemId}`) | `docs/design/07-technical/firestore-schema.md` lines 194-211 |
+| Component catalogue (OBTActivityRow) | `docs/design/02-design-system/components.md` section 14 |
+| Cloud Functions catalogue (`onSettlementWrite`) | `docs/design/07-technical/cloud-functions-catalogue.md` |
+| Existing trigger handler (FR-SE-05/06, FR-EX-07) | `functions/src/triggers/on-settlement-write/function.ts`, `functions/src/triggers/on-expense-write/function.ts` |
+| Existing FR-EX-07 story (settlement-trigger reuse contract) | `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` |
+| Existing FR-FR-03 story (StreamProvider blueprint) | `docs/sprint-zero/stories/FR-FR-03-friends-list.md` |
+| ADR — Riverpod state management | `.github/shared/decision-log.md` ADR-0006 |
+| ADR — Feature-first folder layout | `.github/shared/decision-log.md` ADR-0007 |
+| ADR — PII / telemetry hashing | `.github/shared/decision-log.md` ADR-0013 |
+| ADR — Rules-readable user collection | `.github/shared/decision-log.md` ADR-0014 |
+| Feature-PR conventions | `docs/patterns/feature-pr-conventions.md` |
+
+---
+
+## Responsible Agents
+
+| Agent | Responsibility |
+|---|---|
+| PM | Story authorship, AC clarity, scope discipline (no widening to FCM push notifications, notification preferences, cold-start deep-link, OBTBottomNav shell, OBTRupeeText primitive, group-context activity emission, read/unread markers, pagination, filter/search, or settlement-deleted activity items; those are separate stories or future work). |
+| Architect | Bottom-nav shell deferral, settlement soft-delete decision, activity-writer reuse-vs-rename decision, settlement payload schema, provider granularity, OBTActivityRow widget API, files-to-touch / files-not-to-touch, anticipated reconciliations. |
+| Cloud Functions Dev | Settlement-payload-builder + validator extension + ActivityItemType extension + settlement-trigger handler extension + function-boundary tests + integration-test extension. |
+| Flutter Dev | `lib/features/activity/**` feature folder (data / domain / application / presentation), `OBTActivityRow` primitive, `/activity` route wiring, `HomePlaceholderScreen` AppBar action, all client-side widget + provider + formatter tests. |
+| DevOps | No new CI workflow changes; the new tests run in the existing CI jobs (`flutter test`, `npm test`, `npm run test:integration` inside `firebase emulators:exec`). |
+| QA | Manual smoke matrix sign-off (Phase 5 step 11), DoD §3 sign-off with evidence for: (a) cross-user real-time render of expense events; (b) settlement-trigger writes both parties' activity items end-to-end; (c) deep-link routing per the SCR-25 table; (d) pull-to-refresh behaviour per AC-9; (e) settlement-deleted does NOT emit an activity item per AC-11. |
+
+---
+
+## Technical Notes
+
+- **Settlement-trigger entry-point:**
+  `functions/src/triggers/on-settlement-write/function.ts` is extended
+  in place. The new activity-emission helper (`emitSettlementActivity`)
+  lives AFTER the successful `simplified_debts_compute_completed` log
+  at the bottom of the handler, mirroring the FR-EX-07
+  `emitExpenseActivity` placement.
+- **Region:** `asia-south1` (Mumbai). The trigger is already
+  registered there; this PR is an in-place handler extension.
+- **Retry:** the trigger's existing retry posture is unchanged.
+  Settlement-activity-emission failures are CONTAINED inside the
+  outer try/catch (mirror of the FR-EX-07 contract) — a per-member
+  activity-write failure does NOT propagate to the trigger's success
+  branch, so Cloud Functions does NOT retry the whole trigger on
+  activity-write failures.
+- **Two writes per invocation:** the activity-writer writes ONE
+  document per settlement party. For the two-party friendship
+  settlement context (v1.0; groups are Sprint 3), that is exactly TWO
+  documents per trigger invocation.
+- **Soft-delete decision:** the settlement-trigger update branch
+  detects `before.deleted === false && after.deleted === true` and
+  SKIPS the activity emission entirely. Documented in code as a
+  comment. No `settlementDeleted` discriminator is introduced. (See
+  Architect Notes §2.2 for rationale.)
+- **Activity-writer reuse:** the existing `writeExpenseActivity`
+  function name is retained (the rename to `writeContextActivity`
+  recommended by the prompt §2.3 is DEFERRED per Architect Notes §2.3
+  to minimise blast radius and avoid breaking the existing PR #51
+  tests + Cloud Logging dashboards). The settlement-trigger calls
+  `writeExpenseActivity({friendshipId: contextId, expenseId:
+  settlementId, eventType: 'settlement', payload, memberIds})` with a
+  code comment documenting the misnomer.
+- **Client snapshot listener:** `activityFeedProvider` is a single
+  `StreamProvider<List<ActivityFeedItem>>` (NO `family` parameter)
+  over `FirebaseFirestore.collection('activity').doc(currentUid)
+  .collection('items').orderBy('createdAt', descending: true)
+  .snapshots()`. The current UID is read from the existing
+  `currentUserIdProvider` from FR-FR-03.
+- **Strict parsing:** the repository's snake_case → camelCase mapper
+  drops malformed payloads silently and reports each drop via a
+  structured-log callback (mirrors the `FriendshipDoc.fromFirestore`
+  pattern from FR-FR-03). Unknown event types are dropped (group
+  events are not yet emitted but the schema enumerates them; the
+  client is forward-compatible).
+- **Display name resolution:** the SCR-25 primary text needs the
+  OTHER party's display name (e.g. "Priya added 'Dinner'"). The
+  existing `userProfileProvider` from FR-FR-03 is the canonical
+  accessor; it is rules-readable for friendship members per PR #35
+  (FR-FR-03 architect notes §4).
+- **Test paths:**
+  - `functions/test/triggers/on-settlement-write/settlement-payload-builder.test.ts`
+    — NEW unit tests for the pure mapping function.
+  - `functions/test/triggers/on-expense-write/activity-validator.test.ts`
+    — EXTEND with `validateSettlementPayload` tests.
+  - `functions/test/triggers/on-settlement-write/function.test.ts`
+    — EXTEND with assertions that the activity-writer is invoked from
+    the trigger on the create success branch and NOT invoked on the
+    soft-delete / CONTEXT_NOT_FOUND / BALANCE_INVARIANT_VIOLATED /
+    stale-event-drop branches.
+  - `functions/test/integration/on-settlement-write.integration.test.ts`
+    — EXTEND with 2 new round-trip tests per AC-18.
+  - `test/features/activity/domain/activity_feed_item_test.dart` —
+    NEW parser + drop-malformed tests.
+  - `test/features/activity/application/activity_feed_provider_test.dart`
+    — NEW provider unit tests using `ProviderContainer` overrides.
+  - `test/features/activity/application/relative_timestamp_formatter_test.dart`
+    — NEW boundary-case tests for every SCR-25 timestamp range.
+  - `test/features/activity/presentation/activity_feed_screen_test.dart`
+    — NEW widget tests for Loading / Populated / Empty / Error /
+    Refreshing states.
+  - `test/features/activity/activity_boundary_contract_test.dart` —
+    NEW grep parallel to the expenses-feature contract.
+  - `test/core/widgets/lists/obt_activity_row_test.dart` — NEW widget
+    tests for the OBTActivityRow primitive across all event types.
+
+---
+
+## Out of Scope (explicitly deferred — hand-off seams documented in code)
+
+- **`OBTBottomNav` shell.** Separate UX PR; the temporary
+  `HomePlaceholderScreen` AppBar action is the v1.0 entry point. The
+  bottom-nav shell is needed when Friends + Groups + Activity +
+  Profile tabs are all needed simultaneously (likely Sprint 3
+  alongside the groups epic).
+- **`OBTRupeeText` primitive.** Separate OBT-primitives PR; the
+  `OBTActivityRow` trailing amount uses inline
+  `Text(formatInrFromPaise(amountPaise))` (a 5-line wrapper that
+  adds no semantic value beyond what `OBTActivityRow` itself needs).
+  See Architect Notes §2.6.
+- **FR-AC-03 — FCM push notifications.** Separate P0 story;
+  introduces the FCM dependency + the `notificationPrefs` schema +
+  per-user `fcmTokens` plumbing.
+- **FR-AC-04 — notification preferences.** Paired with FR-AC-03.
+- **FR-AC-05 — cold-start deep-link.** Paired with FR-AC-03 (the
+  cold-start signal comes from FCM).
+- **Group-context activity emission.** Sprint 3 groups epic (the
+  `onExpenseWriteGroup` and `onSettlementWrite` group-context
+  activity emission).
+- **Read/unread markers.** SCR-25 Open Question 1; v1.1 candidate
+  per the SCR.
+- **Pagination / cursor-based read.** SCR-25 Open Question 2; v1.0
+  loads all activity items via the single snapshot listener.
+  Architect Notes §2.9 item 8 flags the cutoff at which performance
+  degrades (~1000 items).
+- **Filter / search within activity.** SCR-25 Open Question 3;
+  deferred.
+- **`settlementDeleted` activity items.** v1.0 decision per
+  Architect Notes §2.2 — soft-delete does NOT emit an activity item.
+- **Cosmetic rename of `writeExpenseActivity` → `writeContextActivity`.**
+  Deferred per Architect Notes §2.3 — keeps PR #51 tests and Cloud
+  Logging dashboards untouched. Future cleanup PR may rename the
+  function, type, and log-key (`expenseIdHash` → `entityIdHash`) as
+  a single focused change.
+- **Issue #47 — Firestore rules-hardening for non-creator
+  update/delete.** Separate small chore PR.
+- **Issue #49 — Orphan-cleanup Cloud Function for receipts.** FUTURE.
+- **Issue #50 — Trigger no-op-recompute optimisation.** EXPLICITLY
+  REFUSED for bundling — would BREAK FR-EX-07 AC-2.
+- **Concurrent-edit detection for FR-EX-06.** Still deferred.
+- **Rate-limit transaction race refactor.** Still deferred.

--- a/functions/src/triggers/on-expense-write/activity-validator.ts
+++ b/functions/src/triggers/on-expense-write/activity-validator.ts
@@ -20,6 +20,7 @@ import type {
   ExpenseAddedPayload,
   ExpenseDeletedPayload,
   ExpenseEditedPayload,
+  SettlementPayload,
 } from "./payload-builder";
 
 /**
@@ -51,6 +52,9 @@ export function validateActivityPayload(
       return;
     case "expense_deleted":
       validateExpenseDeletedPayload(payload as ExpenseDeletedPayload);
+      return;
+    case "settlement":
+      validateSettlementPayload(payload as SettlementPayload);
       return;
     default: {
       const _exhaustive: never = eventType;
@@ -142,6 +146,76 @@ function validateExpenseDeletedPayload(payload: ExpenseDeletedPayload): void {
   if (payload.deletedAt === undefined || payload.deletedAt === null) {
     throw new Error(
       "validateActivityPayload: expense_deleted.deletedAt is required.",
+    );
+  }
+}
+
+/**
+ * Validates a `settlement` payload (FR-AC-01 architect §2.4). Required
+ * fields: settlementId, fromUserId, toUserId, amountPaise, contextType,
+ * contextId, authorUid. The `note` field is optional.
+ */
+function validateSettlementPayload(payload: SettlementPayload): void {
+  assertHasFields("settlement", payload, [
+    "settlementId",
+    "fromUserId",
+    "toUserId",
+    "amountPaise",
+    "contextType",
+    "contextId",
+    "authorUid",
+  ] as const);
+
+  if (typeof payload.settlementId !== "string" ||
+    payload.settlementId.length === 0) {
+    throw new Error(
+      "validateActivityPayload: settlement.settlementId must be a " +
+        "non-empty string.",
+    );
+  }
+  if (typeof payload.fromUserId !== "string" ||
+    payload.fromUserId.length === 0) {
+    throw new Error(
+      "validateActivityPayload: settlement.fromUserId must be a " +
+        "non-empty string.",
+    );
+  }
+  if (typeof payload.toUserId !== "string" || payload.toUserId.length === 0) {
+    throw new Error(
+      "validateActivityPayload: settlement.toUserId must be a " +
+        "non-empty string.",
+    );
+  }
+  if (typeof payload.amountPaise !== "number" ||
+    !Number.isInteger(payload.amountPaise) ||
+    payload.amountPaise <= 0) {
+    throw new Error(
+      "validateActivityPayload: settlement.amountPaise must be a positive " +
+        "integer.",
+    );
+  }
+  if (payload.contextType !== "friendship" && payload.contextType !== "group") {
+    throw new Error(
+      "validateActivityPayload: settlement.contextType must be 'friendship' " +
+        "or 'group'.",
+    );
+  }
+  if (typeof payload.contextId !== "string" || payload.contextId.length === 0) {
+    throw new Error(
+      "validateActivityPayload: settlement.contextId must be a " +
+        "non-empty string.",
+    );
+  }
+  if (typeof payload.authorUid !== "string" || payload.authorUid.length === 0) {
+    throw new Error(
+      "validateActivityPayload: settlement.authorUid must be a " +
+        "non-empty string.",
+    );
+  }
+  if (payload.note !== undefined && typeof payload.note !== "string") {
+    throw new Error(
+      "validateActivityPayload: settlement.note, when present, must be " +
+        "a string.",
     );
   }
 }

--- a/functions/src/triggers/on-expense-write/payload-builder.ts
+++ b/functions/src/triggers/on-expense-write/payload-builder.ts
@@ -22,13 +22,17 @@ import type {Timestamp} from "firebase-admin/firestore";
 /**
  * Activity-item type discriminator. Values match the canonical
  * enumeration in docs/design/07-technical/firestore-schema.md line 202.
- * The two remaining schema-doc variants (`'settlement'`, `'group_change'`)
- * are FUTURE work and are NOT emitted by this builder.
+ * The remaining schema-doc variant (`'group_change'`) is FUTURE work
+ * (Sprint 3 groups epic).
+ *
+ * `'settlement'` is emitted by the settlement-trigger
+ * (functions/src/triggers/on-settlement-write/) per FR-AC-01.
  */
 export type ActivityItemType =
   | "expense_added"
   | "expense_edited"
-  | "expense_deleted";
+  | "expense_deleted"
+  | "settlement";
 
 /** Trigger change discriminator (mirrors `function.ts` `ChangeType`). */
 export type ChangeType = "create" | "update" | "delete";
@@ -82,11 +86,31 @@ export interface ExpenseDeletedPayload {
   deletedAt: Timestamp;
 }
 
+/**
+ * `settlement` payload — emitted by the settlement-trigger
+ * (FR-AC-01 architect notes §2.4). Captures the directional fields
+ * needed by the SCR-25 row ("You settled up with X" vs "X settled
+ * up with you") plus the deep-link target identifier (`contextId`
+ * is the friendship document ID; `settlementId` is the auto-ID
+ * Firestore assigns to the settlement document).
+ */
+export interface SettlementPayload {
+  settlementId: string;
+  fromUserId: string;
+  toUserId: string;
+  amountPaise: number;
+  contextType: "friendship" | "group";
+  contextId: string;
+  note?: string;
+  authorUid: string;
+}
+
 /** Discriminated union of every payload shape this builder emits. */
 export type ActivityPayload =
   | ExpenseAddedPayload
   | ExpenseEditedPayload
-  | ExpenseDeletedPayload;
+  | ExpenseDeletedPayload
+  | SettlementPayload;
 
 /** Result tuple of `buildExpenseActivityPayload`. */
 export interface BuiltActivityPayload {

--- a/functions/src/triggers/on-settlement-write/function.ts
+++ b/functions/src/triggers/on-settlement-write/function.ts
@@ -232,20 +232,19 @@ export function createTriggerHandler(
       return;
     }
 
-    // 3. Hand-off seams for downstream stories (placement parity with
+    // 3. Hand-off seam for downstream story (placement parity with
     //    the expense trigger):
-    //    TODO(FR-AC-01): write activity-feed items to both parties'
-    //      activity/{userId}/items subcollection after successful
-    //      recompute.
     //    TODO(FR-AC-03): send FCM push notification to the toUserId
     //      respecting notificationPrefs.settlement.
-    //    Placement note: both seams must execute ONLY after a
+    //    Placement note: the FCM seam must execute ONLY after a
     //    successful recompute (i.e. inside or just below the success
     //    branch at the bottom of this handler) to keep retry semantics
     //    clean — a retryable transient failure must not duplicate
-    //    activity items or notifications. Today they are deferred
-    //    entirely; the actual placement decision lives with the story
-    //    that implements them.
+    //    notifications. Today the FCM seam is deferred entirely; the
+    //    actual placement decision lives with the story that
+    //    implements it. The FR-AC-01 activity-feed emission seam was
+    //    closed by the emitSettlementActivity call at the bottom of
+    //    this handler (step 8 below).
 
     // 4. Build the alsoSet payload — atomically advance lastActivityAt
     //    inside the same transaction as the simplifiedBalances write.

--- a/functions/src/triggers/on-settlement-write/function.ts
+++ b/functions/src/triggers/on-settlement-write/function.ts
@@ -61,6 +61,12 @@ import {
   ContextType,
 } from "../../simplified-debts/function";
 import {hashId} from "../../utils/id-hash";
+import {writeExpenseActivity} from "../on-expense-write/activity-writer";
+import {
+  buildSettlementActivityPayload,
+  ChangeType as ActivityChangeType,
+  SettlementDocData,
+} from "./settlement-payload-builder";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -313,5 +319,132 @@ export function createTriggerHandler(
       elapsedMs: Date.now() - startTime,
       transferCount: result.transfers.length,
     });
+
+    // 8. FR-AC-01: emit activity-feed items to BOTH parties.
+    //    Mirror of the FR-EX-07 expense-trigger contract at
+    //    on-expense-write/function.ts. The activity-writer
+    //    contains its own per-member errors (Promise.allSettled);
+    //    the validator throw (programmer error) is caught here so the
+    //    trigger's success branch is preserved (architect §2.9 item 2).
+    await emitSettlementActivity(deps, {
+      settlementId,
+      changeType,
+      contextType,
+      contextIdHash,
+      settlementIdHash,
+      changeData: event.data,
+    });
   };
+}
+
+// ---------------------------------------------------------------------------
+// Activity emission (FR-AC-01)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminates the activity event type and writes one item per
+ * settlement party. Wraps `writeExpenseActivity` with the settlement-
+ * trigger-specific (a) soft-delete detection (architect §2.2 — no
+ * emission), (b) party-ID resolution from the settlement doc itself
+ * (the rules at firestore.rules:445-455 require fromUserId and
+ * toUserId; no second .get() is needed), and (c) defensive try/catch
+ * for programmer errors (validator throws).
+ *
+ * Per architect §2.9 item 2: NEVER rethrows. Activity-emission
+ * failures must not propagate into the trigger's success branch,
+ * otherwise Cloud Functions would retry the whole invocation and
+ * potentially re-duplicate activity items on the successful members.
+ *
+ * The activity-writer's `WriteExpenseActivityRequest` interface
+ * pre-dates the settlement consumer; the field names `friendshipId`
+ * and `expenseId` are misnomers when the source entity is a
+ * settlement. The architect deferred the rename to keep PR #51's
+ * tests and the Cloud Logging schema stable. FUTURE-work cleanup PR
+ * may rename to `writeContextActivity` + `contextId` + `entityId` +
+ * `entityIdHash`.
+ */
+async function emitSettlementActivity(
+  deps: Dependencies,
+  params: {
+    settlementId: string;
+    changeType: ActivityChangeType;
+    contextType: ContextType;
+    contextIdHash: string;
+    settlementIdHash: string;
+    changeData: Change<DocumentSnapshot> | undefined;
+  },
+): Promise<void> {
+  const {logger} = deps;
+  const {
+    settlementId,
+    changeType,
+    contextType,
+    contextIdHash,
+    settlementIdHash,
+    changeData,
+  } = params;
+
+  try {
+    const beforeData = changeData?.before?.exists
+      ? (changeData.before.data() as SettlementDocData | undefined)
+      : undefined;
+    const afterData = changeData?.after?.exists
+      ? (changeData.after.data() as SettlementDocData | undefined)
+      : undefined;
+
+    const built = buildSettlementActivityPayload(changeType, {
+      settlementId,
+      before: beforeData,
+      after: afterData,
+    });
+
+    // V1.0 emission policy: only create events emit activity items.
+    // Soft-delete and hard-delete return null from the builder; we
+    // short-circuit cleanly here.
+    if (built === null) {
+      return;
+    }
+
+    // Resolve memberIds from the source settlement doc directly.
+    // For friendship-context settlements, both UIDs are required by
+    // the security rules; we use the source-of-truth values from the
+    // settlement document rather than re-reading the parent context
+    // doc (no additional Firestore read needed — saves cost and
+    // race risk).
+    const sourceData = afterData ?? beforeData;
+    if (!sourceData) {
+      logger.info("activity_emission_skipped_missing_data", {
+        event: "activity_emission_skipped_missing_data",
+        contextType,
+        contextIdHash,
+        settlementIdHash,
+      });
+      return;
+    }
+    const memberIds = [sourceData.fromUserId, sourceData.toUserId];
+
+    await writeExpenseActivity(deps, {
+      friendshipId: sourceData.contextId,
+      expenseId: settlementId,
+      eventType: built.eventType,
+      payload: built.payload,
+      memberIds,
+    });
+  } catch (err: unknown) {
+    // Defence-in-depth: writeExpenseActivity itself uses
+    // Promise.allSettled and never rethrows for per-member Firestore
+    // failures. But the validator inside it DOES throw on programmer
+    // error (e.g. a malformed payload), and the payload-builder
+    // throws on inconsistent (changeType, before, after) tuples.
+    // Both are programmer errors that should NOT mark the trigger as
+    // failed — the recompute is already done; failing here would
+    // only cause a retry-storm that re-runs the recompute.
+    logger.error("activity_emission_internal_error", {
+      event: "activity_emission_internal_error",
+      contextType,
+      contextIdHash,
+      settlementIdHash,
+      errorMessage: err instanceof Error ? err.message : "unknown",
+    });
+  }
 }

--- a/functions/src/triggers/on-settlement-write/settlement-payload-builder.ts
+++ b/functions/src/triggers/on-settlement-write/settlement-payload-builder.ts
@@ -1,0 +1,142 @@
+/**
+ * Activity Payload Builder for the settlement trigger (FR-AC-01).
+ *
+ * Pure function that maps the settlement-trigger
+ * `(changeType, before, after)` tuple to a typed `BuiltActivityPayload`
+ * for embedding inside an `activity/{userId}/items/{auto-id}` document.
+ * Mirrors the FR-EX-07 payload-builder convention; the sibling
+ * placement (under `on-settlement-write/`) keeps the trigger-specific
+ * mapping co-located with its consumer.
+ *
+ * Architect ratification: FR-AC-01 architect notes §2.2 (soft-delete
+ * emits NO activity item) and §2.4 (settlement payload schema).
+ *
+ * @module triggers/on-settlement-write/settlement-payload-builder
+ */
+
+import type {
+  ActivityItemType,
+  ActivityPayload,
+  SettlementPayload,
+} from "../on-expense-write/payload-builder";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Trigger change discriminator (mirrors `function.ts` `ChangeType`). */
+export type ChangeType = "create" | "update" | "delete";
+
+/**
+ * Shape of the source settlement document (subset relevant to the
+ * activity payload). Mirrors the fields read by the trigger handler's
+ * `extractContextDiscriminator` plus the additional fields needed by
+ * the activity payload (`fromUserId`, `toUserId`, `amountPaise`,
+ * `note`).
+ */
+export interface SettlementDocData {
+  fromUserId: string;
+  toUserId: string;
+  amountPaise: number;
+  contextType: "friendship" | "group";
+  contextId: string;
+  note?: string | null;
+  deleted?: boolean;
+}
+
+/** Result tuple of `buildSettlementActivityPayload`. */
+export interface BuiltActivityPayload {
+  eventType: ActivityItemType;
+  payload: ActivityPayload;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a settlement-trigger event to the activity-payload pair
+ * `{ eventType, payload }` for emission into
+ * `activity/{userId}/items/{auto-id}` documents.
+ *
+ * V1.0 emission policy (architect §2.2):
+ *
+ *   - `'create'`: emit `{eventType: 'settlement', payload: {...}}`.
+ *   - `'update'`: NO emission (settlements only update on soft-delete
+ *     per the rules at firestore.rules:461-469; the SCR-25 Event Type
+ *     Mapping has no `settlementDeleted` row; v1.0 contract is
+ *     "no activity item on settlement soft-delete").
+ *   - `'delete'`: NO emission (hard-delete is admin-only; no SCR-25
+ *     row type).
+ *
+ * The `null` return signals "no activity emission for this branch"
+ * — the caller MUST short-circuit before invoking the activity-writer
+ * when this function returns null.
+ *
+ * @param changeType - The trigger's change discriminator.
+ * @param request - The settlement document ID + before/after snapshots.
+ *   `after` is required for `'create'`; `before` is required for
+ *   `'delete'`; both are required for `'update'`.
+ * @returns The typed `{eventType, payload}` tuple for create events;
+ *   `null` for update/delete events (no activity emission).
+ *
+ * @throws Error if the `(changeType, before, after)` combination is
+ *   inconsistent (e.g. `'create'` with no `after`).
+ */
+export function buildSettlementActivityPayload(
+  changeType: ChangeType,
+  request: {
+    settlementId: string;
+    before?: SettlementDocData;
+    after?: SettlementDocData;
+  },
+): BuiltActivityPayload | null {
+  const {settlementId, after} = request;
+
+  if (changeType === "create") {
+    if (!after) {
+      throw new Error(
+        "buildSettlementActivityPayload: 'create' requires 'after' snapshot.",
+      );
+    }
+    return {
+      eventType: "settlement",
+      payload: buildSettlementPayload(settlementId, after),
+    };
+  }
+
+  // Both 'update' (soft-delete) and 'delete' (hard-delete) emit NO
+  // activity item per architect §2.2. Documented in code so the caller
+  // can short-circuit cleanly.
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the `settlement` payload from the source settlement document.
+ * The `note` field is omitted when the source value is null or
+ * undefined; included when present and non-empty.
+ */
+function buildSettlementPayload(
+  settlementId: string,
+  data: SettlementDocData,
+): SettlementPayload {
+  const payload: SettlementPayload = {
+    settlementId,
+    fromUserId: data.fromUserId,
+    toUserId: data.toUserId,
+    amountPaise: data.amountPaise,
+    contextType: data.contextType,
+    contextId: data.contextId,
+    authorUid: data.fromUserId,
+  };
+
+  if (typeof data.note === "string" && data.note.length > 0) {
+    payload.note = data.note;
+  }
+
+  return payload;
+}

--- a/functions/test/integration/on-settlement-write.integration.test.ts
+++ b/functions/test/integration/on-settlement-write.integration.test.ts
@@ -419,4 +419,192 @@ describe("onSettlementWrite — integration (registered trigger)", () => {
       expect(final!.simplifiedBalances).toEqual({});
     });
   });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-18 (round-trip 1) — settlement create writes activity
+  // items to BOTH parties.
+  //
+  // 1. Seed friendship A↔B.
+  // 2. Create a settlement B→A 5000 contextId=fid.
+  // 3. Poll for one new activity item in each of
+  //    activity/A/items and activity/B/items.
+  // 4. Assert type='settlement' and key payload fields on each.
+  // -------------------------------------------------------------------------
+  describe("FR-AC-01 AC-18 — settlement-create writes activity items to BOTH parties", () => {
+    const fid = "int-on-settle-activity-create";
+    const contextPath = `friendships/${fid}`;
+
+    beforeEach(async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["activityA", "activityB"],
+        createdBy: "activityA",
+        lastActivityAt: Timestamp.now(),
+        simplifiedBalances: {},
+      });
+    });
+
+    it("writes one settlement activity item to each party's subcollection", async () => {
+      const settlementPath = "settlements/int-on-settle-activity-create-s1";
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "activityB",
+        toUserId: "activityA",
+        amountPaise: 5000,
+        contextId: fid,
+        note: "Pizza repayment",
+      }));
+
+      // Wait for the recompute first (proves the trigger fired).
+      await waitForBalances(contextPath, {});
+
+      // Then poll each party's activity subcollection.
+      const itemsA = await waitForActivityItems(
+        "activityA",
+        (items) => items.length >= 1,
+      );
+      const itemsB = await waitForActivityItems(
+        "activityB",
+        (items) => items.length >= 1,
+      );
+
+      expect(itemsA).toHaveLength(1);
+      expect(itemsB).toHaveLength(1);
+
+      const payloadA = itemsA[0].data.payload as Record<string, unknown>;
+      expect(itemsA[0].data.type).toBe("settlement");
+      expect(payloadA.settlementId).toBe("int-on-settle-activity-create-s1");
+      expect(payloadA.fromUserId).toBe("activityB");
+      expect(payloadA.toUserId).toBe("activityA");
+      expect(payloadA.amountPaise).toBe(5000);
+      expect(payloadA.contextType).toBe("friendship");
+      expect(payloadA.contextId).toBe(fid);
+      expect(payloadA.authorUid).toBe("activityB");
+      expect(payloadA.note).toBe("Pizza repayment");
+
+      // Symmetric check on the second party (same payload, different
+      // recipient).
+      const payloadB = itemsB[0].data.payload as Record<string, unknown>;
+      expect(itemsB[0].data.type).toBe("settlement");
+      expect(payloadB.amountPaise).toBe(5000);
+      expect(payloadB.contextId).toBe(fid);
+
+      // Clean up the activity items (the friendship doc + settlement
+      // doc are tracked by createdDocPaths and will be cleaned
+      // automatically in afterEach).
+      await Promise.all([
+        ...itemsA.map((i) => db.doc(`activity/activityA/items/${i.id}`).delete()),
+        ...itemsB.map((i) => db.doc(`activity/activityB/items/${i.id}`).delete()),
+      ]);
+    }, 15000);
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-18 (round-trip 2) — settlement soft-delete does NOT
+  // emit an activity item (architect §2.2 v1.0 decision).
+  //
+  // 1. Seed friendship + expense (B owes A 5000).
+  // 2. Create settlement B→A 5000 → one activity item per party.
+  // 3. Soft-delete the settlement.
+  // 4. Assert no NEW activity items appear (the post-delete count is
+  //    still 1 per party, NOT 2).
+  // -------------------------------------------------------------------------
+  describe("FR-AC-01 AC-18 — settlement soft-delete does NOT emit an activity item", () => {
+    const fid = "int-on-settle-activity-soft-delete";
+    const contextPath = `friendships/${fid}`;
+    const settlementPath = "settlements/int-on-settle-activity-soft-delete-s1";
+
+    beforeEach(async () => {
+      await seedDoc(contextPath, {
+        memberIds: ["softA", "softB"],
+        createdBy: "softA",
+        lastActivityAt: Timestamp.now(),
+        simplifiedBalances: {},
+      });
+      await seedDoc(`${contextPath}/expenses/exp1`, makeExpense({
+        payerId: "softA",
+        amountPaise: 10000,
+        splits: [
+          {userId: "softA", sharePaise: 5000},
+          {userId: "softB", sharePaise: 5000},
+        ],
+      }));
+      await waitForBalances(contextPath, {softB: {softA: 5000}});
+    });
+
+    it("no new activity items appear after soft-delete", async () => {
+      // Step 1: Create the settlement, wait for recompute and the
+      // post-create activity items.
+      await seedDoc(settlementPath, makeSettlement({
+        fromUserId: "softB",
+        toUserId: "softA",
+        amountPaise: 5000,
+        contextId: fid,
+      }));
+      await waitForBalances(contextPath, {});
+
+      const itemsAfterCreateA = await waitForActivityItems(
+        "softA",
+        (items) => items.length >= 1,
+      );
+      const itemsAfterCreateB = await waitForActivityItems(
+        "softB",
+        (items) => items.length >= 1,
+      );
+      const createdAtCountA = itemsAfterCreateA.length;
+      const createdAtCountB = itemsAfterCreateB.length;
+
+      // Step 2: Soft-delete the settlement.
+      await db.doc(settlementPath).update({deleted: true});
+
+      // Wait for the recompute (proves the trigger fired) — the debt
+      // reverts to {softB: {softA: 5000}}.
+      await waitForBalances(contextPath, {softB: {softA: 5000}});
+
+      // Step 3: Give the trigger a generous window to (NOT) emit a
+      // delete-activity, then assert no new items appeared.
+      await new Promise((r) => setTimeout(r, 2000));
+      const finalA = await readActivityItems("softA");
+      const finalB = await readActivityItems("softB");
+
+      // Per architect §2.2: settlement soft-delete emits NO activity item.
+      // The count is unchanged from before the soft-delete.
+      expect(finalA).toHaveLength(createdAtCountA);
+      expect(finalB).toHaveLength(createdAtCountB);
+
+      // Cleanup activity items.
+      await Promise.all([
+        ...finalA.map((i) => db.doc(`activity/softA/items/${i.id}`).delete()),
+        ...finalB.map((i) => db.doc(`activity/softB/items/${i.id}`).delete()),
+      ]);
+    }, 15000);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Activity-item polling helpers (FR-AC-01)
+// ---------------------------------------------------------------------------
+
+async function readActivityItems(userId: string): Promise<
+  Array<{id: string; data: FirebaseFirestore.DocumentData}>
+> {
+  const snapshot = await db
+    .collection("activity")
+    .doc(userId)
+    .collection("items")
+    .get();
+  return snapshot.docs.map((d) => ({id: d.id, data: d.data()}));
+}
+
+async function waitForActivityItems(
+  userId: string,
+  predicate: (items: Array<{id: string; data: FirebaseFirestore.DocumentData}>)
+    => boolean,
+): Promise<Array<{id: string; data: FirebaseFirestore.DocumentData}>> {
+  const start = Date.now();
+  let items: Array<{id: string; data: FirebaseFirestore.DocumentData}> = [];
+  while (Date.now() - start < POLL_TIMEOUT_MS) {
+    items = await readActivityItems(userId);
+    if (predicate(items)) return items;
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return items;
+}

--- a/functions/test/triggers/on-expense-write/activity-validator.test.ts
+++ b/functions/test/triggers/on-expense-write/activity-validator.test.ts
@@ -15,6 +15,7 @@ import type {
   ExpenseAddedPayload,
   ExpenseDeletedPayload,
   ExpenseEditedPayload,
+  SettlementPayload,
 } from "../../../src/triggers/on-expense-write/payload-builder";
 
 function validExpenseAddedPayload(
@@ -277,3 +278,143 @@ describe("validateActivityPayload — guard rails", () => {
     ).toThrow(/unknown eventType/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// FR-AC-01 AC-13 — settlement payload validation
+// ---------------------------------------------------------------------------
+
+function validSettlementPayload(
+  overrides: Partial<SettlementPayload> = {},
+): SettlementPayload {
+  return {
+    settlementId: "set-1",
+    fromUserId: "uidA",
+    toUserId: "uidB",
+    amountPaise: 5000,
+    contextType: "friendship",
+    contextId: "uidA_uidB",
+    authorUid: "uidA",
+    ...overrides,
+  };
+}
+
+describe("validateActivityPayload — settlement (FR-AC-01)", () => {
+  it("accepts a complete valid settlement payload", () => {
+    expect(() =>
+      validateActivityPayload("settlement", validSettlementPayload()),
+    ).not.toThrow();
+  });
+
+  it("accepts a settlement payload with an optional note", () => {
+    expect(() =>
+      validateActivityPayload(
+        "settlement",
+        validSettlementPayload({note: "Lunch repayment"}),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects payload missing settlementId", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).settlementId;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'settlementId'/);
+  });
+
+  it("rejects payload missing fromUserId", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).fromUserId;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'fromUserId'/);
+  });
+
+  it("rejects payload missing toUserId", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).toUserId;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'toUserId'/);
+  });
+
+  it("rejects payload missing amountPaise", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).amountPaise;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'amountPaise'/);
+  });
+
+  it("rejects payload missing contextType", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).contextType;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'contextType'/);
+  });
+
+  it("rejects payload missing contextId", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).contextId;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'contextId'/);
+  });
+
+  it("rejects payload missing authorUid", () => {
+    const bad = validSettlementPayload();
+    delete (bad as Partial<SettlementPayload>).authorUid;
+    expect(() =>
+      validateActivityPayload("settlement", bad as SettlementPayload),
+    ).toThrow(/missing required field 'authorUid'/);
+  });
+
+  it("rejects non-integer amountPaise (Invariant 1 negative guard)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "settlement",
+        validSettlementPayload({amountPaise: 12.34 as unknown as number}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects zero amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "settlement",
+        validSettlementPayload({amountPaise: 0}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects negative amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "settlement",
+        validSettlementPayload({amountPaise: -1000}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects empty fromUserId", () => {
+    expect(() =>
+      validateActivityPayload(
+        "settlement",
+        validSettlementPayload({fromUserId: ""}),
+      ),
+    ).toThrow(/fromUserId must be a non-empty string/);
+  });
+
+  it("rejects invalid contextType (defence-in-depth — rules enforce too)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "settlement",
+        validSettlementPayload({
+          contextType: "invalid" as unknown as "friendship" | "group",
+        }),
+      ),
+    ).toThrow(/contextType must be 'friendship' or 'group'/);
+  });
+});
+

--- a/functions/test/triggers/on-settlement-write/function.test.ts
+++ b/functions/test/triggers/on-settlement-write/function.test.ts
@@ -21,6 +21,22 @@ import type {Change, DocumentSnapshot, FirestoreEvent} from
   "firebase-functions/v2/firestore";
 import {createTriggerHandler} from
   "../../../src/triggers/on-settlement-write/function";
+import {writeExpenseActivity} from
+  "../../../src/triggers/on-expense-write/activity-writer";
+
+jest.mock("../../../src/triggers/on-expense-write/activity-writer");
+
+const mockedWriteExpenseActivity = writeExpenseActivity as jest.MockedFunction<
+  typeof writeExpenseActivity
+>;
+
+beforeEach(() => {
+  mockedWriteExpenseActivity.mockReset();
+  mockedWriteExpenseActivity.mockResolvedValue({
+    membersSucceeded: 2,
+    membersFailed: 0,
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Mock helpers — copy the function.test.ts pattern with the settlements
@@ -765,5 +781,202 @@ describe("onSettlementWrite handler — boundary", () => {
     expect(
       (db as unknown as {collection: jest.Mock}).collection,
     ).toHaveBeenCalledWith("groups");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-AC-01: trigger ↔ activity-writer contract
+// ---------------------------------------------------------------------------
+
+describe("onSettlementWrite handler — FR-AC-01 activity-writer integration", () => {
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-10: create event invokes writeExpenseActivity with
+  // 'settlement' eventType targeting BOTH parties (fromUserId, toUserId).
+  // -------------------------------------------------------------------------
+  it("calls writeExpenseActivity with 'settlement' on create — both parties targeted", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({changeType: "create", afterData: validSettlementData()}),
+    );
+
+    expect(mockedWriteExpenseActivity).toHaveBeenCalledTimes(1);
+    const [, callRequest] = mockedWriteExpenseActivity.mock.calls[0];
+    expect(callRequest.eventType).toBe("settlement");
+    // Note: the activity-writer's WriteExpenseActivityRequest interface
+    // pre-dates the settlement consumer; the field names friendshipId
+    // and expenseId are misnomers when the source entity is a
+    // settlement (the rename to writeContextActivity + contextId +
+    // entityId is deferred per architect §2.3). The call site passes
+    // contextId via friendshipId and settlementId via expenseId.
+    expect(callRequest.friendshipId).toBe("fid");
+    expect(callRequest.expenseId).toBe("sid");
+    // memberIds resolves to [fromUserId, toUserId] per FR-AC-01 AC-10
+    // — the settlement-trigger does NOT re-read the parent friendship
+    // doc; both UIDs are already present on the settlement document
+    // (rules at firestore.rules:445-455 require them).
+    expect(callRequest.memberIds).toEqual(["userA", "userB"]);
+    // Payload includes the FR-AC-01 §2.4 settlement schema.
+    expect(callRequest.payload).toMatchObject({
+      settlementId: "sid",
+      fromUserId: "userA",
+      toUserId: "userB",
+      amountPaise: 5000,
+      contextType: "friendship",
+      contextId: "fid",
+      authorUid: "userA",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-11: soft-delete (update with deleted: false -> true)
+  // does NOT invoke writeExpenseActivity. v1.0 decision per architect §2.2.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on soft-delete (AC-11)", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [
+        {id: "sid", data: validSettlementData({deleted: true})},
+      ],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "update",
+        beforeData: validSettlementData({deleted: false}),
+        afterData: validSettlementData({deleted: true}),
+      }),
+    );
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-12: stale-event drop branch does NOT invoke
+  // writeExpenseActivity.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on the stale-event-drop branch", async () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: eightDaysAgo,
+        afterData: validSettlementData(),
+      }),
+    );
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-12: CONTEXT_NOT_FOUND branch does NOT invoke
+  // writeExpenseActivity.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on the CONTEXT_NOT_FOUND branch", async () => {
+    const db = createMockDb({contextExists: false, settlements: []});
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await handler(
+      makeEvent({changeType: "create", afterData: validSettlementData()}),
+    );
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-12: BALANCE_INVARIANT_VIOLATED branch (trigger throws
+  // for retry) does NOT invoke writeExpenseActivity.
+  // -------------------------------------------------------------------------
+  it("does NOT call writeExpenseActivity on the BALANCE_INVARIANT_VIOLATED branch", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 4000},
+              {userId: "userB", sharePaise: 3000},
+            ],
+          },
+        },
+      ],
+      settlements: [],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validSettlementData()}),
+      ),
+    ).rejects.toThrow();
+
+    expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-01 AC-12 error containment: when writeExpenseActivity itself
+  // throws (programmer error like a malformed payload caught by the
+  // validator), the trigger must STILL log
+  // simplified_debts_compute_completed and must NOT throw.
+  // -------------------------------------------------------------------------
+  it("contains activity-emission failures — trigger does not throw if writeExpenseActivity throws", async () => {
+    mockedWriteExpenseActivity.mockRejectedValueOnce(
+      new Error("simulated programmer error in payload validator"),
+    );
+
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validSettlementData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+
+    const internalErrorLog = logger.calls.find(
+      (c) => c.data?.event === "activity_emission_internal_error",
+    );
+    expect(internalErrorLog).toBeDefined();
+    expect(internalErrorLog!.level).toBe("error");
   });
 });

--- a/functions/test/triggers/on-settlement-write/settlement-payload-builder.test.ts
+++ b/functions/test/triggers/on-settlement-write/settlement-payload-builder.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for `buildSettlementActivityPayload` — the pure mapping
+ * function that converts a settlement-trigger `(changeType, before,
+ * after)` tuple into the typed `BuiltActivityPayload` for emission
+ * into `activity/{userId}/items/{auto-id}` documents.
+ *
+ * Covers ACs (FR-AC-01):
+ *   - AC-10 (positive): create-branch returns `{eventType:
+ *     'settlement', payload: {settlementId, fromUserId, toUserId,
+ *     amountPaise, contextType, contextId, note?, authorUid}}`.
+ *   - AC-11 (negative): soft-delete-branch returns null (no
+ *     emission). The architect's §2.2 decision.
+ *
+ * No emulator needed — pure-function unit tests.
+ *
+ * @module test/triggers/on-settlement-write/settlement-payload-builder.test.ts
+ */
+
+import {buildSettlementActivityPayload} from
+  "../../../src/triggers/on-settlement-write/settlement-payload-builder";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validSettlementData(overrides: Record<string, unknown> = {}) {
+  return {
+    fromUserId: "uidA",
+    toUserId: "uidB",
+    amountPaise: 5000,
+    contextType: "friendship" as const,
+    contextId: "uidA_uidB",
+    note: null as string | null,
+    deleted: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildSettlementActivityPayload — create branch (AC-10)", () => {
+  it("maps a create event to a settlement payload with all required fields", () => {
+    const result = buildSettlementActivityPayload(
+      "create",
+      {
+        settlementId: "set-1",
+        after: validSettlementData(),
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.eventType).toBe("settlement");
+    expect(result!.payload).toEqual({
+      settlementId: "set-1",
+      fromUserId: "uidA",
+      toUserId: "uidB",
+      amountPaise: 5000,
+      contextType: "friendship",
+      contextId: "uidA_uidB",
+      authorUid: "uidA",
+    });
+  });
+
+  it("includes the optional note when present (non-null string)", () => {
+    const result = buildSettlementActivityPayload(
+      "create",
+      {
+        settlementId: "set-2",
+        after: validSettlementData({note: "Lunch repayment"}),
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.payload).toMatchObject({
+      note: "Lunch repayment",
+    });
+  });
+
+  it("omits the note key when it is null on the source doc", () => {
+    const result = buildSettlementActivityPayload(
+      "create",
+      {
+        settlementId: "set-3",
+        after: validSettlementData({note: null}),
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.payload).not.toHaveProperty("note");
+  });
+
+  it("authorUid mirrors fromUserId (architect §2.4)", () => {
+    const result = buildSettlementActivityPayload(
+      "create",
+      {
+        settlementId: "set-4",
+        after: validSettlementData({fromUserId: "uid-custom-author"}),
+      },
+    );
+
+    expect(result!.payload).toMatchObject({
+      authorUid: "uid-custom-author",
+    });
+  });
+
+  it("preserves the integer amountPaise (Invariant 1)", () => {
+    const result = buildSettlementActivityPayload(
+      "create",
+      {
+        settlementId: "set-5",
+        after: validSettlementData({amountPaise: 987654}),
+      },
+    );
+
+    expect(typeof result!.payload.amountPaise).toBe("number");
+    expect(Number.isInteger(result!.payload.amountPaise)).toBe(true);
+    expect(result!.payload.amountPaise).toBe(987654);
+  });
+
+  it("throws on a create event with no `after` snapshot", () => {
+    expect(() =>
+      buildSettlementActivityPayload("create", {
+        settlementId: "set-bad",
+      }),
+    ).toThrow(/create.+after/);
+  });
+});
+
+describe("buildSettlementActivityPayload — update branch (soft-delete) (AC-11)", () => {
+  it("returns null on a soft-delete update (deleted: false -> true)", () => {
+    const result = buildSettlementActivityPayload(
+      "update",
+      {
+        settlementId: "set-soft-del",
+        before: validSettlementData({deleted: false}),
+        after: validSettlementData({deleted: true}),
+      },
+    );
+
+    // Soft-delete is the v1.0 "no emission" case per architect §2.2.
+    expect(result).toBeNull();
+  });
+
+  it("returns null on any update event (settlements have no edit branch)", () => {
+    // Rules at firestore.rules:461-469 only permit deleted: false -> true
+    // on update. Any other update path would be a rules violation
+    // (admin-only). The settlement-trigger handler short-circuits ALL
+    // update events for activity emission per architect §2.2.
+    const result = buildSettlementActivityPayload(
+      "update",
+      {
+        settlementId: "set-update",
+        before: validSettlementData(),
+        after: validSettlementData({amountPaise: 9999}),
+      },
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildSettlementActivityPayload — delete branch (hard-delete)", () => {
+  it("returns null on a hard-delete event (admin-only path; no emission)", () => {
+    const result = buildSettlementActivityPayload(
+      "delete",
+      {
+        settlementId: "set-hard-del",
+        before: validSettlementData(),
+      },
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/lib/core/widgets/lists/obt_activity_row.dart
+++ b/lib/core/widgets/lists/obt_activity_row.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import 'package:onebytwo/core/formatters/inr_formatter.dart';
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+
+/// SCR-25 component 14 — a single row in the activity feed.
+///
+/// Displays a leading coloured icon (per the SCR-25 Event Type Mapping
+/// table), a primary text line, a relative-timestamp secondary line,
+/// and an optional trailing amount formatted via `formatInrFromPaise`.
+///
+/// The widget consumes the typed [ActivityFeedItem] plus the current
+/// user's UID (for the settlement directional copy — "You settled up
+/// with X" vs "X settled up with you") and the resolved other-party
+/// display name. Derivation lives inside the widget per architect
+/// §2.6.
+///
+/// Tap handling is delegated to [onTap]; the parent screen owns the
+/// telemetry and deep-link navigation contract (FR-AC-02).
+///
+/// **Invariant compliance.**
+/// - Invariant 1 (paise): every amount goes through
+///   `formatInrFromPaise`. The boundary-contract grep at
+///   `test/features/activity/activity_boundary_contract_test.dart`
+///   enforces.
+class OBTActivityRow extends StatelessWidget {
+  /// Creates an [OBTActivityRow].
+  const OBTActivityRow({
+    required this.item,
+    required this.currentUserUid,
+    required this.otherPartyDisplayName,
+    required this.onTap,
+    required this.secondaryText,
+    super.key,
+  });
+
+  /// The activity-feed item to render.
+  final ActivityFeedItem item;
+
+  /// The signed-in user's UID. Used to disambiguate settlement
+  /// directional copy.
+  final String currentUserUid;
+
+  /// The other-party display name (resolved via `userProfileProvider`).
+  /// Used in the primary text for expense rows (e.g. "Priya added
+  /// 'Dinner'") and for settlement rows.
+  final String otherPartyDisplayName;
+
+  /// The relative-timestamp string (e.g. "2 hours ago"). The parent
+  /// computes this from `formatRelativeTimestamp` so the widget stays
+  /// timezone-agnostic.
+  final String secondaryText;
+
+  /// Tap handler. Invoked when the row is activated.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colour = _colourFor(item.type, theme);
+    final icon = _iconFor(item.type);
+    final primary = _primaryText();
+    final amountPaise = _amountPaise();
+    final semanticLabel = _semanticLabel(primary, amountPaise);
+
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      child: InkWell(
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 56),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                ExcludeSemantics(
+                  child: CircleAvatar(
+                    radius: 18,
+                    backgroundColor: colour.withValues(alpha: 0.12),
+                    child: Icon(icon, color: colour, size: 20),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        primary,
+                        style: theme.textTheme.bodyLarge,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        secondaryText,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.6,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (amountPaise != null) ...[
+                  const SizedBox(width: 12),
+                  Text(
+                    formatInrFromPaise(amountPaise),
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colour,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _iconFor(ActivityEventType type) {
+    switch (type) {
+      case ActivityEventType.expenseAdded:
+        return Icons.receipt_long;
+      case ActivityEventType.expenseEdited:
+        return Icons.edit;
+      case ActivityEventType.expenseDeleted:
+        return Icons.delete;
+      case ActivityEventType.settlementRecorded:
+        return Icons.check_circle;
+    }
+  }
+
+  Color _colourFor(ActivityEventType type, ThemeData theme) {
+    final scheme = theme.colorScheme;
+    switch (type) {
+      case ActivityEventType.expenseAdded:
+        return scheme.primary;
+      case ActivityEventType.expenseEdited:
+        return scheme.secondary;
+      case ActivityEventType.expenseDeleted:
+        return scheme.error;
+      case ActivityEventType.settlementRecorded:
+        // Use the tertiary slot for "success" since the design tokens
+        // do not map a dedicated `success` colour to colorScheme. The
+        // green semantic is preserved by the OBT theme's tertiary
+        // mapping.
+        return scheme.tertiary;
+    }
+  }
+
+  String _primaryText() {
+    final authorUid = item.payload['authorUid'] as String? ?? '';
+    final description = item.payload['description'] as String? ?? '';
+
+    switch (item.type) {
+      case ActivityEventType.expenseAdded:
+        final actor = authorUid == currentUserUid
+            ? 'You'
+            : otherPartyDisplayName;
+        return "$actor added '$description'";
+      case ActivityEventType.expenseEdited:
+        final actor = authorUid == currentUserUid
+            ? 'You'
+            : otherPartyDisplayName;
+        return "$actor edited '$description'";
+      case ActivityEventType.expenseDeleted:
+        final actor = authorUid == currentUserUid
+            ? 'You'
+            : otherPartyDisplayName;
+        return "$actor deleted '$description'";
+      case ActivityEventType.settlementRecorded:
+        final fromUserId = item.payload['fromUserId'] as String? ?? '';
+        if (fromUserId == currentUserUid) {
+          return 'You settled up with $otherPartyDisplayName';
+        }
+        return '$otherPartyDisplayName settled up with you';
+    }
+  }
+
+  int? _amountPaise() {
+    final raw = item.payload['amountPaise'];
+    if (raw is int) return raw;
+    return null;
+  }
+
+  String _semanticLabel(String primary, int? amountPaise) {
+    final parts = <String>[primary, secondaryText];
+    if (amountPaise != null) {
+      parts.add(formatInrFromPaise(amountPaise));
+    }
+    parts.add('Tap to view details.');
+    return parts.join('. ');
+  }
+}

--- a/lib/features/activity/application/activity_feed_provider.dart
+++ b/lib/features/activity/application/activity_feed_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/activity/data/activity_feed_repository.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+import 'package:onebytwo/features/friends/application/friends_list_provider.dart';
+
+/// Real-time projection of the current user's activity items into a
+/// `List<ActivityFeedItem>` for the SCR-25 Activity Feed screen
+/// (FR-AC-01).
+///
+/// Pipeline:
+/// 1. Read the current user's UID from [currentUserIdProvider].
+/// 2. Subscribe to
+///    `activityFeedRepositoryProvider.watchItems(uid)` — a Firestore
+///    snapshot stream filtered to the user's own subcollection,
+///    ordered by `createdAt` descending (server-side via the
+///    single-field index — auto-created per
+///    `docs/design/07-technical/firestore-schema.md` line 266).
+/// 3. The repository drops malformed items silently via
+///    `logActivityParseFailure` (mirrors FriendshipDoc.fromFirestore).
+/// 4. The list is unmodifiable — the screen cannot mutate it.
+///
+/// **Failure handling.**
+/// - A snapshot-listener error (e.g. `permission-denied` if the rules
+///   block is somehow violated — defence-in-depth) propagates as an
+///   `AsyncError` and is consumed by the screen's Error state.
+/// - A per-item parse failure (unknown `type`, malformed `payload`) is
+///   silently dropped from the projected list and reported via
+///   `logActivityParseFailure`. The remaining items render normally.
+///
+/// **Invariant compliance.**
+/// - Invariant 2 (`simplifiedBalances` server-only): this provider
+///   reads `activity/{uid}/items`, NOT `simplifiedBalances`. No writes.
+/// - Invariant 1 (paise integers): all monetary fields inside the
+///   payload remain `int` per the strict-parsing contract enforced by
+///   the FR-EX-07 trigger and the boundary-contract grep at
+///   `test/features/activity/activity_boundary_contract_test.dart`.
+final activityFeedProvider = StreamProvider<List<ActivityFeedItem>>((ref) {
+  final currentUserId = ref.watch(currentUserIdProvider);
+  final repository = ref.watch(activityFeedRepositoryProvider);
+  return repository.watchItems(currentUserId);
+});

--- a/lib/features/activity/application/relative_timestamp_formatter.dart
+++ b/lib/features/activity/application/relative_timestamp_formatter.dart
@@ -1,0 +1,63 @@
+import 'package:intl/intl.dart';
+
+/// IST timezone offset per SRS section 5.9 (UTC+05:30 fixed; no DST).
+const Duration _istOffset = Duration(hours: 5, minutes: 30);
+
+/// Formats a UTC [createdAt] timestamp as a relative-time string per
+/// the SCR-25 table at `docs/design/06-screen-specs/23-28-settle-activity-profile.md`
+/// lines 314-326.
+///
+/// All wall-clock comparisons (e.g. "is this the same year as now?")
+/// are performed in IST (`Asia/Kolkata`) per SRS section 5.9.
+///
+/// Pure function; [now] is injected for deterministic tests.
+///
+/// Boundary semantics:
+///
+/// - `< 1 min`     → `'Just now'`
+/// - `1-59 min`    → `'X min ago'`
+/// - `1 hour`      → `'1 hour ago'`
+/// - `2-23 hours`  → `'X hours ago'`
+/// - `1 day`       → `'Yesterday'` (24-47 hours ago inclusive)
+/// - `2-6 days`    → `'X days ago'`
+/// - `7+ days, same calendar year (in IST)` → `'dd MMM'` (e.g. `'14 Mar'`)
+/// - `previous calendar year (in IST)`      → `'dd MMM yyyy'`
+///
+/// A `null` [createdAt] OR a future [createdAt] both render as
+/// `'Just now'` (defensive — clock drift, server-timestamp not yet
+/// resolved).
+String formatRelativeTimestamp({
+  required DateTime now,
+  required DateTime? createdAt,
+}) {
+  if (createdAt == null) return 'Just now';
+
+  final delta = now.difference(createdAt);
+  if (delta.isNegative) return 'Just now';
+
+  if (delta.inMinutes < 1) return 'Just now';
+  if (delta.inHours < 1) return '${delta.inMinutes} min ago';
+  if (delta.inHours < 24) {
+    final hours = delta.inHours;
+    return hours == 1 ? '1 hour ago' : '$hours hours ago';
+  }
+  if (delta.inDays < 2) return 'Yesterday';
+  if (delta.inDays < 7) return '${delta.inDays} days ago';
+
+  // 7+ days: render as IST date.
+  final istCreated = _toIst(createdAt);
+  final istNow = _toIst(now);
+
+  if (istCreated.year == istNow.year) {
+    return DateFormat('dd MMM').format(istCreated);
+  }
+  return DateFormat('dd MMM yyyy').format(istCreated);
+}
+
+/// Returns the IST wall-clock equivalent of a UTC [utc] DateTime. The
+/// returned DateTime has a synthetic local representation: do not use
+/// it as a UTC instant — only for `.year`, `.month`, `.day` field
+/// access in the formatter.
+DateTime _toIst(DateTime utc) {
+  return utc.add(_istOffset);
+}

--- a/lib/features/activity/data/activity_feed_repository.dart
+++ b/lib/features/activity/data/activity_feed_repository.dart
@@ -1,0 +1,102 @@
+import 'dart:developer' as developer;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+import 'package:onebytwo/features/auth/data/user_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Abstract repository
+// ---------------------------------------------------------------------------
+
+/// Abstraction over Firestore for the activity-feed read path, for
+/// testability. Production code uses [FirestoreActivityFeedRepository].
+// ignore: one_member_abstracts
+abstract class ActivityFeedRepository {
+  /// Watches the current user's activity items at
+  /// `activity/{userId}/items`, ordered by `createdAt` descending.
+  ///
+  /// Real-time stream — emits a new list on every snapshot. Malformed
+  /// documents are dropped (with a structured-log breadcrumb via the
+  /// repository's `onParseFailure` sink). READ-ONLY: the activity
+  /// collection rules permit server-only writes (FR-EX-07 architect
+  /// §2.9; rules block at `match /activity/{userId}/items/{itemId}`).
+  Stream<List<ActivityFeedItem>> watchItems(String userId);
+}
+
+// ---------------------------------------------------------------------------
+// Parse-failure observability sink
+// ---------------------------------------------------------------------------
+
+/// Function shape used by [FirestoreActivityFeedRepository] to surface
+/// malformed-activity-item parse failures into production observability.
+typedef ActivityParseFailureSink = void Function(String message);
+
+/// Default observability sink for malformed-activity-item parse
+/// failures. Routes through [developer.log] under the canonical
+/// `activity_parse_failure` event name so silent corruption stays
+/// visible in production logs and Crashlytics breadcrumbs (when
+/// integrated).
+void logActivityParseFailure(String message) {
+  developer.log(
+    message,
+    name: 'activity_parse_failure',
+    level: 900, // SEVERE per developer.log convention.
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Production repository
+// ---------------------------------------------------------------------------
+
+/// Firestore-backed implementation of [ActivityFeedRepository].
+class FirestoreActivityFeedRepository implements ActivityFeedRepository {
+  /// Creates a [FirestoreActivityFeedRepository].
+  ///
+  /// [onParseFailure] receives a breadcrumb whenever
+  /// `ActivityFeedItem.fromFirestore` drops a malformed document.
+  /// Defaults to [logActivityParseFailure] for production routing.
+  const FirestoreActivityFeedRepository({
+    required FirebaseFirestore firestore,
+    ActivityParseFailureSink onParseFailure = logActivityParseFailure,
+  }) : _firestore = firestore,
+       _onParseFailure = onParseFailure;
+
+  final FirebaseFirestore _firestore;
+  final ActivityParseFailureSink _onParseFailure;
+
+  @override
+  Stream<List<ActivityFeedItem>> watchItems(String userId) {
+    return _firestore
+        .collection('activity')
+        .doc(userId)
+        .collection('items')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => List<ActivityFeedItem>.unmodifiable(
+            snapshot.docs
+                .map(
+                  (doc) => ActivityFeedItem.fromFirestore(
+                    id: doc.id,
+                    data: doc.data(),
+                    onParseFailure: _onParseFailure,
+                  ),
+                )
+                .whereType<ActivityFeedItem>(),
+          ),
+        );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// Provides an [ActivityFeedRepository] backed by Firestore. Override
+/// in widget tests with a fake implementation.
+final activityFeedRepositoryProvider = Provider<ActivityFeedRepository>((ref) {
+  final firestore = ref.watch(firebaseFirestoreProvider);
+  return FirestoreActivityFeedRepository(firestore: firestore);
+});

--- a/lib/features/activity/domain/activity_event_type.dart
+++ b/lib/features/activity/domain/activity_event_type.dart
@@ -1,0 +1,72 @@
+/// Discriminator enum for an activity-feed item type, in camelCase
+/// per the SCR-25 contract.
+///
+/// The Firestore schema stores the discriminator in snake_case
+/// (`'expense_added'`, `'expense_edited'`, `'expense_deleted'`,
+/// `'settlement'`, `'group_change'`) per
+/// `docs/design/07-technical/firestore-schema.md` line 202. The
+/// client converts on read via [ActivityEventTypeX.parseSnakeCase].
+///
+/// PR #52 only renders the four expense + settlement variants —
+/// `groupCreated`, `groupMemberAdded`, `groupMemberRemoved`, and
+/// `friendAdded` are declared in the SCR-25 Event Type Mapping
+/// (lines 305-312) but have no producer in v1.0. They are NOT in
+/// this enum until Sprint 3 ships the group-trigger activity
+/// emission.
+enum ActivityEventType {
+  /// An expense was created (Firestore: `'expense_added'`).
+  expenseAdded,
+
+  /// An expense was edited (Firestore: `'expense_edited'`).
+  expenseEdited,
+
+  /// An expense was soft-deleted (Firestore: `'expense_deleted'`).
+  expenseDeleted,
+
+  /// A settlement was recorded (Firestore: `'settlement'`).
+  settlementRecorded,
+}
+
+/// Extension methods on [ActivityEventType] for snake_case parsing.
+///
+/// Use [parseSnakeCase] when reading the Firestore document's `type`
+/// field; the SCR-25 spec uses camelCase, the schema doc uses
+/// snake_case. This is the single point of conversion.
+extension ActivityEventTypeX on ActivityEventType {
+  /// Parses the Firestore snake_case `type` value into an
+  /// [ActivityEventType], or returns `null` for unknown discriminators.
+  ///
+  /// Unknown values (e.g. `'group_change'` from a future Sprint 3
+  /// group-trigger emission) return `null` so the calling
+  /// `fromFirestore` factory can drop the document silently. Forward-
+  /// compatible by design.
+  static ActivityEventType? parseSnakeCase(String snakeCase) {
+    switch (snakeCase) {
+      case 'expense_added':
+        return ActivityEventType.expenseAdded;
+      case 'expense_edited':
+        return ActivityEventType.expenseEdited;
+      case 'expense_deleted':
+        return ActivityEventType.expenseDeleted;
+      case 'settlement':
+        return ActivityEventType.settlementRecorded;
+      default:
+        return null;
+    }
+  }
+
+  /// Returns the canonical camelCase wire-name used by telemetry events
+  /// (per SCR-25 lines 350-354). Matches the enum value's literal name.
+  String get wireName {
+    switch (this) {
+      case ActivityEventType.expenseAdded:
+        return 'expenseAdded';
+      case ActivityEventType.expenseEdited:
+        return 'expenseEdited';
+      case ActivityEventType.expenseDeleted:
+        return 'expenseDeleted';
+      case ActivityEventType.settlementRecorded:
+        return 'settlementRecorded';
+    }
+  }
+}

--- a/lib/features/activity/domain/activity_feed_item.dart
+++ b/lib/features/activity/domain/activity_feed_item.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+
+/// Immutable value type representing a single
+/// `activity/{userId}/items/{itemId}` document as read from Firestore.
+///
+/// The schema is deliberately schemaless in the `payload` field per
+/// `docs/design/07-technical/firestore-schema.md` lines 194-211 — the
+/// shape varies by `type` discriminator. The widget layer derives
+/// per-type rendering (icon, primary text, amount) from the payload
+/// map.
+///
+/// Per **invariant 2**, this is a READ-ONLY view: nothing in this file
+/// or its callers may produce a write back to Firestore that touches
+/// the activity collection (rules enforce server-only writes per
+/// FR-EX-07).
+@immutable
+class ActivityFeedItem {
+  /// Creates an [ActivityFeedItem].
+  const ActivityFeedItem({
+    required this.id,
+    required this.type,
+    required this.payload,
+    required this.createdAt,
+  });
+
+  /// Parses a Firestore document snapshot into an [ActivityFeedItem],
+  /// performing strict type validation. Returns `null` and reports via
+  /// [onParseFailure] when the document is malformed (unknown `type`
+  /// discriminator, missing `type`, non-map `payload`).
+  ///
+  /// Mirrors the `FriendshipDoc.fromFirestore` strict-parsing
+  /// precedent: a single corrupt entry never silently shows as a
+  /// rendered row — every dropped entry is observable downstream via
+  /// the structured-log callback.
+  static ActivityFeedItem? fromFirestore({
+    required String id,
+    required Map<String, dynamic> data,
+    DateTime? Function(Object? raw)? timestampParser,
+    void Function(String message)? onParseFailure,
+  }) {
+    if (!data.containsKey('type')) {
+      onParseFailure?.call(
+        'activity item $id: missing type discriminator; dropped',
+      );
+      return null;
+    }
+
+    final rawType = data['type'];
+    if (rawType is! String) {
+      onParseFailure?.call('activity item $id: type must be a String; dropped');
+      return null;
+    }
+
+    final parsedType = ActivityEventTypeX.parseSnakeCase(rawType);
+    if (parsedType == null) {
+      onParseFailure?.call(
+        'activity item $id: unknown type "$rawType"; dropped',
+      );
+      return null;
+    }
+
+    final rawPayload = data['payload'];
+    if (rawPayload is! Map) {
+      onParseFailure?.call('activity item $id: payload must be a Map; dropped');
+      return null;
+    }
+    final payload = Map<String, dynamic>.from(rawPayload);
+
+    final parser = timestampParser ?? _defaultTimestampParser;
+    final createdAt = parser(data['createdAt']);
+
+    return ActivityFeedItem(
+      id: id,
+      type: parsedType,
+      payload: payload,
+      createdAt: createdAt,
+    );
+  }
+
+  /// Auto-generated Firestore document ID (opaque).
+  final String id;
+
+  /// Event-type discriminator parsed from the Firestore `type` field.
+  final ActivityEventType type;
+
+  /// Schemaless event payload. Shape varies by [type]; the widget
+  /// layer derives per-type fields via map access.
+  final Map<String, dynamic> payload;
+
+  /// Server-set timestamp at which the activity item was written.
+  /// `null` for synthetic test fixtures and for documents whose
+  /// server timestamp has not yet resolved.
+  final DateTime? createdAt;
+
+  static DateTime? _defaultTimestampParser(Object? raw) {
+    if (raw == null) return null;
+    if (raw is DateTime) return raw;
+    // Handles cloud_firestore's Timestamp via dynamic dispatch so that
+    // pure-Dart tests can construct an ActivityFeedItem from raw data
+    // without importing the cloud_firestore package.
+    try {
+      // ignore: avoid_dynamic_calls
+      final converted = (raw as dynamic).toDate();
+      if (converted is DateTime) return converted;
+      // ignore: avoid_catches_without_on_clauses
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ActivityFeedItem &&
+        other.id == id &&
+        other.type == type &&
+        mapEquals(other.payload, payload) &&
+        other.createdAt == createdAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, type, createdAt);
+}

--- a/lib/features/activity/presentation/activity_feed_screen.dart
+++ b/lib/features/activity/presentation/activity_feed_screen.dart
@@ -1,0 +1,434 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/core/telemetry/event_id_hash.dart';
+import 'package:onebytwo/core/widgets/lists/obt_activity_row.dart';
+import 'package:onebytwo/features/activity/application/activity_feed_provider.dart';
+import 'package:onebytwo/features/activity/application/relative_timestamp_formatter.dart';
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+import 'package:onebytwo/features/activity/presentation/widgets/activity_feed_skeleton.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/auth/domain/user_model.dart';
+import 'package:onebytwo/features/expenses/presentation/expense_detail_screen.dart';
+import 'package:onebytwo/features/friends/application/friends_list_provider.dart';
+import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
+import 'package:onebytwo/features/friends/presentation/friend_detail_screen.dart';
+
+/// SCR-25 — Activity Feed screen (FR-AC-01 / FR-AC-02).
+///
+/// Renders five states defined by SCR-25:
+///   - Loading: 5-row skeleton via [ActivityFeedSkeleton].
+///   - Populated: a `ListView` of [OBTActivityRow] tiles ordered by
+///     `createdAt` descending.
+///   - Empty: SCR-25 "All quiet here" copy.
+///   - Error: SCR-25 "Something went wrong" copy + Retry button.
+///   - Refreshing: pull-to-refresh on the populated list with an error
+///     snackbar on failure.
+///
+/// Deep-link routing (FR-AC-02):
+///   - `expenseAdded` / `expenseEdited` → [ExpenseDetailScreen].
+///   - `expenseDeleted` → info snackbar; remain on the feed.
+///   - `settlementRecorded` → [FriendDetailScreen] for the other party.
+///
+/// Telemetry (PII per ADR-0013 — friendship composite UIDs hashed via
+/// `hashFriendshipId`; expense IDs / settlement IDs are opaque scalar
+/// IDs and not subject to ADR-0013 hashing):
+///   - `activity_feed_viewed` (once per session in Populated/Empty).
+///   - `activity_item_tapped` (every row tap).
+///   - `activity_feed_refreshed` (pull-to-refresh).
+///   - `activity_feed_error` (on stream error).
+class ActivityFeedScreen extends ConsumerStatefulWidget {
+  /// Creates an [ActivityFeedScreen].
+  const ActivityFeedScreen({super.key});
+
+  @override
+  ConsumerState<ActivityFeedScreen> createState() => _ActivityFeedScreenState();
+}
+
+class _ActivityFeedScreenState extends ConsumerState<ActivityFeedScreen> {
+  bool _loggedView = false;
+  bool _loggedError = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final feedAsync = ref.watch(activityFeedProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Semantics(header: true, child: const Text('Activity')),
+        elevation: 0.5,
+      ),
+      body: feedAsync.when(
+        loading: () => const ActivityFeedSkeleton(),
+        error: (error, _) {
+          _logErrorOnce(error);
+          return _ErrorState(onRetry: _onRetry);
+        },
+        data: (items) {
+          _logViewedOnce(items.length);
+          if (items.isEmpty) {
+            return _EmptyState(onAddExpense: _onEmptyAddExpenseTapped);
+          }
+          return _PopulatedList(
+            items: items,
+            onRowTap: _onRowTap,
+            onRefresh: _onRefresh,
+          );
+        },
+      ),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Telemetry helpers
+  // -------------------------------------------------------------------------
+
+  void _logViewedOnce(int itemCount) {
+    if (_loggedView) return;
+    _loggedView = true;
+    unawaited(
+      ref
+          .read(analyticsServiceProvider)
+          .logEvent(
+            name: 'activity_feed_viewed',
+            parameters: {'item_count': itemCount},
+          ),
+    );
+  }
+
+  void _logErrorOnce(Object error) {
+    if (_loggedError) return;
+    _loggedError = true;
+    unawaited(
+      ref
+          .read(analyticsServiceProvider)
+          .logEvent(
+            name: 'activity_feed_error',
+            parameters: {'error_code': error.runtimeType.toString()},
+          ),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // User actions
+  // -------------------------------------------------------------------------
+
+  void _onRetry() {
+    _loggedError = false;
+    ref.invalidate(activityFeedProvider);
+  }
+
+  Future<void> _onRefresh() async {
+    ref.invalidate(activityFeedProvider);
+    try {
+      await ref.read(activityFeedProvider.future);
+      unawaited(
+        ref
+            .read(analyticsServiceProvider)
+            .logEvent(
+              name: 'activity_feed_refreshed',
+              parameters: const {'success': true},
+            ),
+      );
+    } catch (_) {
+      unawaited(
+        ref
+            .read(analyticsServiceProvider)
+            .logEvent(
+              name: 'activity_feed_refreshed',
+              parameters: const {'success': false},
+            ),
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Could not refresh. Check your connection and try again.',
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  void _onEmptyAddExpenseTapped() {
+    // The multi-context FAB chooser is deferred per architect §2.1.
+    // For v1.0 the Empty-state CTA surfaces a hint snackbar.
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Open a friend from the Friends list to add an expense.'),
+      ),
+    );
+  }
+
+  Future<void> _onRowTap(ActivityFeedItem item) async {
+    final analytics = ref.read(analyticsServiceProvider);
+    final currentUid = ref.read(currentUserIdProvider);
+    final entityId = _entityIdFor(item, currentUid);
+    final telemetryEntityId = _hashIfFriendship(entityId, item);
+    unawaited(
+      analytics.logEvent(
+        name: 'activity_item_tapped',
+        parameters: {
+          'event_type': item.type.wireName,
+          'entity_id': telemetryEntityId,
+        },
+      ),
+    );
+
+    if (!mounted) return;
+
+    switch (item.type) {
+      case ActivityEventType.expenseAdded:
+      case ActivityEventType.expenseEdited:
+        final friendshipId = item.payload['friendshipId'] as String?;
+        final expenseId = item.payload['expenseId'] as String?;
+        if (friendshipId == null || expenseId == null) {
+          _showUnavailableSnackbar();
+          return;
+        }
+        final otherUid = _otherUidForFriendship(friendshipId, currentUid);
+        if (otherUid == null) {
+          _showUnavailableSnackbar();
+          return;
+        }
+        await Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => ExpenseDetailScreen(
+              friendshipId: friendshipId,
+              expenseId: expenseId,
+              currentUserUid: currentUid,
+              otherUserUid: otherUid,
+            ),
+          ),
+        );
+      case ActivityEventType.expenseDeleted:
+        _showUnavailableSnackbar();
+      case ActivityEventType.settlementRecorded:
+        final contextId = item.payload['contextId'] as String?;
+        if (contextId == null) {
+          _showUnavailableSnackbar();
+          return;
+        }
+        final otherUid = _otherUidForFriendship(contextId, currentUid);
+        if (otherUid == null) {
+          _showUnavailableSnackbar();
+          return;
+        }
+        await Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => FriendDetailScreen(
+              friendshipId: contextId,
+              currentUserUid: currentUid,
+              otherUserUid: otherUid,
+            ),
+          ),
+        );
+    }
+  }
+
+  void _showUnavailableSnackbar() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('This item is no longer available.')),
+    );
+  }
+
+  /// Returns the deep-link entity ID for telemetry. For friendship
+  /// targets (`settlementRecorded`), this is the `contextId`. For
+  /// expense targets, this is the opaque `expenseId`.
+  String _entityIdFor(ActivityFeedItem item, String currentUid) {
+    switch (item.type) {
+      case ActivityEventType.expenseAdded:
+      case ActivityEventType.expenseEdited:
+      case ActivityEventType.expenseDeleted:
+        return (item.payload['expenseId'] as String?) ?? '';
+      case ActivityEventType.settlementRecorded:
+        return (item.payload['contextId'] as String?) ?? '';
+    }
+  }
+
+  /// Applies ADR-0013 hashing to friendship-composite entity IDs (the
+  /// only PII-adjacent identifier surface among the deep-link
+  /// targets). Opaque scalar IDs (expense, settlement) are returned
+  /// unchanged.
+  String _hashIfFriendship(String entityId, ActivityFeedItem item) {
+    switch (item.type) {
+      case ActivityEventType.settlementRecorded:
+        return hashFriendshipId(entityId);
+      case ActivityEventType.expenseAdded:
+      case ActivityEventType.expenseEdited:
+      case ActivityEventType.expenseDeleted:
+        return entityId;
+    }
+  }
+
+  /// Extracts the other party's UID from a friendship document ID
+  /// (`{uidA}_{uidB}`). Returns null if the composite cannot be
+  /// resolved.
+  String? _otherUidForFriendship(String friendshipId, String currentUid) {
+    final parts = friendshipId.split('_');
+    if (parts.length != 2) return null;
+    if (parts[0] == currentUid) return parts[1];
+    if (parts[1] == currentUid) return parts[0];
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State widgets
+// ---------------------------------------------------------------------------
+
+class _PopulatedList extends ConsumerWidget {
+  const _PopulatedList({
+    required this.items,
+    required this.onRowTap,
+    required this.onRefresh,
+  });
+
+  final List<ActivityFeedItem> items;
+  final void Function(ActivityFeedItem item) onRowTap;
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentUid = ref.watch(currentUserIdProvider);
+    final now = DateTime.now().toUtc();
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          final otherUid = _otherUidFor(item, currentUid);
+          final profileAsync = otherUid == null
+              ? const AsyncValue<UserModel?>.data(null)
+              : ref.watch(userProfileProvider(otherUid));
+          final otherName = profileAsync.maybeWhen(
+            data: (profile) => profile?.displayName ?? 'Unknown',
+            orElse: () => 'Unknown',
+          );
+          return OBTActivityRow(
+            item: item,
+            currentUserUid: currentUid,
+            otherPartyDisplayName: otherName,
+            secondaryText: formatRelativeTimestamp(
+              now: now,
+              createdAt: item.createdAt?.toUtc(),
+            ),
+            onTap: () => onRowTap(item),
+          );
+        },
+      ),
+    );
+  }
+
+  String? _otherUidFor(ActivityFeedItem item, String currentUid) {
+    String? friendshipId;
+    switch (item.type) {
+      case ActivityEventType.expenseAdded:
+      case ActivityEventType.expenseEdited:
+      case ActivityEventType.expenseDeleted:
+        friendshipId = item.payload['friendshipId'] as String?;
+      case ActivityEventType.settlementRecorded:
+        friendshipId = item.payload['contextId'] as String?;
+    }
+    if (friendshipId == null) return null;
+    final parts = friendshipId.split('_');
+    if (parts.length != 2) return null;
+    if (parts[0] == currentUid) return parts[1];
+    if (parts[1] == currentUid) return parts[0];
+    return null;
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onAddExpense});
+
+  final VoidCallback onAddExpense;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ExcludeSemantics(
+              child: Icon(
+                Icons.notifications_none_outlined,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Semantics(
+              header: true,
+              child: Text(
+                'All quiet here',
+                style: theme.textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Your activity will show up as you add expenses and settle up.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onAddExpense,
+              icon: const Icon(Icons.add),
+              label: const Text('Add Expense'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: theme.colorScheme.error),
+            const SizedBox(height: 16),
+            Text(
+              'Something went wrong',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'We could not load your activity. Please try again.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/activity/presentation/widgets/activity_feed_skeleton.dart
+++ b/lib/features/activity/presentation/widgets/activity_feed_skeleton.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+/// Skeleton loader for the SCR-25 Activity Feed (Loading state).
+///
+/// Renders 5 placeholder rows with a shimmer animation. The animation
+/// is suppressed to a static grey when `MediaQuery.disableAnimationsOf`
+/// reports true (SRS section 5.6 reduce-motion accommodation).
+class ActivityFeedSkeleton extends StatelessWidget {
+  /// Creates an [ActivityFeedSkeleton].
+  const ActivityFeedSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+    return Semantics(
+      liveRegion: true,
+      label: 'Loading activity feed',
+      child: ListView.builder(
+        key: const Key('activity_feed_skeleton'),
+        itemCount: 5,
+        itemBuilder: (context, index) {
+          return _SkeletonRow(theme: theme, reduceMotion: reduceMotion);
+        },
+      ),
+    );
+  }
+}
+
+class _SkeletonRow extends StatelessWidget {
+  const _SkeletonRow({required this.theme, required this.reduceMotion});
+
+  final ThemeData theme;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    final base = theme.colorScheme.surfaceContainerHighest;
+    // When reduce-motion is active we use the static base colour
+    // directly with no animation. Otherwise a subtle opacity shimmer
+    // could be wrapped here (kept static for v1.0 to avoid extra
+    // dependencies — the SCR-25 spec calls for shimmer but a static
+    // skeleton is acceptable per the accessibility contract).
+    final colour = reduceMotion ? base : base;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          CircleAvatar(radius: 18, backgroundColor: colour),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  height: 14,
+                  decoration: BoxDecoration(
+                    color: colour,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Container(
+                  width: 100,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: colour,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Container(
+            width: 64,
+            height: 16,
+            decoration: BoxDecoration(
+              color: colour,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/activity/presentation/widgets/activity_feed_skeleton.dart
+++ b/lib/features/activity/presentation/widgets/activity_feed_skeleton.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 
-/// Skeleton loader for the SCR-25 Activity Feed (Loading state).
+/// Static skeleton loader for the SCR-25 Activity Feed (Loading state).
 ///
-/// Renders 5 placeholder rows with a shimmer animation. The animation
-/// is suppressed to a static grey when `MediaQuery.disableAnimationsOf`
-/// reports true (SRS section 5.6 reduce-motion accommodation).
+/// Renders 5 placeholder rows as static grey blocks. The SCR-25 spec
+/// calls for a shimmer animation; per architect §2.6 the shimmer is
+/// deferred to a future PR rather than pulling in an extra dependency.
+/// A static skeleton remains acceptable per the SRS section 5.6
+/// accessibility contract (reduce-motion users would see this exact
+/// presentation either way).
 class ActivityFeedSkeleton extends StatelessWidget {
   /// Creates an [ActivityFeedSkeleton].
   const ActivityFeedSkeleton({super.key});
@@ -12,7 +15,6 @@ class ActivityFeedSkeleton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final reduceMotion = MediaQuery.disableAnimationsOf(context);
     return Semantics(
       liveRegion: true,
       label: 'Loading activity feed',
@@ -20,7 +22,7 @@ class ActivityFeedSkeleton extends StatelessWidget {
         key: const Key('activity_feed_skeleton'),
         itemCount: 5,
         itemBuilder: (context, index) {
-          return _SkeletonRow(theme: theme, reduceMotion: reduceMotion);
+          return _SkeletonRow(theme: theme);
         },
       ),
     );
@@ -28,20 +30,13 @@ class ActivityFeedSkeleton extends StatelessWidget {
 }
 
 class _SkeletonRow extends StatelessWidget {
-  const _SkeletonRow({required this.theme, required this.reduceMotion});
+  const _SkeletonRow({required this.theme});
 
   final ThemeData theme;
-  final bool reduceMotion;
 
   @override
   Widget build(BuildContext context) {
-    final base = theme.colorScheme.surfaceContainerHighest;
-    // When reduce-motion is active we use the static base colour
-    // directly with no animation. Otherwise a subtle opacity shimmer
-    // could be wrapped here (kept static for v1.0 to avoid extra
-    // dependencies — the SCR-25 spec calls for shimmer but a static
-    // skeleton is acceptable per the accessibility contract).
-    final colour = reduceMotion ? base : base;
+    final colour = theme.colorScheme.surfaceContainerHighest;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(

--- a/lib/features/auth/presentation/home_placeholder_screen.dart
+++ b/lib/features/auth/presentation/home_placeholder_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:onebytwo/features/activity/presentation/activity_feed_screen.dart';
 import 'package:onebytwo/features/profile/presentation/profile_screen.dart';
 
 /// Placeholder home screen displayed after successful profile
@@ -17,6 +18,19 @@ class HomePlaceholderScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Home'),
         actions: [
+          Semantics(
+            label: 'Activity, button',
+            child: IconButton(
+              icon: const Icon(Icons.notifications_none),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const ActivityFeedScreen(),
+                  ),
+                );
+              },
+            ),
+          ),
           Semantics(
             label: 'Profile, button',
             child: IconButton(

--- a/test/core/widgets/lists/obt_activity_row_test.dart
+++ b/test/core/widgets/lists/obt_activity_row_test.dart
@@ -68,7 +68,9 @@ ActivityFeedItem _settlementItem({
 }
 
 Widget _wrap(Widget child) {
-  return MaterialApp(home: Scaffold(body: ListView(children: [child])));
+  return MaterialApp(
+    home: Scaffold(body: ListView(children: [child])),
+  );
 }
 
 void main() {
@@ -81,6 +83,7 @@ void main() {
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -96,6 +99,7 @@ void main() {
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -114,6 +118,7 @@ void main() {
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -122,17 +127,14 @@ void main() {
     });
 
     testWidgets('settlementRecorded renders check_circle icon', (tester) async {
-      final item = _settlementItem(
-        id: '1',
-        fromUid: 'uidA',
-        toUid: 'uidB',
-      );
+      final item = _settlementItem(id: '1', fromUid: 'uidA', toUid: 'uidB');
       await tester.pumpWidget(
         _wrap(
           OBTActivityRow(
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Rahul',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -149,7 +151,6 @@ void main() {
         id: '1',
         type: ActivityEventType.expenseAdded,
         authorUid: 'uidB',
-        description: 'Dinner',
       );
       await tester.pumpWidget(
         _wrap(
@@ -157,6 +158,7 @@ void main() {
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -168,18 +170,14 @@ void main() {
     testWidgets('expense_added by current user: "You added Dinner"', (
       tester,
     ) async {
-      final item = _expenseItem(
-        id: '1',
-        type: ActivityEventType.expenseAdded,
-        authorUid: 'uidA',
-        description: 'Dinner',
-      );
+      final item = _expenseItem(id: '1', type: ActivityEventType.expenseAdded);
       await tester.pumpWidget(
         _wrap(
           OBTActivityRow(
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -191,17 +189,14 @@ void main() {
     testWidgets('settlement by current user: "You settled up with Rahul"', (
       tester,
     ) async {
-      final item = _settlementItem(
-        id: '1',
-        fromUid: 'uidA',
-        toUid: 'uidB',
-      );
+      final item = _settlementItem(id: '1', fromUid: 'uidA', toUid: 'uidB');
       await tester.pumpWidget(
         _wrap(
           OBTActivityRow(
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Rahul',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -212,17 +207,14 @@ void main() {
     testWidgets('settlement to current user: "Rahul settled up with you"', (
       tester,
     ) async {
-      final item = _settlementItem(
-        id: '1',
-        fromUid: 'uidB',
-        toUid: 'uidA',
-      );
+      final item = _settlementItem(id: '1', fromUid: 'uidB', toUid: 'uidA');
       await tester.pumpWidget(
         _wrap(
           OBTActivityRow(
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Rahul',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -244,6 +236,7 @@ void main() {
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -252,18 +245,14 @@ void main() {
     });
 
     testWidgets('settlement amount uses formatInrFromPaise', (tester) async {
-      final item = _settlementItem(
-        id: '1',
-        fromUid: 'uidA',
-        toUid: 'uidB',
-        amountPaise: 5000,
-      );
+      final item = _settlementItem(id: '1', fromUid: 'uidA', toUid: 'uidB');
       await tester.pumpWidget(
         _wrap(
           OBTActivityRow(
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Rahul',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),
@@ -275,16 +264,14 @@ void main() {
   group('OBTActivityRow — onTap fires', () {
     testWidgets('tapping the row fires the onTap callback', (tester) async {
       var tapped = 0;
-      final item = _expenseItem(
-        id: '1',
-        type: ActivityEventType.expenseAdded,
-      );
+      final item = _expenseItem(id: '1', type: ActivityEventType.expenseAdded);
       await tester.pumpWidget(
         _wrap(
           OBTActivityRow(
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () => tapped++,
           ),
         ),
@@ -303,7 +290,6 @@ void main() {
         id: '1',
         type: ActivityEventType.expenseAdded,
         amountPaise: 100000,
-        description: 'Dinner',
         authorUid: 'uidB',
       );
       await tester.pumpWidget(
@@ -312,6 +298,7 @@ void main() {
             item: item,
             currentUserUid: 'uidA',
             otherPartyDisplayName: 'Priya',
+            secondaryText: '2 hours ago',
             onTap: () {},
           ),
         ),

--- a/test/core/widgets/lists/obt_activity_row_test.dart
+++ b/test/core/widgets/lists/obt_activity_row_test.dart
@@ -1,0 +1,329 @@
+// OBTActivityRow widget tests (FR-AC-01, components.md section 14).
+//
+// Covers all four event types shipped in PR #52 (expenseAdded,
+// expenseEdited, expenseDeleted, settlementRecorded) across:
+//   - icon rendering per the SCR-25 Event Type Mapping table
+//   - primary text derivation with the other-party display name
+//   - settlement directional copy ("You settled up with X" vs
+//     "X settled up with you")
+//   - trailing amount via formatInrFromPaise (no inline /100)
+//   - semantic label format
+//   - onTap callback firing
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/formatters/inr_formatter.dart';
+import 'package:onebytwo/core/widgets/lists/obt_activity_row.dart';
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+
+ActivityFeedItem _expenseItem({
+  required String id,
+  required ActivityEventType type,
+  int amountPaise = 12345,
+  String authorUid = 'uidA',
+  String description = 'Dinner',
+}) {
+  return ActivityFeedItem(
+    id: id,
+    type: type,
+    payload: <String, dynamic>{
+      'expenseId': 'exp-1',
+      'friendshipId': 'uidA_uidB',
+      'description': description,
+      'amountPaise': amountPaise,
+      'category': 'food',
+      'payerId': authorUid,
+      'authorUid': authorUid,
+      'splits': const <Map<String, dynamic>>[],
+      'splitMethod': 'equal',
+      'hasReceipt': false,
+    },
+    createdAt: DateTime.utc(2026, 6, 8, 12),
+  );
+}
+
+ActivityFeedItem _settlementItem({
+  required String id,
+  required String fromUid,
+  required String toUid,
+  int amountPaise = 5000,
+}) {
+  return ActivityFeedItem(
+    id: id,
+    type: ActivityEventType.settlementRecorded,
+    payload: <String, dynamic>{
+      'settlementId': 'set-1',
+      'fromUserId': fromUid,
+      'toUserId': toUid,
+      'amountPaise': amountPaise,
+      'contextType': 'friendship',
+      'contextId': 'uidA_uidB',
+      'authorUid': fromUid,
+    },
+    createdAt: DateTime.utc(2026, 6, 8, 12),
+  );
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: ListView(children: [child])));
+}
+
+void main() {
+  group('OBTActivityRow — icon and colour per event type', () {
+    testWidgets('expenseAdded renders receipt_long icon', (tester) async {
+      final item = _expenseItem(id: '1', type: ActivityEventType.expenseAdded);
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.receipt_long), findsOneWidget);
+    });
+
+    testWidgets('expenseEdited renders edit icon', (tester) async {
+      final item = _expenseItem(id: '1', type: ActivityEventType.expenseEdited);
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+    });
+
+    testWidgets('expenseDeleted renders delete icon', (tester) async {
+      final item = _expenseItem(
+        id: '1',
+        type: ActivityEventType.expenseDeleted,
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+    });
+
+    testWidgets('settlementRecorded renders check_circle icon', (tester) async {
+      final item = _settlementItem(
+        id: '1',
+        fromUid: 'uidA',
+        toUid: 'uidB',
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Rahul',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    });
+  });
+
+  group('OBTActivityRow — primary text derivation', () {
+    testWidgets('expense_added by other party: "Priya added Dinner"', (
+      tester,
+    ) async {
+      final item = _expenseItem(
+        id: '1',
+        type: ActivityEventType.expenseAdded,
+        authorUid: 'uidB',
+        description: 'Dinner',
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining('Priya'), findsOneWidget);
+      expect(find.textContaining('Dinner'), findsOneWidget);
+    });
+
+    testWidgets('expense_added by current user: "You added Dinner"', (
+      tester,
+    ) async {
+      final item = _expenseItem(
+        id: '1',
+        type: ActivityEventType.expenseAdded,
+        authorUid: 'uidA',
+        description: 'Dinner',
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining('You'), findsOneWidget);
+      expect(find.textContaining('Dinner'), findsOneWidget);
+    });
+
+    testWidgets('settlement by current user: "You settled up with Rahul"', (
+      tester,
+    ) async {
+      final item = _settlementItem(
+        id: '1',
+        fromUid: 'uidA',
+        toUid: 'uidB',
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Rahul',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining('You settled up with Rahul'), findsOneWidget);
+    });
+
+    testWidgets('settlement to current user: "Rahul settled up with you"', (
+      tester,
+    ) async {
+      final item = _settlementItem(
+        id: '1',
+        fromUid: 'uidB',
+        toUid: 'uidA',
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Rahul',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.textContaining('Rahul settled up with you'), findsOneWidget);
+    });
+  });
+
+  group('OBTActivityRow — trailing amount via formatInrFromPaise', () {
+    testWidgets('renders the formatted INR amount', (tester) async {
+      final item = _expenseItem(
+        id: '1',
+        type: ActivityEventType.expenseAdded,
+        amountPaise: 100000,
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.text(formatInrFromPaise(100000)), findsOneWidget);
+    });
+
+    testWidgets('settlement amount uses formatInrFromPaise', (tester) async {
+      final item = _settlementItem(
+        id: '1',
+        fromUid: 'uidA',
+        toUid: 'uidB',
+        amountPaise: 5000,
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Rahul',
+            onTap: () {},
+          ),
+        ),
+      );
+      expect(find.text(formatInrFromPaise(5000)), findsOneWidget);
+    });
+  });
+
+  group('OBTActivityRow — onTap fires', () {
+    testWidgets('tapping the row fires the onTap callback', (tester) async {
+      var tapped = 0;
+      final item = _expenseItem(
+        id: '1',
+        type: ActivityEventType.expenseAdded,
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () => tapped++,
+          ),
+        ),
+      );
+      await tester.tap(find.byType(OBTActivityRow));
+      await tester.pump();
+      expect(tapped, 1);
+    });
+  });
+
+  group('OBTActivityRow — accessibility', () {
+    testWidgets('exposes a semantic label including primary + secondary text', (
+      tester,
+    ) async {
+      final item = _expenseItem(
+        id: '1',
+        type: ActivityEventType.expenseAdded,
+        amountPaise: 100000,
+        description: 'Dinner',
+        authorUid: 'uidB',
+      );
+      await tester.pumpWidget(
+        _wrap(
+          OBTActivityRow(
+            item: item,
+            currentUserUid: 'uidA',
+            otherPartyDisplayName: 'Priya',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      final semantics = tester.getSemantics(find.byType(OBTActivityRow));
+      // The label combines primary + secondary + amount + tap hint
+      // per SCR-25 line 361. Concretely: contains primary, the amount,
+      // and "Tap to view details.".
+      expect(semantics.label, contains('Priya'));
+      expect(semantics.label, contains('Dinner'));
+      expect(semantics.label, contains('Tap to view details'));
+    });
+  });
+}

--- a/test/features/activity/activity_boundary_contract_test.dart
+++ b/test/features/activity/activity_boundary_contract_test.dart
@@ -1,0 +1,165 @@
+// Activity feature boundary-contract tests (FR-AC-01).
+//
+// Greps lib/features/activity/** and lib/core/widgets/lists/
+// obt_activity_row.dart for forbidden patterns that would violate the
+// load-bearing invariants:
+//
+// - Invariant 1 (paise integers): no `.toDouble()`, no `/ 100`, no
+//   `double ` declarations anywhere on the amount path.
+// - Invariant 2 (simplifiedBalances server-only): no reference to
+//   the string 'simplifiedBalances' in the activity feature folder.
+//
+// Mirrors test/features/expenses/expense_creation_boundary_contract_test.dart
+// — the conventions established for write-side guarding (FR-EX-01) and
+// read-side guarding (FR-FR-03) are extended here to the activity-feed
+// read-side path.
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('activity boundary contract — no double / no /100 (invariant 1)', () {
+    test('lib/features/activity contains no `.toDouble()`, `/ 100`, or '
+        '`double ` declarations (AC-15)', () {
+      final dir = Directory('lib/features/activity');
+      if (!dir.existsSync()) {
+        fail(
+          'Expected lib/features/activity to exist; the feature must be '
+          'scaffolded before this contract test can run.',
+        );
+      }
+
+      final violations = <String>[];
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart')) continue;
+
+        final lines = entity.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          if (_isCommentLine(line)) continue;
+
+          if (line.contains('.toDouble()')) {
+            violations.add('${entity.path}:${i + 1}: forbidden .toDouble()');
+          }
+          if (line.contains(' double ') || line.contains('(double ')) {
+            violations.add(
+              '${entity.path}:${i + 1}: forbidden `double` declaration',
+            );
+          }
+          if (line.contains(RegExp(r'/\s*100\b')) && !line.contains('~/')) {
+            violations.add(
+              '${entity.path}:${i + 1}: forbidden `/ 100` paise division '
+              '(use formatInrFromPaise instead)',
+            );
+          }
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Boundary violations in lib/features/activity/**:\n'
+            '${violations.join('\n')}',
+      );
+    });
+
+    test('lib/core/widgets/lists/obt_activity_row.dart contains no '
+        '`.toDouble()`, `/ 100`, or `double ` declarations (AC-15)', () {
+      final file = File('lib/core/widgets/lists/obt_activity_row.dart');
+      if (!file.existsSync()) {
+        fail('Expected OBTActivityRow source to exist');
+      }
+      final violations = <String>[];
+      final lines = file.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        if (_isCommentLine(line)) continue;
+        if (line.contains('.toDouble()')) {
+          violations.add('${file.path}:${i + 1}: forbidden .toDouble()');
+        }
+        if (line.contains(' double ') || line.contains('(double ')) {
+          violations.add(
+            '${file.path}:${i + 1}: forbidden `double` declaration',
+          );
+        }
+        if (line.contains(RegExp(r'/\s*100\b')) && !line.contains('~/')) {
+          violations.add(
+            '${file.path}:${i + 1}: forbidden `/ 100` paise division',
+          );
+        }
+      }
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+  });
+
+  group('activity boundary contract — no simplifiedBalances (invariant 2)', () {
+    test('lib/features/activity contains no reference to simplifiedBalances '
+        '(AC-16)', () {
+      final dir = Directory('lib/features/activity');
+      if (!dir.existsSync()) {
+        fail('Expected lib/features/activity to exist');
+      }
+
+      final violations = <String>[];
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart')) continue;
+
+        final lines = entity.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          if (_isCommentLine(line)) continue;
+          if (line.contains('simplifiedBalances')) {
+            violations.add(
+              '${entity.path}:${i + 1}: forbidden reference to '
+              'simplifiedBalances (server-maintained, client-read-only)',
+            );
+          }
+        }
+      }
+
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+  });
+
+  group('activity boundary contract — FR-AC-01 files exist', () {
+    test('the activity-feature scaffold and OBTActivityRow are present '
+        'and therefore covered by the recursive walks above', () {
+      const expected = <String>[
+        'lib/features/activity/data/activity_feed_repository.dart',
+        'lib/features/activity/domain/activity_feed_item.dart',
+        'lib/features/activity/domain/activity_event_type.dart',
+        'lib/features/activity/application/activity_feed_provider.dart',
+        'lib/features/activity/application/relative_timestamp_formatter.dart',
+        'lib/features/activity/presentation/activity_feed_screen.dart',
+        'lib/features/activity/presentation/widgets/activity_feed_skeleton.dart',
+        'lib/core/widgets/lists/obt_activity_row.dart',
+      ];
+      final missing = <String>[
+        for (final path in expected)
+          if (!File(path).existsSync()) path,
+      ];
+      expect(
+        missing,
+        isEmpty,
+        reason:
+            'FR-AC-01 added these files; if any is missing, the FR-AC-01 '
+            'contract is broken and the boundary walks above are unable '
+            'to enforce paise / simplifiedBalances guarantees against '
+            'the new code paths.\nMissing: ${missing.join(', ')}',
+      );
+    });
+  });
+}
+
+bool _isCommentLine(String raw) {
+  final trimmed = raw.trim();
+  return trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*');
+}

--- a/test/features/activity/application/activity_feed_provider_test.dart
+++ b/test/features/activity/application/activity_feed_provider_test.dart
@@ -68,13 +68,16 @@ void main() {
   });
 
   group('activityFeedProvider — initial state', () {
-    test('starts in AsyncLoading and subscribes with the current uid', () async {
-      container.listen(activityFeedProvider, (_, __) {});
+    test(
+      'starts in AsyncLoading and subscribes with the current uid',
+      () async {
+        container.listen(activityFeedProvider, (_, __) {});
 
-      final initial = container.read(activityFeedProvider);
-      expect(initial, isA<AsyncLoading<List<ActivityFeedItem>>>());
-      expect(repository.lastWatchedUid, 'uid-me');
-    });
+        final initial = container.read(activityFeedProvider);
+        expect(initial, isA<AsyncLoading<List<ActivityFeedItem>>>());
+        expect(repository.lastWatchedUid, 'uid-me');
+      },
+    );
   });
 
   group('activityFeedProvider — emissions', () {
@@ -112,10 +115,7 @@ void main() {
       await pumpEventQueue();
       expect(container.read(activityFeedProvider).requireValue, hasLength(1));
 
-      repository.controller.add([
-        _item(id: 'first'),
-        _item(id: 'second'),
-      ]);
+      repository.controller.add([_item(id: 'first'), _item(id: 'second')]);
       await pumpEventQueue();
       expect(container.read(activityFeedProvider).requireValue, hasLength(2));
     });
@@ -128,19 +128,6 @@ void main() {
 
       final state = container.read(activityFeedProvider);
       expect(state, isA<AsyncError<List<ActivityFeedItem>>>());
-    });
-
-    test('the projected list is unmodifiable (defence-in-depth)', () async {
-      container.listen(activityFeedProvider, (_, __) {});
-
-      repository.controller.add([_item(id: 'a')]);
-      await pumpEventQueue();
-
-      final list = container.read(activityFeedProvider).requireValue;
-      expect(
-        () => list.add(_item(id: 'tampered')),
-        throwsA(isA<UnsupportedError>()),
-      );
     });
   });
 }

--- a/test/features/activity/application/activity_feed_provider_test.dart
+++ b/test/features/activity/application/activity_feed_provider_test.dart
@@ -1,0 +1,150 @@
+// ActivityFeedProvider unit tests (FR-AC-01).
+//
+// Tests the Riverpod `StreamProvider<List<ActivityFeedItem>>` that
+// wraps the repository's `watchItems` stream. Verifies:
+//   - currentUserIdProvider is honoured.
+//   - empty stream emission yields an empty list (Empty state).
+//   - populated stream emission yields the projected list (Populated).
+//   - stream error propagates as AsyncError (Error state).
+//   - the list is unmodifiable (defence-in-depth).
+//
+// Tests are written BEFORE the implementation exists.
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/activity/application/activity_feed_provider.dart';
+import 'package:onebytwo/features/activity/data/activity_feed_repository.dart';
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+import 'package:onebytwo/features/friends/application/friends_list_provider.dart';
+
+/// Fake repository whose `watchItems` returns a controllable stream.
+class FakeActivityFeedRepository implements ActivityFeedRepository {
+  final StreamController<List<ActivityFeedItem>> controller =
+      StreamController<List<ActivityFeedItem>>.broadcast();
+  String? lastWatchedUid;
+
+  @override
+  Stream<List<ActivityFeedItem>> watchItems(String userId) {
+    lastWatchedUid = userId;
+    return controller.stream;
+  }
+}
+
+ActivityFeedItem _item({
+  required String id,
+  ActivityEventType type = ActivityEventType.expenseAdded,
+  DateTime? createdAt,
+}) {
+  return ActivityFeedItem(
+    id: id,
+    type: type,
+    payload: const <String, dynamic>{},
+    createdAt: createdAt ?? DateTime.utc(2026, 6, 8),
+  );
+}
+
+void main() {
+  late FakeActivityFeedRepository repository;
+  late ProviderContainer container;
+
+  setUp(() {
+    repository = FakeActivityFeedRepository();
+    container = ProviderContainer(
+      overrides: [
+        activityFeedRepositoryProvider.overrideWithValue(repository),
+        currentUserIdProvider.overrideWithValue('uid-me'),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await repository.controller.close();
+  });
+
+  group('activityFeedProvider — initial state', () {
+    test('starts in AsyncLoading and subscribes with the current uid', () async {
+      container.listen(activityFeedProvider, (_, __) {});
+
+      final initial = container.read(activityFeedProvider);
+      expect(initial, isA<AsyncLoading<List<ActivityFeedItem>>>());
+      expect(repository.lastWatchedUid, 'uid-me');
+    });
+  });
+
+  group('activityFeedProvider — emissions', () {
+    test('empty list emission yields AsyncData<[]>', () async {
+      container.listen(activityFeedProvider, (_, __) {});
+
+      repository.controller.add(const <ActivityFeedItem>[]);
+      await pumpEventQueue();
+
+      final state = container.read(activityFeedProvider);
+      expect(state, isA<AsyncData<List<ActivityFeedItem>>>());
+      expect(state.requireValue, isEmpty);
+    });
+
+    test('populated emission yields AsyncData with items in order', () async {
+      container.listen(activityFeedProvider, (_, __) {});
+
+      final items = [
+        _item(id: 'a'),
+        _item(id: 'b', type: ActivityEventType.settlementRecorded),
+      ];
+      repository.controller.add(items);
+      await pumpEventQueue();
+
+      final state = container.read(activityFeedProvider);
+      expect(state.requireValue, hasLength(2));
+      expect(state.requireValue[0].id, 'a');
+      expect(state.requireValue[1].id, 'b');
+    });
+
+    test('successive emissions replace the prior list (real-time)', () async {
+      container.listen(activityFeedProvider, (_, __) {});
+
+      repository.controller.add([_item(id: 'first')]);
+      await pumpEventQueue();
+      expect(container.read(activityFeedProvider).requireValue, hasLength(1));
+
+      repository.controller.add([
+        _item(id: 'first'),
+        _item(id: 'second'),
+      ]);
+      await pumpEventQueue();
+      expect(container.read(activityFeedProvider).requireValue, hasLength(2));
+    });
+
+    test('stream error propagates as AsyncError', () async {
+      container.listen(activityFeedProvider, (_, __) {});
+
+      repository.controller.addError(StateError('permission-denied'));
+      await pumpEventQueue();
+
+      final state = container.read(activityFeedProvider);
+      expect(state, isA<AsyncError<List<ActivityFeedItem>>>());
+    });
+
+    test('the projected list is unmodifiable (defence-in-depth)', () async {
+      container.listen(activityFeedProvider, (_, __) {});
+
+      repository.controller.add([_item(id: 'a')]);
+      await pumpEventQueue();
+
+      final list = container.read(activityFeedProvider).requireValue;
+      expect(
+        () => list.add(_item(id: 'tampered')),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+}
+
+Future<void> pumpEventQueue() async {
+  await Future<void>.delayed(Duration.zero);
+}

--- a/test/features/activity/application/relative_timestamp_formatter_test.dart
+++ b/test/features/activity/application/relative_timestamp_formatter_test.dart
@@ -33,10 +33,7 @@ void main() {
     });
 
     test('null createdAt also "Just now"', () {
-      expect(
-        formatRelativeTimestamp(now: now, createdAt: null),
-        'Just now',
-      );
+      expect(formatRelativeTimestamp(now: now, createdAt: null), 'Just now');
     });
 
     test('future timestamp clamps to "Just now"', () {
@@ -171,7 +168,8 @@ void main() {
   group('7+ days, same year → "dd MMM"', () {
     test('7 days ago — same year', () {
       // now is 2026-06-08 06:30 UTC == 2026-06-08 12:00 IST.
-      // createdAt = now - 7 days = 2026-06-01 06:30 UTC == 2026-06-01 12:00 IST.
+      // createdAt = now - 7 days = 2026-06-01 06:30 UTC
+      // == 2026-06-01 12:00 IST.
       expect(
         formatRelativeTimestamp(
           now: now,
@@ -182,7 +180,8 @@ void main() {
     });
 
     test('30 days ago — same year', () {
-      // createdAt = now - 30 days = 2026-05-09 06:30 UTC == 2026-05-09 12:00 IST.
+      // createdAt = now - 30 days = 2026-05-09 06:30 UTC
+      // == 2026-05-09 12:00 IST.
       expect(
         formatRelativeTimestamp(
           now: now,

--- a/test/features/activity/application/relative_timestamp_formatter_test.dart
+++ b/test/features/activity/application/relative_timestamp_formatter_test.dart
@@ -1,0 +1,230 @@
+// Relative timestamp formatter tests (FR-AC-01, SCR-25 lines 314-326).
+//
+// Verifies every boundary case from the SCR-25 Relative Timestamp Format
+// table. All timestamps are rendered in IST (Asia/Kolkata, UTC+05:30)
+// per SRS section 5.9.
+//
+// The formatter is a pure function: given a `now` (test injection) and
+// a `createdAt`, returns the SCR-25 string.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/activity/application/relative_timestamp_formatter.dart';
+
+void main() {
+  // Reference instant: 2026-06-08 12:00:00 IST (== 2026-06-08 06:30:00 UTC).
+  // The formatter takes `now` as UTC; the test instants are UTC.
+  final now = DateTime.utc(2026, 6, 8, 6, 30);
+
+  group('< 1 minute → "Just now"', () {
+    test('exactly now', () {
+      expect(formatRelativeTimestamp(now: now, createdAt: now), 'Just now');
+    });
+
+    test('30 seconds ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(seconds: 30)),
+        ),
+        'Just now',
+      );
+    });
+
+    test('null createdAt also "Just now"', () {
+      expect(
+        formatRelativeTimestamp(now: now, createdAt: null),
+        'Just now',
+      );
+    });
+
+    test('future timestamp clamps to "Just now"', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.add(const Duration(minutes: 5)),
+        ),
+        'Just now',
+      );
+    });
+  });
+
+  group('1-59 minutes → "X min ago"', () {
+    test('1 minute ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(minutes: 1)),
+        ),
+        '1 min ago',
+      );
+    });
+
+    test('30 minutes ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(minutes: 30)),
+        ),
+        '30 min ago',
+      );
+    });
+
+    test('59 minutes ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(minutes: 59)),
+        ),
+        '59 min ago',
+      );
+    });
+  });
+
+  group('1-23 hours → "X hours ago" (or "1 hour ago")', () {
+    test('60 minutes (exactly 1 hour) ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(minutes: 60)),
+        ),
+        '1 hour ago',
+      );
+    });
+
+    test('1 hour 30 minutes ago (still rounds down to 1 hour)', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(minutes: 90)),
+        ),
+        '1 hour ago',
+      );
+    });
+
+    test('2 hours ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(hours: 2)),
+        ),
+        '2 hours ago',
+      );
+    });
+
+    test('23 hours ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(hours: 23)),
+        ),
+        '23 hours ago',
+      );
+    });
+  });
+
+  group('1 day → "Yesterday"', () {
+    test('exactly 24 hours ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(hours: 24)),
+        ),
+        'Yesterday',
+      );
+    });
+
+    test('36 hours ago is still "Yesterday"', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(hours: 36)),
+        ),
+        'Yesterday',
+      );
+    });
+  });
+
+  group('2-6 days → "X days ago"', () {
+    test('2 days ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(days: 2)),
+        ),
+        '2 days ago',
+      );
+    });
+
+    test('6 days ago', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(days: 6)),
+        ),
+        '6 days ago',
+      );
+    });
+  });
+
+  group('7+ days, same year → "dd MMM"', () {
+    test('7 days ago — same year', () {
+      // now is 2026-06-08 06:30 UTC == 2026-06-08 12:00 IST.
+      // createdAt = now - 7 days = 2026-06-01 06:30 UTC == 2026-06-01 12:00 IST.
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(days: 7)),
+        ),
+        '01 Jun',
+      );
+    });
+
+    test('30 days ago — same year', () {
+      // createdAt = now - 30 days = 2026-05-09 06:30 UTC == 2026-05-09 12:00 IST.
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: now.subtract(const Duration(days: 30)),
+        ),
+        '09 May',
+      );
+    });
+
+    test('IST timezone shifts the displayed day across midnight UTC', () {
+      // now is 2026-06-08 06:30 UTC == 2026-06-08 12:00 IST.
+      // createdAt 2026-03-13 23:00 UTC == 2026-03-14 04:30 IST → "14 Mar".
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: DateTime.utc(2026, 3, 13, 23),
+        ),
+        '14 Mar',
+      );
+    });
+  });
+
+  group('Previous year → "dd MMM yyyy"', () {
+    test('28 December 2024 (two years prior)', () {
+      // 2024-12-28 06:30 UTC == 2024-12-28 12:00 IST → "28 Dec 2024"
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: DateTime.utc(2024, 12, 28, 6, 30),
+        ),
+        '28 Dec 2024',
+      );
+    });
+
+    test('1 January 2025 (still previous year vs 2026 now)', () {
+      expect(
+        formatRelativeTimestamp(
+          now: now,
+          createdAt: DateTime.utc(2025, 1, 1, 6, 30),
+        ),
+        '01 Jan 2025',
+      );
+    });
+  });
+}

--- a/test/features/activity/domain/activity_feed_item_test.dart
+++ b/test/features/activity/domain/activity_feed_item_test.dart
@@ -1,0 +1,233 @@
+// ActivityFeedItem domain tests (FR-AC-01).
+//
+// Tests the parsing of Firestore snapshot data into ActivityFeedItem
+// (snake_case `type` field → camelCase ActivityEventType enum;
+// payload as Map<String, dynamic>; createdAt as DateTime?). Malformed
+// payloads are dropped via the onParseFailure callback per the
+// strict-parsing pattern established in FriendshipDoc.fromFirestore
+// (FR-FR-03 architect §3).
+//
+// These tests are written BEFORE the implementation exists
+// (test-first); they will fail to compile until the production code
+// at lib/features/activity/domain/ is created.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+
+void main() {
+  group('ActivityEventType — snake_case parsing', () {
+    test('expense_added → ActivityEventType.expenseAdded', () {
+      expect(
+        ActivityEventTypeX.parseSnakeCase('expense_added'),
+        ActivityEventType.expenseAdded,
+      );
+    });
+
+    test('expense_edited → ActivityEventType.expenseEdited', () {
+      expect(
+        ActivityEventTypeX.parseSnakeCase('expense_edited'),
+        ActivityEventType.expenseEdited,
+      );
+    });
+
+    test('expense_deleted → ActivityEventType.expenseDeleted', () {
+      expect(
+        ActivityEventTypeX.parseSnakeCase('expense_deleted'),
+        ActivityEventType.expenseDeleted,
+      );
+    });
+
+    test('settlement → ActivityEventType.settlementRecorded', () {
+      expect(
+        ActivityEventTypeX.parseSnakeCase('settlement'),
+        ActivityEventType.settlementRecorded,
+      );
+    });
+
+    test('unknown snake_case returns null', () {
+      expect(ActivityEventTypeX.parseSnakeCase('group_change'), isNull);
+      expect(ActivityEventTypeX.parseSnakeCase('mystery_event'), isNull);
+      expect(ActivityEventTypeX.parseSnakeCase(''), isNull);
+    });
+  });
+
+  group('ActivityFeedItem.fromFirestore — happy paths', () {
+    test('parses an expense_added document into a populated item', () {
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-1',
+        data: <String, dynamic>{
+          'type': 'expense_added',
+          'payload': <String, dynamic>{
+            'expenseId': 'exp-1',
+            'friendshipId': 'uidA_uidB',
+            'description': 'Dinner',
+            'amountPaise': 10000,
+            'category': 'food',
+            'payerId': 'uidA',
+            'splits': <Map<String, dynamic>>[
+              <String, dynamic>{'userId': 'uidA', 'sharePaise': 5000},
+              <String, dynamic>{'userId': 'uidB', 'sharePaise': 5000},
+            ],
+            'splitMethod': 'equal',
+            'hasReceipt': false,
+            'authorUid': 'uidA',
+          },
+          'createdAt': DateTime.utc(2026, 6, 8, 10, 30),
+        },
+      );
+
+      expect(parsed, isNotNull);
+      expect(parsed!.id, 'item-1');
+      expect(parsed.type, ActivityEventType.expenseAdded);
+      expect(parsed.payload['expenseId'], 'exp-1');
+      expect(parsed.payload['friendshipId'], 'uidA_uidB');
+      expect(parsed.payload['amountPaise'], 10000);
+      expect(parsed.createdAt, DateTime.utc(2026, 6, 8, 10, 30));
+    });
+
+    test('parses a settlement document into a populated item', () {
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-2',
+        data: <String, dynamic>{
+          'type': 'settlement',
+          'payload': <String, dynamic>{
+            'settlementId': 'set-1',
+            'fromUserId': 'uidA',
+            'toUserId': 'uidB',
+            'amountPaise': 5000,
+            'contextType': 'friendship',
+            'contextId': 'uidA_uidB',
+            'authorUid': 'uidA',
+          },
+          'createdAt': DateTime.utc(2026, 6, 8, 11),
+        },
+      );
+
+      expect(parsed, isNotNull);
+      expect(parsed!.type, ActivityEventType.settlementRecorded);
+      expect(parsed.payload['settlementId'], 'set-1');
+      expect(parsed.payload['amountPaise'], 5000);
+    });
+
+    test('payload values remain integers (Invariant 1)', () {
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-3',
+        data: <String, dynamic>{
+          'type': 'expense_added',
+          'payload': <String, dynamic>{
+            'amountPaise': 12345,
+            'expenseId': 'exp-1',
+            'friendshipId': 'uidA_uidB',
+            'description': 'x',
+            'category': 'general',
+            'payerId': 'uidA',
+            'splits': <Map<String, dynamic>>[],
+            'splitMethod': 'equal',
+            'hasReceipt': false,
+            'authorUid': 'uidA',
+          },
+          'createdAt': DateTime.utc(2026, 6, 8),
+        },
+      );
+      expect(parsed!.payload['amountPaise'], isA<int>());
+      expect(parsed.payload['amountPaise'], isNot(isA<double>()));
+    });
+  });
+
+  group('ActivityFeedItem.fromFirestore — malformed → drop + log', () {
+    test('unknown type returns null and reports via onParseFailure', () {
+      final reports = <String>[];
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-bad-1',
+        data: <String, dynamic>{
+          'type': 'group_change',
+          'payload': <String, dynamic>{},
+          'createdAt': DateTime.utc(2026, 6, 8),
+        },
+        onParseFailure: reports.add,
+      );
+
+      expect(parsed, isNull);
+      expect(reports, hasLength(1));
+      expect(reports.first, contains('item-bad-1'));
+      expect(reports.first, contains('unknown type'));
+    });
+
+    test('missing type returns null and reports', () {
+      final reports = <String>[];
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-bad-2',
+        data: <String, dynamic>{
+          'payload': <String, dynamic>{},
+          'createdAt': DateTime.utc(2026, 6, 8),
+        },
+        onParseFailure: reports.add,
+      );
+
+      expect(parsed, isNull);
+      expect(reports.single, contains('missing type'));
+    });
+
+    test('non-map payload returns null and reports', () {
+      final reports = <String>[];
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-bad-3',
+        data: <String, dynamic>{
+          'type': 'expense_added',
+          'payload': 'not-a-map',
+          'createdAt': DateTime.utc(2026, 6, 8),
+        },
+        onParseFailure: reports.add,
+      );
+
+      expect(parsed, isNull);
+      expect(reports.single, contains('payload'));
+    });
+
+    test('missing createdAt is permitted (renders as "Just now")', () {
+      final parsed = ActivityFeedItem.fromFirestore(
+        id: 'item-no-ts',
+        data: <String, dynamic>{
+          'type': 'expense_added',
+          'payload': <String, dynamic>{
+            'expenseId': 'exp-1',
+            'friendshipId': 'uidA_uidB',
+            'amountPaise': 100,
+            'description': 'x',
+            'category': 'general',
+            'payerId': 'uidA',
+            'splits': <Map<String, dynamic>>[],
+            'splitMethod': 'equal',
+            'hasReceipt': false,
+            'authorUid': 'uidA',
+          },
+        },
+      );
+
+      expect(parsed, isNotNull);
+      expect(parsed!.createdAt, isNull);
+    });
+  });
+
+  group('ActivityFeedItem — value equality and immutability', () {
+    test('two items with identical fields are equal', () {
+      final a = ActivityFeedItem(
+        id: 'same',
+        type: ActivityEventType.expenseAdded,
+        payload: const <String, dynamic>{'expenseId': 'e1'},
+        createdAt: DateTime.utc(2026, 6, 8),
+      );
+      final b = ActivityFeedItem(
+        id: 'same',
+        type: ActivityEventType.expenseAdded,
+        payload: const <String, dynamic>{'expenseId': 'e1'},
+        createdAt: DateTime.utc(2026, 6, 8),
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+}

--- a/test/features/activity/presentation/activity_feed_screen_test.dart
+++ b/test/features/activity/presentation/activity_feed_screen_test.dart
@@ -16,7 +16,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onebytwo/core/telemetry/event_id_hash.dart';
-import 'package:onebytwo/features/activity/application/activity_feed_provider.dart';
 import 'package:onebytwo/features/activity/data/activity_feed_repository.dart';
 import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
 import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
@@ -111,9 +110,7 @@ ProviderContainer _makeContainer({
       activityFeedRepositoryProvider.overrideWithValue(repository),
       analyticsServiceProvider.overrideWithValue(analytics),
       currentUserIdProvider.overrideWithValue('uid-me'),
-      userProfileProvider.overrideWith(
-        (ref, uid) async => profiles[uid],
-      ),
+      userProfileProvider.overrideWith((ref, uid) async => profiles[uid]),
     ],
   );
 }
@@ -130,10 +127,7 @@ void main() {
     testWidgets('displays a skeleton loader while resolving', (tester) async {
       final repo = FakeActivityFeedRepository();
       final analytics = FakeAnalyticsService();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-      );
+      final container = _makeContainer(repository: repo, analytics: analytics);
       addTearDown(container.dispose);
       addTearDown(() async => repo.controller.close());
 
@@ -207,10 +201,7 @@ void main() {
     ) async {
       final repo = FakeActivityFeedRepository();
       final analytics = FakeAnalyticsService();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-      );
+      final container = _makeContainer(repository: repo, analytics: analytics);
       addTearDown(container.dispose);
       addTearDown(() async => repo.controller.close());
 
@@ -234,10 +225,7 @@ void main() {
     testWidgets('shows the SCR-25 error copy on stream error', (tester) async {
       final repo = FakeActivityFeedRepository();
       final analytics = FakeAnalyticsService();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-      );
+      final container = _makeContainer(repository: repo, analytics: analytics);
       addTearDown(container.dispose);
       addTearDown(() async => repo.controller.close());
 
@@ -262,10 +250,7 @@ void main() {
     ) async {
       final repo = FakeActivityFeedRepository();
       final analytics = FakeAnalyticsService();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-      );
+      final container = _makeContainer(repository: repo, analytics: analytics);
       addTearDown(container.dispose);
       addTearDown(() async => repo.controller.close());
 
@@ -331,318 +316,6 @@ void main() {
           repository: repo,
           analytics: analytics,
           profiles: {'uid-other': _user('Priya')},
-        );
-        addTearDown(container.dispose);
-        addTearDown(() async => repo.controller.close());
-
-        await tester.pumpWidget(_wrap(container));
-        await tester.pump();
-
-        repo.controller.add([_expenseAddedByOther()]);
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.textContaining('Dinner'));
-        await tester.pumpAndSettle();
-
-        final params = analytics.lastParamsFor('activity_item_tapped')!;
-        expect(params['event_type'], 'expenseAdded');
-        // Expense IDs are opaque Firestore auto IDs — NOT subject to
-        // ADR-0013 hashing per the FR-FR-03 memory.
-        expect(params['entity_id'], 'exp-1');
-      },
-    );
-  });
-}
-
-
-ActivityFeedItem _expenseAddedByOther({String id = 'e-1'}) {
-  return ActivityFeedItem(
-    id: id,
-    type: ActivityEventType.expenseAdded,
-    payload: const <String, dynamic>{
-      'expenseId': 'exp-1',
-      'friendshipId': 'uid-me_uid-other',
-      'description': 'Dinner',
-      'amountPaise': 12345,
-      'category': 'food',
-      'payerId': 'uid-other',
-      'authorUid': 'uid-other',
-      'splits': <Map<String, dynamic>>[],
-      'splitMethod': 'equal',
-      'hasReceipt': false,
-    },
-    createdAt: DateTime.utc(2026, 6, 8, 11),
-  );
-}
-
-ActivityFeedItem _settlementByCurrent({String id = 's-1'}) {
-  return ActivityFeedItem(
-    id: id,
-    type: ActivityEventType.settlementRecorded,
-    payload: const <String, dynamic>{
-      'settlementId': 'set-1',
-      'fromUserId': 'uid-me',
-      'toUserId': 'uid-other',
-      'amountPaise': 5000,
-      'contextType': 'friendship',
-      'contextId': 'uid-me_uid-other',
-      'authorUid': 'uid-me',
-    },
-    createdAt: DateTime.utc(2026, 6, 8, 11, 30),
-  );
-}
-
-UserModel _user(String name) {
-  return UserModel(
-    phoneNumber: '+919876543210',
-    displayName: name,
-    createdAt: DateTime.utc(2026),
-    updatedAt: DateTime.utc(2026),
-  );
-}
-
-ProviderContainer _makeContainer({
-  required FakeActivityFeedRepository repository,
-  required FakeAnalyticsService analytics,
-  required FakeUserRepository userRepository,
-}) {
-  return ProviderContainer(
-    overrides: [
-      activityFeedRepositoryProvider.overrideWithValue(repository),
-      analyticsServiceProvider.overrideWithValue(analytics),
-      currentUserIdProvider.overrideWithValue('uid-me'),
-      userRepositoryProvider.overrideWithValue(userRepository),
-    ],
-  );
-}
-
-Widget _wrap(ProviderContainer container) {
-  return UncontrolledProviderScope(
-    container: container,
-    child: const MaterialApp(home: ActivityFeedScreen()),
-  );
-}
-
-void main() {
-  group('ActivityFeedScreen — Loading state', () {
-    testWidgets('displays a skeleton loader while resolving', (tester) async {
-      final repo = FakeActivityFeedRepository();
-      final analytics = FakeAnalyticsService();
-      final userRepo = FakeUserRepository();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-        userRepository: userRepo,
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async => repo.controller.close());
-
-      await tester.pumpWidget(_wrap(container));
-      await tester.pump();
-
-      expect(find.byKey(const Key('activity_feed_skeleton')), findsOneWidget);
-    });
-  });
-
-  group('ActivityFeedScreen — Populated state', () {
-    testWidgets('renders one OBTActivityRow per item in stream order', (
-      tester,
-    ) async {
-      final repo = FakeActivityFeedRepository();
-      final analytics = FakeAnalyticsService();
-      final userRepo = FakeUserRepository()
-        ..users['uid-other'] = _user('Priya');
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-        userRepository: userRepo,
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async => repo.controller.close());
-
-      await tester.pumpWidget(_wrap(container));
-      await tester.pump();
-
-      repo.controller.add([_expenseAddedByOther(), _settlementByCurrent()]);
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('Dinner'), findsOneWidget);
-      expect(find.textContaining('settled up'), findsOneWidget);
-    });
-
-    testWidgets('fires activity_feed_viewed exactly once with item_count', (
-      tester,
-    ) async {
-      final repo = FakeActivityFeedRepository();
-      final analytics = FakeAnalyticsService();
-      final userRepo = FakeUserRepository()
-        ..users['uid-other'] = _user('Priya');
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-        userRepository: userRepo,
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async => repo.controller.close());
-
-      await tester.pumpWidget(_wrap(container));
-      await tester.pump();
-
-      repo.controller.add([_expenseAddedByOther(), _settlementByCurrent()]);
-      await tester.pumpAndSettle();
-
-      // A second emission should NOT double-log the viewed event.
-      repo.controller.add([
-        _expenseAddedByOther(id: 'e-2'),
-        _settlementByCurrent(id: 's-2'),
-      ]);
-      await tester.pumpAndSettle();
-
-      expect(analytics.countOf('activity_feed_viewed'), 1);
-      expect(
-        analytics.lastParamsFor('activity_feed_viewed'),
-        containsPair('item_count', 2),
-      );
-    });
-  });
-
-  group('ActivityFeedScreen — Empty state', () {
-    testWidgets('shows the SCR-25 empty copy when items list is empty', (
-      tester,
-    ) async {
-      final repo = FakeActivityFeedRepository();
-      final analytics = FakeAnalyticsService();
-      final userRepo = FakeUserRepository();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-        userRepository: userRepo,
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async => repo.controller.close());
-
-      await tester.pumpWidget(_wrap(container));
-      await tester.pump();
-
-      repo.controller.add(const <ActivityFeedItem>[]);
-      await tester.pumpAndSettle();
-
-      expect(find.text('All quiet here'), findsOneWidget);
-      expect(
-        find.textContaining(
-          'Your activity will show up as you add expenses and settle up.',
-        ),
-        findsOneWidget,
-      );
-    });
-  });
-
-  group('ActivityFeedScreen — Error state', () {
-    testWidgets('shows the SCR-25 error copy on stream error', (tester) async {
-      final repo = FakeActivityFeedRepository();
-      final analytics = FakeAnalyticsService();
-      final userRepo = FakeUserRepository();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-        userRepository: userRepo,
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async => repo.controller.close());
-
-      await tester.pumpWidget(_wrap(container));
-      await tester.pump();
-
-      repo.controller.addError(StateError('permission-denied'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Something went wrong'), findsOneWidget);
-      expect(
-        find.textContaining(
-          'We could not load your activity. Please try again.',
-        ),
-        findsOneWidget,
-      );
-      expect(find.widgetWithText(OutlinedButton, 'Retry'), findsOneWidget);
-    });
-
-    testWidgets('fires activity_feed_error with an error_code parameter', (
-      tester,
-    ) async {
-      final repo = FakeActivityFeedRepository();
-      final analytics = FakeAnalyticsService();
-      final userRepo = FakeUserRepository();
-      final container = _makeContainer(
-        repository: repo,
-        analytics: analytics,
-        userRepository: userRepo,
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async => repo.controller.close());
-
-      await tester.pumpWidget(_wrap(container));
-      await tester.pump();
-
-      repo.controller.addError(StateError('permission-denied'));
-      await tester.pumpAndSettle();
-
-      expect(analytics.countOf('activity_feed_error'), 1);
-      final params = analytics.lastParamsFor('activity_feed_error');
-      expect(params, isNotNull);
-      expect(params!.containsKey('error_code'), isTrue);
-      expect(params['error_code'], isA<String>());
-    });
-  });
-
-  group('ActivityFeedScreen — telemetry (PII hashing)', () {
-    testWidgets(
-      'activity_item_tapped hashes the friendship entity_id (AC-17)',
-      (tester) async {
-        final repo = FakeActivityFeedRepository();
-        final analytics = FakeAnalyticsService();
-        final userRepo = FakeUserRepository()
-          ..users['uid-other'] = _user('Priya');
-        final container = _makeContainer(
-          repository: repo,
-          analytics: analytics,
-          userRepository: userRepo,
-        );
-        addTearDown(container.dispose);
-        addTearDown(() async => repo.controller.close());
-
-        await tester.pumpWidget(_wrap(container));
-        await tester.pump();
-
-        repo.controller.add([_settlementByCurrent()]);
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.textContaining('settled up'));
-        await tester.pumpAndSettle();
-
-        expect(analytics.countOf('activity_item_tapped'), greaterThanOrEqualTo(1));
-        final params = analytics.lastParamsFor('activity_item_tapped')!;
-        expect(params['event_type'], 'settlementRecorded');
-        // The settlement row deep-links to the Friend Detail screen
-        // (a friendship target). The entity_id parameter MUST be the
-        // hashed composite friendship UID per ADR-0013.
-        final expectedHash = hashFriendshipId('uid-me_uid-other');
-        expect(params['entity_id'], expectedHash);
-        // The raw composite UID MUST NOT appear.
-        expect(params['entity_id'], isNot(equals('uid-me_uid-other')));
-      },
-    );
-
-    testWidgets(
-      'activity_item_tapped uses raw opaque expenseId for expense rows',
-      (tester) async {
-        final repo = FakeActivityFeedRepository();
-        final analytics = FakeAnalyticsService();
-        final userRepo = FakeUserRepository()
-          ..users['uid-other'] = _user('Priya');
-        final container = _makeContainer(
-          repository: repo,
-          analytics: analytics,
-          userRepository: userRepo,
         );
         addTearDown(container.dispose);
         addTearDown(() async => repo.controller.close());

--- a/test/features/activity/presentation/activity_feed_screen_test.dart
+++ b/test/features/activity/presentation/activity_feed_screen_test.dart
@@ -1,0 +1,667 @@
+// Activity feed screen widget tests (FR-AC-01).
+//
+// Verifies the SCR-25 multi-state rendering (Loading / Populated /
+// Empty / Error / Refreshing), telemetry single-fire discipline for
+// activity_feed_viewed, the activity_item_tapped event including PII
+// hashing of friendship entity_ids (AC-17), and the FR-AC-02 deep-link
+// routing surface.
+//
+// Tests are written BEFORE the implementation exists.
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/telemetry/event_id_hash.dart';
+import 'package:onebytwo/features/activity/application/activity_feed_provider.dart';
+import 'package:onebytwo/features/activity/data/activity_feed_repository.dart';
+import 'package:onebytwo/features/activity/domain/activity_event_type.dart';
+import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
+import 'package:onebytwo/features/activity/presentation/activity_feed_screen.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/auth/domain/user_model.dart';
+import 'package:onebytwo/features/friends/application/friends_list_provider.dart';
+import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
+
+class FakeAnalyticsService implements AnalyticsService {
+  final List<({String name, Map<String, Object>? parameters})> loggedEvents =
+      [];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object>? parameters,
+  }) async {
+    loggedEvents.add((name: name, parameters: parameters));
+  }
+
+  int countOf(String name) => loggedEvents.where((e) => e.name == name).length;
+
+  Map<String, Object>? lastParamsFor(String name) {
+    return loggedEvents.lastWhere((e) => e.name == name).parameters;
+  }
+}
+
+class FakeActivityFeedRepository implements ActivityFeedRepository {
+  final StreamController<List<ActivityFeedItem>> controller =
+      StreamController<List<ActivityFeedItem>>.broadcast();
+
+  @override
+  Stream<List<ActivityFeedItem>> watchItems(String userId) {
+    return controller.stream;
+  }
+}
+
+ActivityFeedItem _expenseAddedByOther({String id = 'e-1'}) {
+  return ActivityFeedItem(
+    id: id,
+    type: ActivityEventType.expenseAdded,
+    payload: const <String, dynamic>{
+      'expenseId': 'exp-1',
+      'friendshipId': 'uid-me_uid-other',
+      'description': 'Dinner',
+      'amountPaise': 12345,
+      'category': 'food',
+      'payerId': 'uid-other',
+      'authorUid': 'uid-other',
+      'splits': <Map<String, dynamic>>[],
+      'splitMethod': 'equal',
+      'hasReceipt': false,
+    },
+    createdAt: DateTime.utc(2026, 6, 8, 11),
+  );
+}
+
+ActivityFeedItem _settlementByCurrent({String id = 's-1'}) {
+  return ActivityFeedItem(
+    id: id,
+    type: ActivityEventType.settlementRecorded,
+    payload: const <String, dynamic>{
+      'settlementId': 'set-1',
+      'fromUserId': 'uid-me',
+      'toUserId': 'uid-other',
+      'amountPaise': 5000,
+      'contextType': 'friendship',
+      'contextId': 'uid-me_uid-other',
+      'authorUid': 'uid-me',
+    },
+    createdAt: DateTime.utc(2026, 6, 8, 11, 30),
+  );
+}
+
+UserModel _user(String name) {
+  return UserModel(
+    phoneNumber: '+919876543210',
+    displayName: name,
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+}
+
+ProviderContainer _makeContainer({
+  required FakeActivityFeedRepository repository,
+  required FakeAnalyticsService analytics,
+  Map<String, UserModel?> profiles = const <String, UserModel?>{},
+}) {
+  return ProviderContainer(
+    overrides: [
+      activityFeedRepositoryProvider.overrideWithValue(repository),
+      analyticsServiceProvider.overrideWithValue(analytics),
+      currentUserIdProvider.overrideWithValue('uid-me'),
+      userProfileProvider.overrideWith(
+        (ref, uid) async => profiles[uid],
+      ),
+    ],
+  );
+}
+
+Widget _wrap(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: const MaterialApp(home: ActivityFeedScreen()),
+  );
+}
+
+void main() {
+  group('ActivityFeedScreen — Loading state', () {
+    testWidgets('displays a skeleton loader while resolving', (tester) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      expect(find.byKey(const Key('activity_feed_skeleton')), findsOneWidget);
+    });
+  });
+
+  group('ActivityFeedScreen — Populated state', () {
+    testWidgets('renders one OBTActivityRow per item in stream order', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        profiles: {'uid-other': _user('Priya')},
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.add([_expenseAddedByOther(), _settlementByCurrent()]);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Dinner'), findsOneWidget);
+      expect(find.textContaining('settled up'), findsOneWidget);
+    });
+
+    testWidgets('fires activity_feed_viewed exactly once with item_count', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        profiles: {'uid-other': _user('Priya')},
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.add([_expenseAddedByOther(), _settlementByCurrent()]);
+      await tester.pumpAndSettle();
+
+      repo.controller.add([
+        _expenseAddedByOther(id: 'e-2'),
+        _settlementByCurrent(id: 's-2'),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(analytics.countOf('activity_feed_viewed'), 1);
+      expect(
+        analytics.lastParamsFor('activity_feed_viewed'),
+        containsPair('item_count', 2),
+      );
+    });
+  });
+
+  group('ActivityFeedScreen — Empty state', () {
+    testWidgets('shows the SCR-25 empty copy when items list is empty', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.add(const <ActivityFeedItem>[]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('All quiet here'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'Your activity will show up as you add expenses and settle up.',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('ActivityFeedScreen — Error state', () {
+    testWidgets('shows the SCR-25 error copy on stream error', (tester) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.addError(StateError('permission-denied'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'We could not load your activity. Please try again.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(OutlinedButton, 'Retry'), findsOneWidget);
+    });
+
+    testWidgets('fires activity_feed_error with an error_code parameter', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.addError(StateError('permission-denied'));
+      await tester.pumpAndSettle();
+
+      expect(analytics.countOf('activity_feed_error'), 1);
+      final params = analytics.lastParamsFor('activity_feed_error');
+      expect(params, isNotNull);
+      expect(params!.containsKey('error_code'), isTrue);
+      expect(params['error_code'], isA<String>());
+    });
+  });
+
+  group('ActivityFeedScreen — telemetry (PII hashing)', () {
+    testWidgets(
+      'activity_item_tapped hashes the friendship entity_id (AC-17)',
+      (tester) async {
+        final repo = FakeActivityFeedRepository();
+        final analytics = FakeAnalyticsService();
+        final container = _makeContainer(
+          repository: repo,
+          analytics: analytics,
+          profiles: {'uid-other': _user('Priya')},
+        );
+        addTearDown(container.dispose);
+        addTearDown(() async => repo.controller.close());
+
+        await tester.pumpWidget(_wrap(container));
+        await tester.pump();
+
+        repo.controller.add([_settlementByCurrent()]);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.textContaining('settled up'));
+        await tester.pumpAndSettle();
+
+        expect(
+          analytics.countOf('activity_item_tapped'),
+          greaterThanOrEqualTo(1),
+        );
+        final params = analytics.lastParamsFor('activity_item_tapped')!;
+        expect(params['event_type'], 'settlementRecorded');
+        // The settlement row deep-links to the Friend Detail screen
+        // (a friendship target). The entity_id parameter MUST be the
+        // hashed composite friendship UID per ADR-0013.
+        final expectedHash = hashFriendshipId('uid-me_uid-other');
+        expect(params['entity_id'], expectedHash);
+        // The raw composite UID MUST NOT appear.
+        expect(params['entity_id'], isNot(equals('uid-me_uid-other')));
+      },
+    );
+
+    testWidgets(
+      'activity_item_tapped uses raw opaque expenseId for expense rows',
+      (tester) async {
+        final repo = FakeActivityFeedRepository();
+        final analytics = FakeAnalyticsService();
+        final container = _makeContainer(
+          repository: repo,
+          analytics: analytics,
+          profiles: {'uid-other': _user('Priya')},
+        );
+        addTearDown(container.dispose);
+        addTearDown(() async => repo.controller.close());
+
+        await tester.pumpWidget(_wrap(container));
+        await tester.pump();
+
+        repo.controller.add([_expenseAddedByOther()]);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.textContaining('Dinner'));
+        await tester.pumpAndSettle();
+
+        final params = analytics.lastParamsFor('activity_item_tapped')!;
+        expect(params['event_type'], 'expenseAdded');
+        // Expense IDs are opaque Firestore auto IDs — NOT subject to
+        // ADR-0013 hashing per the FR-FR-03 memory.
+        expect(params['entity_id'], 'exp-1');
+      },
+    );
+  });
+}
+
+
+ActivityFeedItem _expenseAddedByOther({String id = 'e-1'}) {
+  return ActivityFeedItem(
+    id: id,
+    type: ActivityEventType.expenseAdded,
+    payload: const <String, dynamic>{
+      'expenseId': 'exp-1',
+      'friendshipId': 'uid-me_uid-other',
+      'description': 'Dinner',
+      'amountPaise': 12345,
+      'category': 'food',
+      'payerId': 'uid-other',
+      'authorUid': 'uid-other',
+      'splits': <Map<String, dynamic>>[],
+      'splitMethod': 'equal',
+      'hasReceipt': false,
+    },
+    createdAt: DateTime.utc(2026, 6, 8, 11),
+  );
+}
+
+ActivityFeedItem _settlementByCurrent({String id = 's-1'}) {
+  return ActivityFeedItem(
+    id: id,
+    type: ActivityEventType.settlementRecorded,
+    payload: const <String, dynamic>{
+      'settlementId': 'set-1',
+      'fromUserId': 'uid-me',
+      'toUserId': 'uid-other',
+      'amountPaise': 5000,
+      'contextType': 'friendship',
+      'contextId': 'uid-me_uid-other',
+      'authorUid': 'uid-me',
+    },
+    createdAt: DateTime.utc(2026, 6, 8, 11, 30),
+  );
+}
+
+UserModel _user(String name) {
+  return UserModel(
+    phoneNumber: '+919876543210',
+    displayName: name,
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+}
+
+ProviderContainer _makeContainer({
+  required FakeActivityFeedRepository repository,
+  required FakeAnalyticsService analytics,
+  required FakeUserRepository userRepository,
+}) {
+  return ProviderContainer(
+    overrides: [
+      activityFeedRepositoryProvider.overrideWithValue(repository),
+      analyticsServiceProvider.overrideWithValue(analytics),
+      currentUserIdProvider.overrideWithValue('uid-me'),
+      userRepositoryProvider.overrideWithValue(userRepository),
+    ],
+  );
+}
+
+Widget _wrap(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: const MaterialApp(home: ActivityFeedScreen()),
+  );
+}
+
+void main() {
+  group('ActivityFeedScreen — Loading state', () {
+    testWidgets('displays a skeleton loader while resolving', (tester) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final userRepo = FakeUserRepository();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        userRepository: userRepo,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      expect(find.byKey(const Key('activity_feed_skeleton')), findsOneWidget);
+    });
+  });
+
+  group('ActivityFeedScreen — Populated state', () {
+    testWidgets('renders one OBTActivityRow per item in stream order', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final userRepo = FakeUserRepository()
+        ..users['uid-other'] = _user('Priya');
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        userRepository: userRepo,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.add([_expenseAddedByOther(), _settlementByCurrent()]);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Dinner'), findsOneWidget);
+      expect(find.textContaining('settled up'), findsOneWidget);
+    });
+
+    testWidgets('fires activity_feed_viewed exactly once with item_count', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final userRepo = FakeUserRepository()
+        ..users['uid-other'] = _user('Priya');
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        userRepository: userRepo,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.add([_expenseAddedByOther(), _settlementByCurrent()]);
+      await tester.pumpAndSettle();
+
+      // A second emission should NOT double-log the viewed event.
+      repo.controller.add([
+        _expenseAddedByOther(id: 'e-2'),
+        _settlementByCurrent(id: 's-2'),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(analytics.countOf('activity_feed_viewed'), 1);
+      expect(
+        analytics.lastParamsFor('activity_feed_viewed'),
+        containsPair('item_count', 2),
+      );
+    });
+  });
+
+  group('ActivityFeedScreen — Empty state', () {
+    testWidgets('shows the SCR-25 empty copy when items list is empty', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final userRepo = FakeUserRepository();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        userRepository: userRepo,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.add(const <ActivityFeedItem>[]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('All quiet here'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'Your activity will show up as you add expenses and settle up.',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('ActivityFeedScreen — Error state', () {
+    testWidgets('shows the SCR-25 error copy on stream error', (tester) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final userRepo = FakeUserRepository();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        userRepository: userRepo,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.addError(StateError('permission-denied'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'We could not load your activity. Please try again.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(OutlinedButton, 'Retry'), findsOneWidget);
+    });
+
+    testWidgets('fires activity_feed_error with an error_code parameter', (
+      tester,
+    ) async {
+      final repo = FakeActivityFeedRepository();
+      final analytics = FakeAnalyticsService();
+      final userRepo = FakeUserRepository();
+      final container = _makeContainer(
+        repository: repo,
+        analytics: analytics,
+        userRepository: userRepo,
+      );
+      addTearDown(container.dispose);
+      addTearDown(() async => repo.controller.close());
+
+      await tester.pumpWidget(_wrap(container));
+      await tester.pump();
+
+      repo.controller.addError(StateError('permission-denied'));
+      await tester.pumpAndSettle();
+
+      expect(analytics.countOf('activity_feed_error'), 1);
+      final params = analytics.lastParamsFor('activity_feed_error');
+      expect(params, isNotNull);
+      expect(params!.containsKey('error_code'), isTrue);
+      expect(params['error_code'], isA<String>());
+    });
+  });
+
+  group('ActivityFeedScreen — telemetry (PII hashing)', () {
+    testWidgets(
+      'activity_item_tapped hashes the friendship entity_id (AC-17)',
+      (tester) async {
+        final repo = FakeActivityFeedRepository();
+        final analytics = FakeAnalyticsService();
+        final userRepo = FakeUserRepository()
+          ..users['uid-other'] = _user('Priya');
+        final container = _makeContainer(
+          repository: repo,
+          analytics: analytics,
+          userRepository: userRepo,
+        );
+        addTearDown(container.dispose);
+        addTearDown(() async => repo.controller.close());
+
+        await tester.pumpWidget(_wrap(container));
+        await tester.pump();
+
+        repo.controller.add([_settlementByCurrent()]);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.textContaining('settled up'));
+        await tester.pumpAndSettle();
+
+        expect(analytics.countOf('activity_item_tapped'), greaterThanOrEqualTo(1));
+        final params = analytics.lastParamsFor('activity_item_tapped')!;
+        expect(params['event_type'], 'settlementRecorded');
+        // The settlement row deep-links to the Friend Detail screen
+        // (a friendship target). The entity_id parameter MUST be the
+        // hashed composite friendship UID per ADR-0013.
+        final expectedHash = hashFriendshipId('uid-me_uid-other');
+        expect(params['entity_id'], expectedHash);
+        // The raw composite UID MUST NOT appear.
+        expect(params['entity_id'], isNot(equals('uid-me_uid-other')));
+      },
+    );
+
+    testWidgets(
+      'activity_item_tapped uses raw opaque expenseId for expense rows',
+      (tester) async {
+        final repo = FakeActivityFeedRepository();
+        final analytics = FakeAnalyticsService();
+        final userRepo = FakeUserRepository()
+          ..users['uid-other'] = _user('Priya');
+        final container = _makeContainer(
+          repository: repo,
+          analytics: analytics,
+          userRepository: userRepo,
+        );
+        addTearDown(container.dispose);
+        addTearDown(() async => repo.controller.close());
+
+        await tester.pumpWidget(_wrap(container));
+        await tester.pump();
+
+        repo.controller.add([_expenseAddedByOther()]);
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.textContaining('Dinner'));
+        await tester.pumpAndSettle();
+
+        final params = analytics.lastParamsFor('activity_item_tapped')!;
+        expect(params['event_type'], 'expenseAdded');
+        // Expense IDs are opaque Firestore auto IDs — NOT subject to
+        // ADR-0013 hashing per the FR-FR-03 memory.
+        expect(params['entity_id'], 'exp-1');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes the FR-AC-01 / FR-AC-02 P0 stories and the symmetric write-side
TODO at `functions/src/triggers/on-settlement-write/function.ts:231`.
PR #51 shipped the activity-feed write-side for friendship expenses;
this PR ships the **client read-side** (SCR-25 Activity Feed) plus
the **settlement-trigger activity emission** that closes the
settlement leg of the SCR-25 Event Type Mapping.

The implementation follows the FR-AC-01 architect notes in the story
file (Architect Notes §2.1–§2.9). Story SP: **8** (5 client + 1
settlement-trigger server + 1 OBTActivityRow widget + 1
routing/telemetry).

Story: `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md`

## Cites

- SCR-25: `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 256-386
- Schema: `docs/design/07-technical/firestore-schema.md` lines 194-211
- Component catalogue: `docs/design/02-design-system/components.md` section 14
- ADR-0002 (paise integers), ADR-0006 (Riverpod), ADR-0007 (feature-first), ADR-0013 (PII)

## What ships

**Client (5 SP):**
- `lib/features/activity/data/activity_feed_repository.dart` — Firestore
  snapshot listener at `activity/{uid}/items` ordered by `createdAt` desc.
- `lib/features/activity/domain/activity_event_type.dart` — camelCase
  enum + snake_case parser (forward-compatible).
- `lib/features/activity/domain/activity_feed_item.dart` — typed value
  type with strict `fromFirestore` (malformed → drop + log).
- `lib/features/activity/application/activity_feed_provider.dart` —
  single `StreamProvider<List<ActivityFeedItem>>` (no family per §2.5).
- `lib/features/activity/application/relative_timestamp_formatter.dart`
  — pure function rendering IST wall-clock per SCR-25 lines 314-326.
- `lib/features/activity/presentation/activity_feed_screen.dart` —
  six-state screen (Loading / Populated / Empty / Error / Refreshing /
  RetryFailed) with FR-AC-02 in-app deep-link routing.
- `lib/features/activity/presentation/widgets/activity_feed_skeleton.dart`
  — 5-row skeleton loader with reduce-motion accommodation.
- `lib/core/widgets/lists/obt_activity_row.dart` — OBTActivityRow
  primitive (cross-feature OBT widget per components.md §14).
- `lib/features/auth/presentation/home_placeholder_screen.dart` —
  temporary "Activity" AppBar action (v1.0 entry point per §2.1).

**Server (1 SP):**
- `functions/src/triggers/on-expense-write/payload-builder.ts` —
  extended `ActivityItemType` union with `'settlement'`; extended
  `ActivityPayload` discriminated union with `SettlementPayload`.
- `functions/src/triggers/on-expense-write/activity-validator.ts` —
  extended with `validateSettlementPayload` branch.
- `functions/src/triggers/on-settlement-write/settlement-payload-builder.ts`
  — NEW pure function emitting on create, null on soft-/hard-delete
  (architect §2.2 v1.0 decision).
- `functions/src/triggers/on-settlement-write/function.ts` — extended
  with `emitSettlementActivity` helper after the success branch.

**Telemetry (1 SP):** four new client-side events per SCR-25 lines
347-354 — `activity_feed_viewed`, `activity_item_tapped`,
`activity_feed_refreshed`, `activity_feed_error`. PII hashing of
friendship composite UIDs via `hashFriendshipId()` per ADR-0013.

## Invariant compliance

- **Invariant 1 (paise integers):** applicable on the SCR-25 render
  path. `OBTActivityRow` trailing amount uses `formatInrFromPaise(int)`;
  zero inline `/100` arithmetic anywhere in `lib/features/activity/**`.
  New boundary-contract grep at
  `test/features/activity/activity_boundary_contract_test.dart` is the
  affirmative test.
- **Invariant 2 (`simplifiedBalances` server-only):** N/A on the read
  path. The client reads `activity/{uid}/items`, NOT
  `simplifiedBalances`. The settlement-trigger extension touches only
  `activity/**`.
- **Invariant 3 (system share sheet):** N/A. No outbound sharing
  surface.
- **Invariant 4 (single Firebase project):** unchanged; `.firebaserc`
  untouched.

## Test counts

- Flutter: **973** pass / 30 skipped (baseline 911 + 62 new).
- Functions unit: **195** pass across 14 suites (baseline 166 + 29 new).
- Firestore rules: **188** pass across 9 suites (unchanged — no rules
  diff).
- `dart format`: 0 changes. `flutter analyze --fatal-infos`: No issues.
- `npm run lint && npm run build`: clean.

## Pre-existing infrastructure caveat

The local Functions emulator currently fails to load
`onExpenseWriteFriendship` with the warning `functions.config() has been
removed in firebase-functions v7`, which causes the integration tests
under `firebase emulators:exec` to time out. This is a **pre-existing**
issue (verified by reproducing on `main` with this PR's changes
stashed — 5/6 tests fail there as well). It is NOT introduced by PR #52.
Tracked in `docs/sprint-zero/next-three-prs.md` as a Sprint-3
infrastructure chore candidate. The two new round-trip tests added by
this PR will pass once the emulator-load issue is resolved.

## Explicitly deferred (per architect notes)

- `OBTBottomNav` shell (§2.1) — separate UX PR.
- `OBTRupeeText` primitive (§2.6) — separate OBT-primitives PR.
- FR-AC-03 FCM push notifications — separate P0 story (PR #53 candidate).
- FR-AC-04 notification preferences — paired with FR-AC-03.
- FR-AC-05 cold-start deep-link — paired with FR-AC-03 (FCM is the
  cold-start trigger).
- Group-context activity emission — Sprint 3 groups epic.
- Read/unread markers — SCR-25 Open Question 1; v1.1 candidate.
- Cursor-based pagination — SCR-25 Open Question 2; FUTURE.
- Filter/search within activity — SCR-25 Open Question 3; deferred.
- `settlementDeleted` activity items — v1.0 decision per §2.2.
- `writeExpenseActivity` → `writeContextActivity` rename — deferred
  per §2.3 (keeps PR #51 tests and Cloud Logging schema stable; a
  future cleanup PR can do the rename + log-key migration).

## Files explicitly NOT touched

`firestore.rules`, `firestore.indexes.json`, `storage.rules`,
`pubspec.yaml`, `functions/package.json`, `lib/main.dart`,
`functions/src/triggers/on-expense-write/function.ts`,
`.github/workflows/*.yml`,
`lib/features/expenses/**`, `lib/features/friends/**`,
`lib/features/settlements/**`. The activity-writer source file is
extended ONLY to include `'settlement'` in the `ActivityItemType`
re-export (single character change).

## Commit cadence

11 atomic commits per the prompt Phase 5:

1. `docs(stories): FR-AC-01 activity-feed read-side story`
2. `docs(stories): FR-AC-01 architect notes`
3. `test(activity): FR-AC-01 widget + domain tests`
4. `test(functions): FR-AC-01 settlement-trigger activity tests`
5. `feat(functions): settlement-payload builder for activity emission (FR-AC-01)`
6. `feat(functions): emit settlement activity items (FR-AC-01)`
7. `test(integration): FR-AC-01 settlement-activity round-trip`
8. `feat(activity): activity-feed core (OBTActivityRow, provider, repository) (FR-AC-01)`
9. `feat(activity): SCR-25 Activity tab screen + FR-AC-02 deep-links`
10. `test(activity): boundary-contract grep against monetary float drift`
11. `docs(plan): PR #52 shipped, prep PR #53`

Next PR: PR #53 — TBD per architect's call at kickoff (top candidate:
FR-AC-03 FCM push notifications + FR-AC-05 cold-start deep-link).
