### PR TITLE
feat(notifications): FR-AC-03 FCM push + FR-AC-05 cold-start deep-link

### DIFF
--- a/docs/audits/sprint-1/07-bucket-b-burndown.md
+++ b/docs/audits/sprint-1/07-bucket-b-burndown.md
@@ -6,7 +6,7 @@
 > Source: `docs/audits/sprint-1/00-triage-summary.md` (Bucket B section).
 > Detail: `docs/audits/sprint-1/06-deferred-to-sprint-2.md`.
 >
-> Last updated: PR #52.
+> Last updated: PR #53.
 
 ---
 
@@ -173,6 +173,8 @@ PR #45 (CHORE-PR45):   30 remaining  ██████████████�
 PR #46 (FR-EX-06):     30 remaining  █████████████████████████████░░░░░░░░░  30/37
 PR #48 (FR-EX-05):     28 remaining  ███████████████████████████░░░░░░░░░░░  28/37
 PR #51 (FR-EX-07):     27 remaining  ██████████████████████████░░░░░░░░░░░░  27/37
+PR #52 (FR-AC-01):     27 remaining  ██████████████████████████░░░░░░░░░░░░  27/37
+PR #53 (FR-AC-03/05):  27 remaining  ██████████████████████████░░░░░░░░░░░░  27/37
 ```
 
 PR #32 closed three items (R1, R2, R3 — friendship rules tests). PR #33 was a
@@ -584,4 +586,45 @@ close any Bucket-B items directly:
   it is not a regression introduced by PR #52.
 
 Net contribution of PR #52 to Bucket-B totals: **0**. The
+remaining count stays at **27 / 37**.
+
+PR #53 (FR-AC-03 FCM push notifications + FR-AC-05 cold-start
+deep-link) makes partial progress on **PY3** and does NOT close
+any Bucket-B items directly:
+
+- **PY3 — Expand integration tests for Sprint 2 flows:** PR #53
+  extends the trigger-handler tests with 11 new FCM-side
+  assertions (the expense + settlement triggers now have explicit
+  test coverage for `sendExpenseNotification` /
+  `sendSettlementNotification` being called on the success branch
+  AND being NOT-called on the stale-event / CONTEXT_NOT_FOUND /
+  BALANCE_INVARIANT_VIOLATED branches AND being error-contained
+  per architect §2.9 item 2). PR #53 also adds 63 new unit tests
+  in the new `functions/test/notifications/` subdirectory
+  (`fcm-send.test.ts` + `payload-renderer.test.ts` +
+  `prefs-filter.test.ts` + `send-expense-notification.test.ts` +
+  `send-settlement-notification.test.ts` + a new
+  `format-inr.test.ts` mirror of the Flutter-side INR formatter
+  test). On the Flutter side, PR #53 ships 95 new tests under
+  `test/features/notifications/**` + `test/core/routing/**`
+  covering the FCM token service, the notification handler,
+  the permission controller, the deep-link handler, the
+  pre-permission dialog, the in-app banner, the
+  notifications boundary-contract grep, and the shared routing
+  helper. Partial credit only; PY3 remains open pending the
+  full emulator-side FCM round-trip integration test (deferred
+  per PR #53 functions-dev §1 deviation — the existing
+  emulator-side integration test infrastructure does not
+  exercise the FCM emission path because `jest.mock()` does
+  not survive the emulator process boundary).
+- **No Bucket-B items closed by PR #53.** The FCM infrastructure
+  is new ground and is not a separately tracked Bucket-B item.
+- **No new Bucket-B items filed by PR #53.** The
+  emulator-side FCM integration test infrastructure gap is
+  tracked as a candidate in `docs/sprint-zero/next-three-prs.md`
+  (PR #54 candidate slot). The pre-existing Functions emulator
+  `functions.config()` load issue noted in the PR #52 burndown
+  remains open and unrelated to this PR.
+
+Net contribution of PR #53 to Bucket-B totals: **0**. The
 remaining count stays at **27 / 37**.

--- a/docs/copilot_prompts/sprint_2/16.md
+++ b/docs/copilot_prompts/sprint_2/16.md
@@ -1,0 +1,410 @@
+1. You are the OneByTwo orchestrator agent. PR #52 (FR-AC-01 — activity feed read-side + settlement-trigger activity emission) has merged (squash commit `fcc4f80`) and the **read-side** of the activity-feed is now live in production: the `ActivityFeedScreen` at `lib/features/activity/presentation/activity_feed_screen.dart` renders the SCR-25 six-state feed (Loading / Populated / Empty / Error / Refreshing / RetryFailed), the `OBTActivityRow` widget sits at `lib/core/widgets/lists/obt_activity_row.dart` ready for reuse, the FR-AC-02 in-app deep-link routing handles `expenseAdded` / `expenseEdited` → ExpenseDetailScreen, `settlementRecorded` → FriendDetailScreen, and `expenseDeleted` → "This item is no longer available." snackbar, the `onSettlementWrite` trigger now emits `'settlement'` activity items to BOTH parties after every successful recompute, and the temporary "Activity" AppBar action on `HomePlaceholderScreen` is the v1.0 entry point. Sprint 2 velocity through end of PR #52: **63 SP across 16 PRs**. We now implement **PR #53: FR-AC-03 + FR-AC-05 — FCM push notifications (foreground/background/cold-start) + cold-start deep-link**. This is the natural P0 follow-on: PR #52 wrote the in-app deep-link routing surface; PR #53 wires FCM as a SECOND producer of that same routing (foreground in-app banner taps, background system notification taps, and cold-start launches). The notification-send half is the bulk: a new `functions/src/notifications/` module (FCM admin SDK helpers + per-event-type renderers + token cleanup on 410), the two TODO seams at `functions/src/triggers/on-expense-write/function.ts:167` and `functions/src/triggers/on-settlement-write/function.ts:237` closed verbatim (mirror of the FR-EX-07 + FR-AC-01 emission patterns), and the client half is the FCM token lifecycle (acquisition after profile-setup-complete per `docs/design/07-technical/notifications.md` §1.1 + §5.1, storage via `arrayUnion` on `users/{uid}.fcmTokens`, `onTokenRefresh` listener, sign-out cleanup via `arrayRemove`), the pre-permission dialog ("Stay in the loop"), the foreground `onMessage` handler with in-app banner, the background `onBackgroundMessage` handler with system notification, and the cold-start launch-payload handler that consumes the FR-AC-01 deep-link routing this PR's predecessor shipped. Story points: **10** (3 server FCM module + 2 trigger-extension hooks + 3 client FCM lifecycle + 1 pre-permission dialog + 1 deep-link cold-start handler); escalate to 12 only if the architect bundles FR-PR-03 notification-preferences UI (NOT recommended — preferences live on the Profile screen and have their own SCR; defer to a dedicated PR).
+
+2. The numbering continues from PR #52 — **PR #53 is the next FEATURE PR.** The post-PR-#52 sequence so far: #52 (PR — feat, merged `fcc4f80`), no new issues filed during PR #52 review. Issues #47 (rules-hardening), #49 (orphan-cleanup), #50 (trigger no-op optimisation — **EXPLICITLY CONSTRAINED** by FR-EX-07 AC-2: cannot close because optimisation would break activity emission on receipt-only updates) remain OPEN and are NOT touched by PR #53. The orchestrator should not assume PR #54 == GitHub issue 54 — issues and PRs share the same sequential namespace, so any new issues filed during PR #53 will consume intermediate numbers. **Pre-merge CI title-lint gotcha (verified PR #45, #46, #48, #51, #52):** the workflow regex `[a-z0-9_-]+` rejects comma-separated scopes — use a single-token scope (e.g. `feat(notifications)` or `feat(functions)`), and the SUBJECT (everything after `<scope>: `) must be ≤ 72 characters total (PR #52 had to be re-titled from 84 chars to 62 chars before merge). Since this PR spans both client (`feat(notifications)`) and server (`feat(functions)`), the architect picks ONE scope for the squash-merge commit title; recommend `feat(notifications)` because the FCM dependency surface is the load-bearing half. Suggested title (62 chars subject): `feat(notifications): FR-AC-03 FCM push + FR-AC-05 cold-start deep-link`.
+
+3. PR #53 is the **first PR that uses `firebase_messaging` from `pubspec.yaml`** (`^16.2.0` is already declared but unused as of PR #52) and the **first PR that writes to `users/{uid}.fcmTokens`**. The seams are already in place:
+   - **Server side (consumers of the existing trigger emit-paths):** `functions/src/triggers/on-expense-write/function.ts:167` reads verbatim:
+     ```
+     // 3. Hand-off seams for downstream stories (placement parity with
+     //    the settlement trigger):
+     //    TODO(FR-AC-03): send FCM push notification respecting
+     //      notificationPrefs.newExpense.
+     //    Placement note: must execute ONLY after a successful recompute
+     //    (i.e. inside or just below the success branch at the bottom of
+     //    this handler) to keep retry semantics clean — a retryable
+     //    transient failure must not duplicate notifications. Today this
+     //    is deferred entirely; the actual placement decision lives with
+     //    the story that implements it. The FR-EX-07 activity-feed
+     //    emission seam was closed by the emitExpenseActivity call at
+     //    the bottom of this handler.
+     ```
+     and `functions/src/triggers/on-settlement-write/function.ts:237` reads (post-PR-#52):
+     ```
+     // 3. Hand-off seam for downstream story (placement parity with
+     //    the expense trigger):
+     //    TODO(FR-AC-03): send FCM push notification to the toUserId
+     //      respecting notificationPrefs.settlement.
+     //    Placement note: the FCM seam must execute ONLY after a
+     //    successful recompute (i.e. inside or just below the success
+     //    branch at the bottom of this handler) to keep retry semantics
+     //    clean — a retryable transient failure must not duplicate
+     //    notifications. Today the FCM seam is deferred entirely; the
+     //    actual placement decision lives with the story that
+     //    implements it. The FR-AC-01 activity-feed emission seam was
+     //    closed by the emitSettlementActivity call at the bottom of
+     //    this handler (step 8 below).
+     ```
+     PR #53 closes the FR-AC-03 half of BOTH seams (verbatim mirror of PR #51's expense-trigger activity-emission extension at `function.ts:264-291` and PR #52's settlement-trigger activity-emission extension at the bottom of the same file). Both follow the SAME error-containment posture: FCM-send failures are CONTAINED inside the helper's own try/catch — the trigger's success branch is preserved (per architect §2.9 item 2 from FR-EX-07).
+   - **Server FCM module:** `functions/src/notifications/` does NOT exist today. PR #53 creates the directory with:
+     - `notifications/fcm-send.ts` — admin-SDK helper `sendFcmToTokens(tokens, payload, deps)` that wraps `getMessaging().sendEach(...)`, dispatches per-token sends in parallel via `Promise.allSettled`, handles `messaging/registration-token-not-registered` errors by writing `arrayRemove(token)` to `users/{uid}.fcmTokens` (server-side cleanup per `notifications.md` §1.4), and logs structured events `fcm_send_attempted` / `fcm_send_succeeded` / `fcm_send_failed` / `fcm_token_pruned`.
+     - `notifications/payload-renderer.ts` — pure functions that render the six per-type templates from `notifications.md` §2.2 table (`expense_added`, `expense_edited`, `expense_deleted`, `settlement_received`, `reminder`, `group_invite`); takes `senderName`, `description`, `amountPaise` and returns the typed FCM data envelope per §2.1. **Invariant 1 preservation:** all amount-paise → rupee conversion at the render boundary uses `formatInrFromPaise()` equivalent — TBD whether this lives in `functions/src/utils/` (new) or is duplicated as a Functions-side helper. **Architect's call at §2.x.**
+     - `notifications/prefs-filter.ts` — checks the recipient's `notificationPrefs.{newExpense|settlement|reminder}` flag and short-circuits the send if disabled (per `notifications.md` §2.3, FR-AC-04). Group invites (`group_invite`) are NOT subject to preference filtering per the same section.
+     - `notifications/index.ts` — exports the public surface (`sendExpenseNotification`, `sendSettlementNotification`) that the triggers consume.
+   - **Trigger extensions:** `emitExpenseFcm()` and `emitSettlementFcm()` helpers added to the same two function.ts files mirroring the existing `emitExpenseActivity()` / `emitSettlementActivity()` patterns. The helpers:
+     - Look up the recipient(s)' `users/{uid}` doc to get `fcmTokens` + `notificationPrefs`.
+     - For expense-trigger: recipients are `memberIds` MINUS the `authorUid` (don't notify the author of their own action).
+     - For settlement-trigger: recipient is `toUserId` ONLY (the payer is the actor; the payee is the one receiving the notification per `notifications.md` §2.2 `settlement_received` template).
+     - Call the appropriate renderer, then `sendFcmToTokens`.
+     - NEVER rethrow — defence-in-depth per architect §2.9 item 2 from FR-EX-07.
+   - **Client side:** `lib/features/notifications/` does NOT exist today. PR #53 creates the standard feature-first layout (data / domain / application / presentation). Key files:
+     - `data/fcm_token_service.dart` — wraps `FirebaseMessaging` for token acquisition + `onTokenRefresh` + sign-out cleanup; writes to `users/{uid}.fcmTokens` via `arrayUnion` / `arrayRemove`. Mirrors the `UserRepository` pattern from FR-AU-06.
+     - `data/notification_handler.dart` — registers `FirebaseMessaging.onMessage` (foreground), `FirebaseMessaging.onBackgroundMessage` (background — must be a top-level function per Flutter Firebase docs), and `FirebaseMessaging.instance.getInitialMessage()` (cold-start launch). Parses the data envelope from `notifications.md` §2.1.
+     - `application/notification_permission_controller.dart` — the Riverpod `Notifier` that drives the pre-permission dialog flow (per `notifications.md` §5.2 + wireframes §1); manages the "Not now" local-flag persistence so the dialog doesn't re-appear in the same session.
+     - `application/deep_link_handler.dart` — consumes the notification payload and dispatches to the FR-AC-01 deep-link routing surface (reuses the same in-app navigation paths the `ActivityFeedScreen._onRowTap` handler uses; refactor those into a shared `lib/core/routing/notification_deep_links.dart` helper at architect's call at §2.x).
+     - `presentation/pre_permission_dialog.dart` — the "Stay in the loop" custom dialog per wireframes §1.1.
+     - `presentation/in_app_notification_banner.dart` — the 300ms slide-in custom banner per wireframes §2.
+   - **App-startup wiring:** `lib/main.dart` currently has NO FCM initialisation. PR #53 must:
+     - Register the top-level `onBackgroundMessage` handler BEFORE `runApp` (Flutter Firebase requires this).
+     - Wire the `notificationHandler` into the app lifecycle so foreground/cold-start events route correctly.
+     - The pre-permission dialog is triggered when the user transitions to `AuthenticatedWithProfile` for the first time per session (mirror of the SCR-04 timing per `notifications.md` §5.1). **Architect's call at §2.x** on whether this lives in `HomePlaceholderScreen.initState`, in a wrapper `AuthGatedShell` widget, or as a Riverpod listener.
+   - **FCM token PII:** the `fcmTokens` array contains opaque platform-issued tokens — NOT PII per ADR-0013 (tokens are not deterministic UIDs and rotate freely). No `hashId()` hashing needed in structured logs. However, the `userId` whose tokens are being written/pruned MUST be hashed in logs per the existing FR-EX-07 PII guard pattern.
+   - **Deep-link contract:** the FR-AC-01 deep-link routing surface PR #52 shipped is a CLIENT-SIDE-ONLY in-app routing (push the target screen on top of the Navigator stack). FR-AC-05 cold-start requires NAVIGATING from the splash screen DIRECTLY to the target screen, bypassing `HomePlaceholderScreen`. Per `notifications.md` §3.3 and §4: the auth-guard runs first; on `Authenticated`, the deep-link intent is resolved immediately; on `Unauthenticated`, the intent is STORED IN MEMORY and replayed after successful sign-in. **Architect's call at §2.x** on whether to introduce a deep-link intent provider (`pendingDeepLinkProvider` — a `StateProvider<NotificationPayload?>`) to hold the cold-start payload between auth states; OR to layer the navigation logic onto the existing `OneBytwoApp.build` switch. Recommend the StateProvider approach — it cleanly separates the navigation intent from the auth state and is testable in isolation.
+
+4. PR #53 has **one mandatory cross-PR bundle**: the **two trigger extensions** (expense + settlement). Without it, both FCM TODO seams remain open and the FCM module ships orphan (no caller). Bundle is small (~2 SP each, ~4 SP total). PR #53 must NOT bundle: FR-AC-04 notification-preferences UI (separate P1 story; lives on the Profile screen and has its own SCR-26+), FR-SE-09 Send Reminder (separate P1 story; introduces the per-friend 24-hour rate-limit subcollection per `notifications.md` §6.1; will REUSE the FCM module this PR ships), the group-trigger FCM emission (Sprint 3 groups epic), the `OBTBottomNav` shell (deferred per PR #52 architect §2.1), the FR-PR-03 notification-preferences screen (P1; separate PR), or any FR-EX-09 / FR-SR-01 / FR-SR-02 related work (search / filter — deferred). The reminder rate-limit subcollection (FR-SE-09) is the **first consumer of the FCM module** after this PR — the `sendFcmToTokens` API surface must be stable enough to support it without further refactoring.
+
+5. Read before starting:
+   - `.github/copilot-instructions.md`
+   - `.github/shared/invariants.md` — invariant 1 (paise integers — applicable on the FCM payload-render path; the `payload-renderer.ts` converts `amountPaise` to rupees via a Functions-side helper that mirrors `formatInrFromPaise()`; the existing Functions-side boundary-contract grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new files), invariant 2 (`simplifiedBalances` server-only — N/A; FCM module touches `users/{uid}` only for token-pruning), invariant 3 (system share sheet — N/A; the share sheet is for invites; FCM is a separate surface), invariant 4 (single Firebase project — defence-in-depth re-check; the FCM admin SDK uses the same `firebase-admin/app` initialisation as the rest of Functions).
+   - `.github/shared/coding-standards.md` — Dart, Riverpod, widget-test, Cloud Functions, and Conventional Commits rules. **Both the Dart section AND the Cloud Functions section are load-bearing for PR #53** — the bulk is split roughly 50/50 between client and server.
+   - **Memory: PR# references in code/test files are forbidden.** Repository memory: "Do not include PR numbers (e.g. 'PR #36', 'PR #37') in comments or descriptions inside code or test files. PR references belong in docs and commit messages only." Use story IDs (FR-AC-03, FR-AC-05) in code comments instead.
+   - **Memory: money formatting.** Repository memory: "All paise→INR conversion goes through formatInrFromPaise(int) in lib/core/formatters/inr_formatter.dart. No inline /100 arithmetic anywhere. Boundary-contract grep enforces." The Functions-side payload-renderer must NOT do inline `/100` arithmetic — extract a Functions-side equivalent helper.
+   - **Memory: telemetry PII hashing.** Repository memory: "Use hashFriendshipId() in lib/core/telemetry/event_id_hash.dart for any telemetry parameter that would otherwise carry a deterministic friendshipId or other UID-composite identifier." The new `fcm_send_*` structured-log events MUST hash any UID-derived parameter via the existing `hashId()` helper from `functions/src/utils/id-hash.ts`. FCM tokens themselves are NOT subject to ADR-0013 hashing (they are not deterministic UIDs).
+   - **Memory: dart format.** Repository memory: "CI runs Flutter 3.44.1 and gates on `dart format --set-exit-if-changed .`. Always run `dart format .` locally before pushing — `flutter analyze` alone does not catch formatter drift."
+   - **Memory: commit message scope.** Repository memory: "PR title lint enforces conventional commit scope `[a-z0-9_-]+` — a single token only. Comma-separated multi-scopes like `chore(functions,docs)` are rejected." AND subject must be ≤ 72 chars (verified PR #52 had to be re-titled from 84 chars). Recommend `feat(notifications): FR-AC-03 FCM push + FR-AC-05 cold-start deep-link` (62 chars).
+   - `.github/shared/decision-log.md` — ADR-0002 (paise integers; applicable on the FCM payload-render path), ADR-0006 (Riverpod state management — `Notifier` for the permission controller; `StateProvider` for the pending-deep-link intent), ADR-0007 (feature-first folder layout; `lib/features/notifications/**` follows the standard data / domain / application / presentation split), ADR-0013 (PII / telemetry hashing — see memory above; FCM tokens are NOT subject; userIds ARE subject), ADR-0014 (rules-readable user collection — the FCM module's `users/{uid}.fcmTokens` read uses admin SDK so rules don't apply, but the schema continues to enforce server-only writes for this field per `firestore.rules` lines for `users/{userId}`).
+   - `docs/patterns/feature-pr-conventions.md` — Feature-First Folder Layout, Boundary-Contract Discipline (the FR-EX-07 architect §2.9 item 7 ratified the Functions-side boundary-contract grep; PR #53 SHOULD parallel that with a `test/features/notifications/notifications_boundary_contract_test.dart` for the new feature folder), Telemetry-Event Discipline (verb-past pattern).
+   - `docs/OneByTwo_Requirements_Spec.md` — section 4.7 lines 236-240 (FR-AC-03 = P0 FCM push; FR-AC-04 = P1 preferences DEFERRED; FR-AC-05 = P0 cold-start deep-link; FR-PR-03 notification preferences = separate P1 story), section 7.2 (`fcmTokens: string[]`, `notificationPrefs: { newExpense, settlement, reminder }` already on the `users/{userId}` schema per the existing `UserModel.toCreateMap`), section 7.3 (Invariant 1 — paise integers across the FCM render boundary).
+   - `docs/design/07-technical/notifications.md` — **the authoritative technical design for this story**. Sections 1.1-1.4 (token lifecycle: acquisition, storage, refresh, cleanup); section 2 (notification payload schema; the six per-type templates at §2.2; the preferences filter at §2.3); section 3.1-3.3 (foreground / background / cold-start handlers); section 4 (deep-link map + entity-not-found fallback); section 5 (permission prompt timing + pre-permission dialog); section 7 (security considerations — token confidentiality, notification content).
+   - `docs/design/04-wireframes/notifications-and-deeplinks.md` — **the authoritative visual design for the pre-permission dialog (§1), the in-app banner (§2), the system notification (§3), the cold-start splash flow (§4)**.
+   - `docs/design/07-technical/firestore-schema.md` lines 38, 41 — `fcmTokens` and `notificationPrefs` are already declared on the `users/{userId}` schema. **No schema change needed for this PR.** The existing rules block at `match /users/{userId}` already enforces owner-only read/write per `notifications.md` §7.1.
+   - `lib/features/auth/domain/user_model.dart` lines 16-22 — `notificationPrefs` already defaults to `{newExpense: true, settlement: true, reminder: true}` and `fcmTokens` already defaults to `[]`. Existing users have these fields after FR-AU-06 (PR #11+). **No backfill needed.**
+   - `lib/features/auth/data/user_repository.dart` — UserRepository exists; PR #53 may need to extend it with `arrayUnion` / `arrayRemove` helpers for the `fcmTokens` field, OR create a dedicated `FcmTokenService` (architect's call at §2.x; recommend the dedicated service to keep `UserRepository` focused on profile CRUD).
+   - `lib/features/auth/application/auth_state_provider.dart` — the existing auth-state machine. The FCM token acquisition happens AFTER the transition to `AuthenticatedWithProfile` for the first time per session. The sign-out cleanup happens BEFORE `FirebaseAuth.signOut()`. **Architect's call at §2.x** on whether to wire these as listeners on `authStateNotifierProvider`, or as `ref.listen` callbacks inside a wrapper widget.
+   - `lib/main.dart` — currently has the conditional emulator wiring for Auth / Firestore / Storage. PR #53 must add the FCM emulator wiring conditionally (FCM emulator is NOT part of the Firebase Emulator Suite — the local-dev story is "use a real FCM project token in a debug build" OR "mock the FCM send at the SDK boundary"; **architect's call at §2.x** — recommend the latter for v1.0 since the FCM emulator is not officially supported).
+   - `lib/features/activity/presentation/activity_feed_screen.dart` — the existing in-app deep-link dispatch logic (`_onRowTap`, `_onUidForFriendship`, `_showUnavailableSnackbar`, etc.). PR #53 should EXTRACT the shared navigation logic into `lib/core/routing/notification_deep_links.dart` (NEW) so both the activity-feed row-tap path AND the FCM tap path use the same navigation contract. **Architect's call at §2.x.**
+   - `functions/src/triggers/on-expense-write/function.ts` lines 165-180 (the FR-AC-03 TODO seam) and lines 264-291 (the `emitExpenseActivity` pattern to mirror).
+   - `functions/src/triggers/on-settlement-write/function.ts` lines 235-248 (the FR-AC-03 TODO seam) and the bottom-of-handler `emitSettlementActivity` pattern to mirror.
+   - `functions/src/utils/id-hash.ts` — `hashId()` is the existing PII hashing helper; reuse for any UID-derived structured-log parameter.
+   - `docs/sprint-zero/stories/FR-EX-07-activity-feed-write-side.md` — the architectural blueprint for the trigger-extension pattern (error containment, structured logging, per-member fan-out, PII guard).
+   - `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md` — the architectural blueprint for the client feature-folder layout (data / domain / application / presentation) and the StreamProvider pattern.
+   - **NEW** `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` — the story to create in Phase 1.
+   - **NEW** `functions/src/notifications/fcm-send.ts` — admin-SDK send helper with token-cleanup-on-410.
+   - **NEW** `functions/src/notifications/payload-renderer.ts` — per-event-type template renderer.
+   - **NEW** `functions/src/notifications/prefs-filter.ts` — `notificationPrefs` short-circuit.
+   - **NEW** `functions/src/notifications/index.ts` — public surface exports.
+   - **NEW** `functions/src/utils/format-inr.ts` — Functions-side paise→rupee helper (mirrors `lib/core/formatters/inr_formatter.dart`). Architect's call at §2.x on placement; recommend `utils/` for parity with the existing `utils/id-hash.ts`.
+   - **NEW** `lib/features/notifications/data/fcm_token_service.dart`
+   - **NEW** `lib/features/notifications/data/notification_handler.dart`
+   - **NEW** `lib/features/notifications/domain/notification_payload.dart`
+   - **NEW** `lib/features/notifications/application/notification_permission_controller.dart`
+   - **NEW** `lib/features/notifications/application/deep_link_handler.dart`
+   - **NEW** `lib/features/notifications/application/pending_deep_link_provider.dart`
+   - **NEW** `lib/features/notifications/presentation/pre_permission_dialog.dart`
+   - **NEW** `lib/features/notifications/presentation/widgets/in_app_notification_banner.dart`
+   - **NEW** `lib/core/routing/notification_deep_links.dart` — shared navigation contract (consumed by both `ActivityFeedScreen` and the FCM tap handler).
+   - `lib/main.dart` — EXTEND with the top-level `onBackgroundMessage` handler registration BEFORE `runApp` + the FCM service initialisation hook.
+   - `lib/features/auth/presentation/home_placeholder_screen.dart` — EXTEND with the first-session pre-permission dialog trigger (architect's call at §2.x on the exact hook).
+   - `lib/features/auth/application/auth_state_provider.dart` — EXTEND with the sign-out FCM-token-cleanup hook (architect's call at §2.x on placement).
+   - **NEW** `functions/test/notifications/fcm-send.test.ts` — unit tests for the send helper (mocked admin Messaging; token-cleanup-on-410 assertion).
+   - **NEW** `functions/test/notifications/payload-renderer.test.ts` — per-template tests for all six types.
+   - **NEW** `functions/test/notifications/prefs-filter.test.ts` — preference-flag short-circuit tests.
+   - `functions/test/triggers/on-expense-write/function.test.ts` — EXTEND with `emitExpenseFcm` integration assertions (jest.mock the FCM send module; assert called on success, NOT called on stale-event / CONTEXT_NOT_FOUND / BALANCE_INVARIANT_VIOLATED branches).
+   - `functions/test/triggers/on-settlement-write/function.test.ts` — EXTEND with `emitSettlementFcm` integration assertions (mirror of the above).
+   - `functions/test/integration/on-expense-write.integration.test.ts` — EXTEND with FCM-side assertions (mock the admin Messaging at the boundary; the integration test verifies the trigger calls into the notification module with the right shape).
+   - `functions/test/integration/on-settlement-write.integration.test.ts` — EXTEND with the mirror.
+   - **NEW** `test/features/notifications/data/fcm_token_service_test.dart` — `arrayUnion` / `arrayRemove` / `onTokenRefresh` tests against a fake repository.
+   - **NEW** `test/features/notifications/data/notification_handler_test.dart` — payload parsing + foreground/background/cold-start dispatch tests.
+   - **NEW** `test/features/notifications/application/notification_permission_controller_test.dart` — Notifier tests covering the pre-permission dialog flow + "Not now" suppression.
+   - **NEW** `test/features/notifications/application/deep_link_handler_test.dart` — payload → route dispatch tests covering the deep-link map at `notifications.md` §4.
+   - **NEW** `test/features/notifications/presentation/pre_permission_dialog_test.dart` — widget tests for the "Stay in the loop" dialog.
+   - **NEW** `test/features/notifications/presentation/in_app_notification_banner_test.dart` — widget tests for the 300ms slide-in banner with auto-dismiss.
+   - **NEW** `test/features/notifications/notifications_boundary_contract_test.dart` — Inv-1 grep over `lib/features/notifications/**` (no `/100`, no `.toDouble()`, etc.; mirrors `test/features/activity/activity_boundary_contract_test.dart`).
+   - **NEW** `test/core/routing/notification_deep_links_test.dart` — pure-function tests for the deep-link target resolver.
+   - `docs/sprint-zero/sprint-2-plan.md` — add PR #53 row (10 SP; cumulative 73 SP / 17 PRs).
+   - `docs/sprint-zero/next-three-prs.md` — roll PR #53 to merged; PR #54 / #55 / #56 candidates (top: FR-SE-09 Send Reminder, which is the first FCM-module consumer after this PR ships).
+   - `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #53 entry; PY3 partial progress (4 new integration test assertions across the two triggers).
+   - `firestore.rules` — UNCHANGED. The existing `users/{userId}` rules already permit owner write on `fcmTokens` (the client writes its own device's token); the FCM module uses admin SDK and bypasses rules. **No diff.**
+   - `firestore.indexes.json` — UNCHANGED.
+   - `storage.rules` — UNCHANGED.
+   - `pubspec.yaml` — UNCHANGED. `firebase_messaging: ^16.2.0` is already present.
+   - `functions/package.json` — UNCHANGED. `firebase-admin` already provides `getMessaging()`.
+   - **CI hygiene** — `dart format .` MUST be run before push because CI runs Flutter 3.44.1 while local toolchains may be older. Run `dart format .` as the final pre-push gate after `flutter analyze --fatal-infos`. **Functions hygiene** — `npm run lint && npm run build && npm test && npm run test:rules` MUST be green; both gates have been load-bearing on every recent PR.
+
+6. Honour the four invariants. Invariant 1 (paise integers) is **applicable on the FCM payload-render boundary**: the `payload-renderer.ts` converts `amountPaise` to rupees for the `body` template string; this conversion MUST use a Functions-side helper (new `functions/src/utils/format-inr.ts`) that mirrors the Flutter `formatInrFromPaise()` semantics; ZERO inline `/100` arithmetic anywhere in `functions/src/notifications/**`. The existing Functions-side boundary-contract grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new files. Client side: `lib/features/notifications/**` carries no monetary fields (the notification payload is rendered server-side; the client only displays the pre-rendered `body` string). The new `test/features/notifications/notifications_boundary_contract_test.dart` grep is defence-in-depth. Invariant 2 (`simplifiedBalances` server-only) — N/A; FCM module touches only `users/{uid}.fcmTokens` and reads `users/{uid}.notificationPrefs`. Invariant 3 N/A. Invariant 4: no second Firebase project — the FCM admin SDK uses the same `firebase-admin/app` initialisation; `.firebaserc` unchanged.
+
+────────────────────────────────────────
+PHASE 0 — DEPENDENCY-DAG CHECK
+────────────────────────────────────────
+
+0.1  Confirm PR #52 has merged to main and the post-merge state is clean:
+     - `git log --oneline -1` on `main` shows `fcc4f80 feat(activity): FR-AC-01 activity feed read-side + settlement-trigger emission (#52)`.
+     - `lib/features/activity/` exists with the full feature folder.
+     - `lib/core/widgets/lists/obt_activity_row.dart` exists.
+     - `functions/src/triggers/on-settlement-write/settlement-payload-builder.ts` exists (PR #52 surface).
+     - `functions/src/triggers/on-expense-write/function.ts:167` still has the FR-AC-03 TODO comment (PR #52 did NOT touch the FCM seam).
+     - `functions/src/triggers/on-settlement-write/function.ts:237` still has the FR-AC-03 TODO comment (PR #52 cleaned the FR-AC-01 sub-bullet but kept FR-AC-03).
+     - `lib/features/notifications/` does NOT exist.
+     - `lib/core/routing/` does NOT exist.
+     - `functions/src/notifications/` does NOT exist.
+     - `flutter analyze --fatal-infos` + `flutter test` exit 0 (973 pass / 30 skipped post-PR-#52).
+     - `cd functions && npm run lint && npm run build && npm test` exit 0 (14 suites / 195 tests pass).
+     - `cd functions && npm run test:rules` exit 0 against the emulator (9 suites / 188 tests pass).
+     - `dart format --set-exit-if-changed .` exits 0.
+     - `.firebaserc` contains exactly one project (Invariant 4 CI gate green).
+     - `pubspec.yaml` declares `firebase_messaging: ^16.2.0` (already present).
+     - Issues #47 (rules-hardening), #49 (orphan-cleanup), #50 (trigger no-op optimisation) are OPEN and unchanged — PR #53 does NOT close any of them.
+
+0.2  Walk the dependency DAG for FR-AC-03 + FR-AC-05:
+     - **FCM client SDK:** `firebase_messaging: ^16.2.0` is already in `pubspec.yaml`; this PR is the first consumer.
+     - **FCM admin SDK:** `firebase-admin` is already in `functions/package.json`; `getMessaging()` is the entry point.
+     - **Token storage:** `users/{uid}.fcmTokens` already exists on the schema + UserModel; this PR is the first writer (client-side) + reader (server-side).
+     - **Preferences storage:** `users/{uid}.notificationPrefs` already exists with the correct default; this PR is the first reader (server-side prefs-filter).
+     - **Trigger seams:** two FR-AC-03 TODO seams (expense + settlement triggers) are ready to be closed.
+     - **Deep-link routing:** the FR-AC-01 in-app dispatch logic shipped in `ActivityFeedScreen._onRowTap` is the architectural blueprint; PR #53 extracts the shared logic into `lib/core/routing/notification_deep_links.dart`.
+     - **Boundary contracts:** the existing Flutter-side grep template at `test/features/activity/activity_boundary_contract_test.dart` does NOT cover `lib/features/notifications/**`. PR #53 ships the parallel grep. The Functions-side grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new payload-renderer.
+
+0.3  Confirm DoR for the feature story:
+     - **No story file exists yet** for FR-AC-03 + FR-AC-05 — `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` must be created by the PM in Phase 1. The story bundles FR-AC-05 cold-start deep-link as the natural pair per the architect's call (FCM IS the cold-start signal).
+     - Story points: **10 SP** (justification: 3 server FCM module + 2 trigger-extension hooks + 3 client FCM lifecycle + 1 pre-permission dialog + 1 deep-link cold-start handler). Escalate to 12 only if the architect bundles FR-PR-03 notification-preferences UI (NOT recommended; deferred per §4).
+     - The story must explicitly enumerate: (a) the GitHub issue this PR closes — **none** (FR-AC-03/04/05 are P0 SRS rows; no separate GitHub issue exists), (b) the four-invariant applicability assessment (Inv-1 applicable on render boundary; Inv-2 N/A; Inv-4 defence-in-depth), (c) the cross-cutting telemetry contract (four server events + three client events), (d) the explicit decision on the FCM-emulator wiring (architect §2.x ratifies "mock the FCM send at the SDK boundary in tests; use real FCM tokens in debug builds for manual smoke").
+
+0.4  Cross-reference the burndown:
+     - PR #53 closes **no Bucket-B items directly**. The FCM infrastructure is new ground.
+     - PR #53 makes partial progress on **PY3** (Expand integration tests for Sprint 2 flows) — 4 new trigger-integration assertions across the two triggers + the new Functions notifications-module unit tests + the new client widget/provider tests.
+     - Issues #47, #49, #50 remain OPEN and are NOT touched by PR #53.
+     - **NEW finding to track:** the pre-existing Functions-emulator integration-test load error (firebase-functions v7 `functions.config()` removal) noted in PR #52 review remains open. This PR may file an issue to track it explicitly if the integration tests fail again locally.
+
+────────────────────────────────────────
+PHASE 1 — STORY READINESS (PM)
+────────────────────────────────────────
+
+PM agent creates the feature story `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` using the SRS §13.2 feature format. Story points: **10** (per §0.3).
+
+Required Given/When/Then ACs (each MUST be testable):
+
+  **FCM token lifecycle — positive ACs**
+
+  - **AC-1 — FCM token is acquired AFTER profile setup, NOT at launch.** Given a freshly-signed-up user completes the profile-setup screen, when they land on the `HomePlaceholderScreen` for the first time, then the pre-permission dialog is displayed; on confirmation the OS-level permission prompt is triggered; on grant, a new FCM token is acquired via `FirebaseMessaging.instance.getToken()` and written to `users/{uid}.fcmTokens` via Firestore `arrayUnion`.
+  - **AC-2 — Token refresh updates the array via arrayRemove + arrayUnion in one batched write.** Given the app is running with an existing FCM token registered, when `FirebaseMessaging.onTokenRefresh` fires with a new token, then the old token is removed and the new token is added in a SINGLE batched write to avoid a window where no valid token exists.
+  - **AC-3 — Sign-out removes the current device token before FirebaseAuth.signOut.** Given the user taps Sign Out, when the sign-out flow runs, then the current device's FCM token is removed from `users/{uid}.fcmTokens` via `arrayRemove` BEFORE `FirebaseAuth.signOut()` is called.
+
+  **Server-side FCM send — positive ACs**
+
+  - **AC-4 — Expense trigger sends FCM to non-author members.** Given an expense is created at `friendships/{fid}/expenses/{eid}`, when the trigger completes the success branch, then `emitExpenseFcm` is called with `recipients = memberIds - authorUid`; for each recipient with `notificationPrefs.newExpense == true` AND non-empty `fcmTokens`, ONE FCM data message is sent per token with the `expense_added` template per `notifications.md` §2.2.
+  - **AC-5 — Settlement trigger sends FCM to toUserId only.** Given a settlement is recorded, when the trigger completes the success branch, then `emitSettlementFcm` is called with `recipient = toUserId`; if `notificationPrefs.settlement == true` AND `fcmTokens` is non-empty, ONE FCM data message is sent per token with the `settlement_received` template.
+  - **AC-6 — Stale FCM tokens are pruned on 410.** Given an FCM send returns `messaging/registration-token-not-registered`, when the send-helper handles the error, then the offending token is removed from `users/{uid}.fcmTokens` via `arrayRemove`; subsequent sends to the same user do NOT re-attempt the pruned token.
+  - **AC-7 — Notification preference flag short-circuits the send.** Given a user has `notificationPrefs.newExpense == false`, when the expense-trigger attempts to send the `expense_added` notification, then ZERO FCM sends are issued; a structured-log event `fcm_send_suppressed_by_prefs` is emitted.
+  - **AC-8 — Amount formatting through Functions-side INR helper preserves Invariant 1.** Given an expense with `amountPaise = 120000`, when the payload renderer constructs the `body` template, then the rendered string contains `"₹1,200"` (Indian numbering); ZERO inline `/100` arithmetic exists in `functions/src/notifications/**`; the existing Functions-side boundary-contract grep enforces.
+
+  **Client foreground / background / cold-start — positive ACs**
+
+  - **AC-9 — Foreground in-app banner renders on FCM data message.** Given the app is in the foreground, when `FirebaseMessaging.onMessage` fires with a valid data payload, then the in-app notification banner (per wireframes §2) slides in from the top with a 300ms ease-in-out animation, auto-dismisses after 4 seconds, and routes to the deep-link target on tap.
+  - **AC-10 — Background system notification renders.** Given the app is backgrounded, when `FirebaseMessaging.onBackgroundMessage` fires (top-level handler), then the system notification tray displays the notification with the rendered `title` and `body` per `notifications.md` §3.2; tapping the notification opens the app and routes to the deep-link target.
+  - **AC-11 — Cold-start deep-link resolves the target after auth check.** Given the app is fully terminated and the user taps a notification, when the OS launches the app, then `FirebaseMessaging.instance.getInitialMessage()` returns the payload; the splash screen is shown for at most 2s while Firebase Auth restores the session; if authenticated, the deep-link target screen is pushed onto the Navigator stack; if unauthenticated, the payload is stored in `pendingDeepLinkProvider` and replayed after successful sign-in.
+
+  **Cross-cutting and negative ACs**
+
+  - **AC-12 — Pre-permission dialog suppresses re-show after "Not now".** Given the user dismissed the pre-permission dialog via "Not now" earlier in the session, when the same dialog trigger fires again in the same session, then the dialog does NOT re-appear; the suppression flag persists for the session lifetime only.
+  - **AC-13 — Permission denial does NOT acquire a token.** Given the user denies the OS-level permission prompt, when the prompt result is handled, then no FCM token is acquired; no write to `users/{uid}.fcmTokens` occurs; a local flag records the denial so the pre-permission dialog is not shown again automatically.
+  - **AC-14 — Telemetry events fire with correct PII guard.** Given any of the new structured-log events (`fcm_send_attempted`, `fcm_send_succeeded`, `fcm_send_failed`, `fcm_token_pruned`, `fcm_send_suppressed_by_prefs`), when the event is emitted, then any UID-derived parameter is hashed via `hashId()`; FCM tokens themselves are NOT hashed (opaque platform-issued; not PII per ADR-0013).
+  - **AC-15 — Invariant 1 boundary contract (client + server).** Given the PR diff, when scanned for `.toDouble()`, `parseFloat`, `/100`, `.toFixed`, or `double` declarations on monetary fields, then ZERO violations exist anywhere in `lib/features/notifications/**`, `lib/core/routing/notification_deep_links.dart`, or `functions/src/notifications/**`. New boundary-contract grep at `test/features/notifications/notifications_boundary_contract_test.dart` is the affirmative client-side test; existing Functions-side grep auto-covers the server side.
+  - **AC-16 — Invariant 2 negative guard.** Given the PR diff, when scanned, then ZERO new writes to `simplifiedBalances` exist anywhere; the FCM module touches only `users/{uid}.fcmTokens` (write) and `users/{uid}.notificationPrefs` (read).
+  - **AC-17 — Trigger error containment (architect §2.9 item 2).** Given any FCM-send failure (network error, admin-SDK throw, validator throw), when the trigger's `emitExpenseFcm` / `emitSettlementFcm` helper runs, then the failure is CONTAINED inside the helper's own try/catch; the trigger's success branch is preserved; a structured-log event `fcm_emission_internal_error` is emitted; Cloud Functions does NOT retry the whole invocation.
+  - **AC-18 — FCM is NOT called on stale-event / CONTEXT_NOT_FOUND / BALANCE_INVARIANT_VIOLATED branches.** Given the trigger drops on any of the three negative branches above, when the trigger handler runs, then `emitExpenseFcm` / `emitSettlementFcm` is NOT called; symmetric with the FR-EX-07 AC-5 + FR-AC-01 AC-12 contracts.
+  - **AC-19 — Group invite notifications bypass the preferences filter.** Given a `group_invite` notification, when the prefs-filter is consulted, then the send proceeds regardless of `notificationPrefs` values (per `notifications.md` §2.3, FR-GR-02). Note: the `group_invite` send path is NOT implemented in this PR (group invites ship with Sprint 3); the prefs-filter behaviour is asserted as a FORWARD-COMPATIBILITY unit test.
+  - **AC-20 — Pre-permission dialog accessibility.** Given a screen reader is active, when the pre-permission dialog displays, then the heading "Stay in the loop" is announced as a heading; both buttons have minimum 48dp tap targets; focus is trapped within the dialog.
+
+────────────────────────────────────────
+PHASE 2 — ARCHITECT HAND-OFF
+────────────────────────────────────────
+
+Architect agent appends `## Architect Notes` to the feature story ratifying:
+
+2.1  **Functions-side INR formatter placement.** RATIFY: create `functions/src/utils/format-inr.ts` as a Functions-side mirror of `lib/core/formatters/inr_formatter.dart`. Same Indian-numbering semantics, same integer-only arithmetic. Co-located with `utils/id-hash.ts`. Boundary-contract grep auto-covers.
+
+2.2  **FCM token cleanup placement.** RATIFY: the token-cleanup-on-410 logic lives INSIDE `fcm-send.ts`, NOT in a separate cleanup function. The cleanup is per-send (synchronous arrayRemove on 410) — no batch reaper needed for v1.0. A future maintenance Cloud Function may run periodic stale-token sweeps; out of v1.0 scope.
+
+2.3  **Deep-link routing shared helper.** RATIFY: extract `lib/core/routing/notification_deep_links.dart` (NEW). The existing `ActivityFeedScreen._onRowTap` logic refactors to call into this helper. Same in-app navigation surface used by both the activity-feed row tap AND the FCM tap.
+
+2.4  **Pending deep-link intent provider.** RATIFY: `lib/features/notifications/application/pending_deep_link_provider.dart` exposes a `StateProvider<NotificationPayload?>`. Set on cold-start when the user is unauthenticated; cleared (and replayed) after successful sign-in.
+
+2.5  **FCM emulator wiring.** RATIFY: NO FCM emulator wiring in `lib/main.dart` (the FCM emulator is not part of the Firebase Emulator Suite). Manual smoke uses a real FCM token in a debug build with `--dart-define=USE_FCM=true`; integration tests mock `FirebaseMessaging` at the SDK boundary via Riverpod overrides.
+
+2.6  **First-session pre-permission dialog trigger.** RATIFY: a Riverpod listener on `authStateNotifierProvider` inside the `OneBytwoApp.build` method. When the state transitions to `AuthenticatedWithProfile` AND the local "shown-this-session" flag is false AND the local "permanently-denied" flag is false, schedule the dialog for the next frame. Mirrors the cleanest separation of concerns; no widget-tree placement coupling.
+
+2.7  **Trigger-extension API surface.** RATIFY: `emitExpenseFcm(deps, params)` and `emitSettlementFcm(deps, params)` mirror the existing `emitExpenseActivity` / `emitSettlementActivity` patterns. Both helpers NEVER rethrow. The shared module surface `functions/src/notifications/index.ts` exports `sendExpenseNotification(deps, request)` and `sendSettlementNotification(deps, request)` — these are the trigger-facing entry points.
+
+2.8  **Files to touch (exhaustive — anything outside this set is scope creep):** [list per §5 above]
+
+2.9  **Files explicitly NOT to touch (negative scope guardrails):**
+     - `firestore.rules`, `firestore.indexes.json`, `storage.rules` — UNCHANGED.
+     - `pubspec.yaml`, `functions/package.json` — UNCHANGED.
+     - `lib/features/expenses/**`, `lib/features/friends/**`, `lib/features/settlements/**`, `lib/features/activity/**` (except for the deep-link refactor in `ActivityFeedScreen`) — UNCHANGED.
+     - `functions/src/triggers/on-expense-write/activity-writer.ts`, `payload-builder.ts`, `activity-validator.ts` — UNCHANGED.
+     - `.github/workflows/*.yml` — UNCHANGED.
+
+2.10 **Anticipated reconciliations:**
+     1. Snake_case vs camelCase notification types — the FCM data payload uses snake_case (`expense_added`, `settlement_received`) per `notifications.md` §2.2; the client deep-link handler converts on read using the same mapper as `ActivityEventTypeX.parseSnakeCase`.
+     2. Group invite path deferral — `group_invite` template is implemented in the renderer for forward compatibility, but no producer ships in PR #53 (groups epic is Sprint 3).
+     3. Reminder rate-limit subcollection deferral — FR-SE-09 ships separately and consumes this PR's FCM module; the rate-limit logic stays out of `notifications/**`.
+     4. Notification-preferences UI deferral — FR-PR-03 / FR-AC-04 ships separately; this PR only READS `notificationPrefs`, never writes.
+     5. FCM-emulator absence — mocked at the SDK boundary in tests; real tokens in debug builds for smoke.
+     6. Token-cleanup is per-send, not batched — see §2.2.
+
+────────────────────────────────────────
+PHASE 3 — SCOPE GUARDRAILS
+────────────────────────────────────────
+
+WHAT GOES IN PR #53:
+
+  - All files listed in §2.8.
+  - FCM send for the four trigger-driven types: `expense_added`, `expense_edited`, `expense_deleted`, `settlement_received`.
+  - The two trigger-extension hooks (`emitExpenseFcm`, `emitSettlementFcm`).
+  - FCM token lifecycle (acquisition, refresh, sign-out cleanup, 410 prune).
+  - The pre-permission dialog + permission denial handling.
+  - The foreground in-app banner.
+  - The background system notification handler.
+  - The cold-start deep-link resolver (FR-AC-05) using the FR-AC-01 in-app routing surface.
+  - The shared `lib/core/routing/notification_deep_links.dart` helper.
+  - Seven new telemetry events (4 server + 3 client).
+  - The story + Architect Notes.
+  - Plan + burndown roll-ups (Phase 7).
+
+WHAT DOES NOT GO IN PR #53:
+
+  - **FR-PR-03 / FR-AC-04 notification-preferences UI** — separate P1 story; lives on the Profile screen with its own SCR.
+  - **FR-SE-09 Send Reminder** — separate P1 story; introduces the per-friend 24-hour rate-limit subcollection; will be the FIRST consumer of this PR's FCM module.
+  - **Group-context FCM (group_invite producer)** — Sprint 3 groups epic. The renderer ships a stub template for forward compatibility but no producer wires it.
+  - **OBTBottomNav shell** — still deferred per PR #52 architect §2.1.
+  - **Pre-existing Functions-emulator integration-test infrastructure fix** — separate small chore PR; tracked in `next-three-prs.md`.
+  - **Read/unread markers**, **pagination**, **filter/search** — SCR-25 Open Questions; FUTURE.
+  - **Issue #47 rules-hardening** — separate small chore PR.
+  - **Issue #49 orphan-cleanup** — FUTURE.
+  - **Issue #50 trigger no-op-recompute optimisation** — EXPLICITLY CONSTRAINED.
+  - **Concurrent-edit detection for FR-EX-06** — still deferred.
+  - **Rate-limit transaction race refactor** — still deferred.
+  - **Activity-writer rename cleanup** — deferred per FR-AC-01 architect §2.3.
+
+If an agent suggests any of: "while we're shipping FCM, let's ship the notification-preferences screen too", "let's bundle FR-SE-09 since it uses FCM", "let's add the group-invite producer now", "let's add cursor-based pagination on the activity feed", "let's wire periodic stale-token sweeps", "let's implement a real FCM emulator" — REFUSE. These are scope creep.
+
+────────────────────────────────────────
+PHASE 4 — TEST-FIRST DISCIPLINE
+────────────────────────────────────────
+
+PR #53 follows the standard test-first cadence:
+
+1. Snapshot the pre-fix baseline: 973 Flutter / 30 skipped; 195 functions / 14 suites; 188 rules / 9 suites.
+2. Write the failing Functions tests first: `fcm-send.test.ts`, `payload-renderer.test.ts`, `prefs-filter.test.ts`; extend `triggers/on-expense-write/function.test.ts` and `triggers/on-settlement-write/function.test.ts` with `emitExpenseFcm` / `emitSettlementFcm` integration assertions.
+3. Write the failing Flutter tests: `fcm_token_service_test.dart`, `notification_handler_test.dart`, `notification_permission_controller_test.dart`, `deep_link_handler_test.dart`, `pre_permission_dialog_test.dart`, `in_app_notification_banner_test.dart`, `notifications_boundary_contract_test.dart`, `core/routing/notification_deep_links_test.dart`.
+4. Implement Functions source: `format-inr.ts` → `payload-renderer.ts` → `prefs-filter.ts` → `fcm-send.ts` → `notifications/index.ts` → trigger extensions.
+5. Implement Flutter source: `notification_payload.dart` → `fcm_token_service.dart` → `notification_handler.dart` → `pending_deep_link_provider.dart` → `deep_link_handler.dart` → `notification_permission_controller.dart` → `pre_permission_dialog.dart` → `in_app_notification_banner.dart` → `core/routing/notification_deep_links.dart` → refactor `ActivityFeedScreen._onRowTap` to use the shared helper → wire `main.dart` and `auth_state_provider.dart`.
+6. Re-run `dart format --set-exit-if-changed .` — 0 changes.
+7. Re-run `flutter analyze --fatal-infos` — "No issues found".
+8. Re-run `flutter test` — expected 973 + ~50 new = ~1023 tests pass.
+9. Re-run `cd functions && npm run lint && npm run build && npm test` — 195 + ~30 new = ~225 tests pass across ~17 suites.
+10. Re-run `cd functions && npm run test:rules` — 188 unchanged (no rules diff).
+11. Re-run `cd functions && npm run test:integration` — 4 new assertions per trigger (mocked FCM at the SDK boundary).
+
+**Combined CI dry-run:** all jobs must be green.
+
+────────────────────────────────────────
+PHASE 5 — EXECUTION PROTOCOL
+────────────────────────────────────────
+
+Mirror the PR #52 commit cadence (11 commits):
+
+ 1. PM creates story `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md`. Commits as `docs(stories): FR-AC-03 FCM push notifications story`.
+ 2. Architect appends `## Architect Notes` (§2.1–§2.10). Commits as `docs(stories): FR-AC-03 architect notes`.
+ 3. Functions-dev writes failing FCM module tests. Commits as `test(functions): FR-AC-03 notifications module tests`.
+ 4. Functions-dev writes failing trigger-extension tests. Commits as `test(functions): FR-AC-03 trigger FCM integration tests`.
+ 5. Functions-dev ships `format-inr.ts` + `payload-renderer.ts` + `prefs-filter.ts` + `fcm-send.ts` + `notifications/index.ts`. Commits as `feat(functions): FCM send module for push notifications (FR-AC-03)`.
+ 6. Functions-dev extends the two trigger handlers. Commits as `feat(functions): emit FCM notifications from expense + settlement triggers (FR-AC-03)`.
+ 7. Functions-dev extends the integration tests. Commits as `test(integration): FR-AC-03 trigger FCM round-trip`.
+ 8. Flutter-dev writes failing client tests. Commits as `test(notifications): FR-AC-03 FCM client tests`.
+ 9. Flutter-dev ships the FCM token service + notification handler + permission controller + pre-permission dialog + in-app banner + cold-start deep-link handler + pending-intent provider + shared routing helper. Commits as `feat(notifications): FCM client lifecycle + FR-AC-05 cold-start deep-link`.
+10. Flutter-dev wires `main.dart` + `auth_state_provider.dart` + refactors `ActivityFeedScreen._onRowTap` to use the shared routing helper. Commits as `feat(notifications): wire FCM into app startup + share deep-link routing`.
+11. Flutter-dev adds the boundary-contract grep. Commits as `test(notifications): boundary-contract grep against monetary float drift`.
+12. QA runs the manual smoke matrix (emulators + real FCM):
+    - Start emulators; sign in as user A on device 1; verify FCM token is written to `users/A.fcmTokens`.
+    - Sign in as user A on device 2 (debug build with a different FCM token); verify both tokens appear in the array.
+    - As user B, add an expense to the A↔B friendship; verify A receives the FCM banner on both devices.
+    - Tap the banner; verify deep-link routing to the Expense Detail screen.
+    - Set `notificationPrefs.newExpense = false` for A; verify subsequent expense adds do NOT trigger FCM.
+    - Soft-delete user A's app and reinstall; verify the stale FCM token is pruned on the next send attempt (410 response).
+    - Cold-start from a tapped notification (kill the app, send an FCM push, tap it); verify the splash → auth-check → target-screen flow per `notifications.md` §3.3.
+    - Sign out user A; verify the device's FCM token is removed from `users/A.fcmTokens` BEFORE `FirebaseAuth.signOut()` completes.
+13. Docs hand updates plan + roll-forward:
+    - `docs/sprint-zero/sprint-2-plan.md` (PR #53 row; 10 SP; cumulative 73 SP / 17 PRs).
+    - `docs/sprint-zero/next-three-prs.md` (PR #54 / #55 / #56 candidates — top is FR-SE-09 Send Reminder now that FCM is live).
+    - `docs/audits/sprint-1/07-bucket-b-burndown.md` (PR #53 entry; no items closed; partial PY3 progress).
+    - Commits as `docs(plan): PR #53 shipped, prep PR #54`.
+14. PR opened. Title (≤72 chars subject): `feat(notifications): FR-AC-03 FCM push + FR-AC-05 cold-start deep-link`. Body must:
+    - Cite `notifications.md` + `notifications-and-deeplinks.md` + the schema doc.
+    - Confirm Invariants 1 / 2 / 4 (Inv-3 N/A).
+    - State explicitly the deferred items: FR-AC-04/PR-03 prefs UI, FR-SE-09 Send Reminder, group_invite producer, OBTBottomNav, etc.
+    - End with `Next PR: PR #54 — TBD per architect's call at kickoff (top candidate: FR-SE-09 Send Reminder).`
+
+────────────────────────────────────────
+PHASE 6 — DEFINITION OF DONE GATE
+────────────────────────────────────────
+
+Walk the DoD checklist. Particular emphasis:
+
+  - DoD §2: every layer green (Flutter / Functions / Rules unchanged / format / analyze).
+  - DoD §3: QA sign-off with evidence for cross-device FCM delivery, cold-start deep-link, sign-out cleanup, 410 prune, and prefs-filter short-circuit.
+  - DoD §7: invariant compliance.
+    * Inv-1: applicable on the FCM payload-render boundary. `functions/src/notifications/**` boundary-contract grep returns 0 violations. Client-side `lib/features/notifications/**` grep returns 0 violations.
+    * Inv-2: ZERO new writes to `simplifiedBalances`; FCM module touches only `users/{uid}` (read prefs, write fcmTokens).
+    * Inv-3: N/A.
+    * Inv-4: `.firebaserc` unchanged.
+  - DoD §8: documentation updated (story + architect notes + sprint-2-plan + next-three-prs + burndown).
+  - DoD §9: deploy verification. The Functions side deploys via `firebase deploy --only functions:onExpenseWriteFriendship,functions:onSettlementWrite` on tag. The Flutter client ships in the next mobile build. QA verifies the FCM flow end-to-end in production post-deploy on the canary device.
+
+QA posts the explicit DoD §3 sign-off, including the negative-scope greps from AC-15 (no `/100` in `lib/features/notifications/**` or `functions/src/notifications/**`) and AC-16 (no new `simplifiedBalances` writes).
+
+**Pre-push CI hygiene:** run `dart format .` AND all test layers BEFORE `git push`.
+
+────────────────────────────────────────
+PHASE 7 — UPDATE THE ROLLING PLAN AND BURNDOWN
+────────────────────────────────────────
+
+PM agent updates:
+  - `docs/sprint-zero/sprint-2-plan.md` — PR #53 status (merged), velocity #17 (10 SP, total now 73 SP across 17 PRs).
+  - `docs/sprint-zero/next-three-prs.md`:
+      * PR #53 row marked merged; numbering note updated.
+      * PR #54: **TBD** per architect's call at kickoff. Top candidates (in rough priority order):
+          - **FR-SE-09 Send Reminder** (P1; consumes this PR's FCM module; introduces the `_rateLimits/{uid}/sends/counter` 24-hour pattern; first downstream consumer).
+          - **FR-PR-03 + FR-AC-04 notification-preferences UI** (P1; lives on the Profile screen; pairs with this PR's prefs-filter server logic).
+          - **OBTBottomNav shell** (UX foundation; needed for Sprint 3 groups epic anyway).
+          - **Issue #47 rules-hardening** (chore; 2 SP).
+          - **Pre-existing Functions-emulator integration-test infrastructure fix** (chore; 1-2 SP).
+          - **Activity-writer rename cleanup** (cosmetic; 1-2 SP).
+      * PR #55 / #56: TBD per PR #54 outcome.
+  - `docs/audits/sprint-1/07-bucket-b-burndown.md`:
+      * Header timestamp: PR #52 → PR #53.
+      * Append a PR #53 section: closes NO Bucket-B items directly. Partial PY3 progress: 4 new trigger-integration assertions + the Functions notifications-module unit tests + the new client widget/provider tests.
+
+Commits as `docs(plan): PR #53 shipped, prep PR #54`.
+
+────────────────────────────────────────
+GUARDRAILS
+────────────────────────────────────────
+
+If during this PR an agent proposes:
+  - "While we're shipping FCM, let's also ship the notification-preferences screen" → REFUSE. Separate P1 story; lives on the Profile screen with its own SCR.
+  - "Let's bundle FR-SE-09 Send Reminder since it uses FCM" → REFUSE. Separate P1 story; the rate-limit subcollection is meaningful complexity.
+  - "Let's add the group-invite producer now" → REFUSE. Sprint 3 groups epic; ship the renderer template for forward compatibility only.
+  - "Let's wire periodic stale-token sweeps in a maintenance Cloud Function" → REFUSE per §2.2. Per-send cleanup on 410 is the v1.0 contract.
+  - "Let's implement a real FCM emulator" → REFUSE per §2.5. FCM emulator is not part of the Firebase Emulator Suite; mock at the SDK boundary in tests.
+  - "Let's defensively add the OBTBottomNav shell so the Notifications tab is reachable" → REFUSE. Notifications is NOT a tab in the v1.0 nav model; it's a system-level integration. OBTBottomNav remains deferred.
+  - "Let's add unread-marker schema field" → REFUSE. SCR-25 Open Question 1; v1.1 candidate.
+  - "Let's implement cursor-based pagination on the activity feed" → REFUSE. SCR-25 Open Question 2; FUTURE.
+  - "Let's close issue #47 (rules-hardening) at the same time" → REFUSE. Separate small chore PR.
+  - "Let's close issue #49 (orphan-cleanup) at the same time" → REFUSE. FUTURE.
+  - "Let's close issue #50 (trigger no-op-recompute optimisation)" → **EXPLICITLY REFUSE** — closing it would BREAK FR-EX-07 AC-2.
+  - "Let's also wire the group-trigger FCM emission" → REFUSE. Sprint 3 groups epic.
+  - "Let's do the activity-writer rename cleanup at the same time" → REFUSE. Cosmetic chore deferred per FR-AC-01 architect §2.3.
+
+If something genuinely surprises (e.g. the `firebase_messaging` SDK requires a top-level `@pragma('vm:entry-point')` annotation on the background handler that breaks the existing app initialisation; or `FirebaseMessaging.instance.getInitialMessage()` returns the same payload on subsequent app launches if not consumed; or the FCM admin SDK's `sendEach` returns partial-success responses that the helper must surface differently than `sendMulticast`; or the iOS APNS entitlements require an additional configuration in `ios/Runner/Info.plist` that the existing build cannot satisfy), STOP and surface the friction. PR #53 is the first PR to integrate Firebase Cloud Messaging end-to-end — get the SDK contracts right before shipping.
+
+Begin with Phase 0 — verify the dependency DAG (PR #52 merge state at `fcc4f80`; baseline test counts; emulators reachable; `firebase_messaging` already in pubspec; both FR-AC-03 TODO seams intact) and re-read the three reference docs (`docs/design/07-technical/notifications.md` in full, `docs/design/04-wireframes/notifications-and-deeplinks.md` sections 1-4, and the existing `functions/src/triggers/on-settlement-write/function.ts` `emitSettlementActivity` block at the bottom of the handler as the architectural blueprint for the symmetric `emitSettlementFcm`) before kickoff.

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -1,11 +1,11 @@
 # Next Three PRs
 
 > Rolling roadmap. Updated at the end of every PR.
-> Last updated: PR #52 merged (FR-AC-01 — activity feed read-side + settlement-trigger activity emission).
+> Last updated: PR #53 merged (FR-AC-03 + FR-AC-05 — FCM push notifications + cold-start deep-link).
 
 ---
 
-## GitHub issue / PR numbering note (post-PR #52)
+## GitHub issue / PR numbering note (post-PR #53)
 
 The numbering jumped because issues and PRs share the same sequential
 namespace on GitHub. The post-PR #48 sequence so far:
@@ -19,51 +19,53 @@ namespace on GitHub. The post-PR #48 sequence so far:
 | #50 | Issue | Trigger no-op-recompute optimisation when update touches only `receiptUrl` + `updatedAt` — OPEN (FUTURE-work chore, 1 SP). **EXPLICITLY CANNOT BE CLOSED** by any FR-EX-07-consuming PR — the optimisation would skip activity emission on receipt-only updates, breaking the FR-EX-07 contract (AC-2). |
 | #51 | PR | FR-EX-07 activity feed write-side, friendship expenses (merged 2026-06-07) |
 | #52 | PR | FR-AC-01 activity feed read-side + settlement-trigger activity emission (merged 2026-06-08) |
-| **#53** | **PR** | **Next feature PR — see below** |
+| #53 | PR | FR-AC-03 FCM push notifications + FR-AC-05 cold-start deep-link (merged 2026-06-08) |
+| **#54** | **PR** | **Next feature PR — see below** |
 
 The "Next three PRs" below refer to the next three FEATURE/CHORE
-**pull requests** — i.e. PR #53, PR #54, PR #55. Their issue-number
+**pull requests** — i.e. PR #54, PR #55, PR #56. Their issue-number
 counterparts (when filed) will consume intermediate numbers; the
-orchestrator should not assume PR #53 = number 53 on GitHub.
+orchestrator should not assume PR #54 = number 54 on GitHub.
 
 ---
 
-## PR #53 — TBD
+## PR #54 — TBD
 
-**Status:** Next up. Architect picks at PR #53 kickoff per Sprint 2 velocity.
+**Status:** Next up. Architect picks at PR #54 kickoff per Sprint 2 velocity.
 
-PR #52 shipped FR-AC-01 / FR-AC-02 — the SCR-25 Activity tab is now
-live as a temporary route reachable from `HomePlaceholderScreen`'s
-AppBar action; the `OBTActivityRow` widget primitive is in the
-component catalogue; the settlement-trigger TODO at
-`functions/src/triggers/on-settlement-write/function.ts:231` is
-closed (settlement events now emit `'settlement'` activity items to
-both parties). The bottom-nav shell remains deferred (architect §2.1
-in `docs/sprint-zero/stories/FR-AC-01-activity-feed-read-side.md`).
-Cold-start deep-link (FR-AC-05) and FCM push notifications (FR-AC-03)
-remain the natural next P0 stories — the FR-AC-01 in-app deep-link
-routing surface this PR shipped is the prerequisite both stories
-consume.
+PR #53 shipped FR-AC-03 + FR-AC-05 — the FCM module is live (server
+notifications module + per-event-type renderer + 410 token cleanup +
+prefs filter + INR formatter parity), both triggers emit FCM (expense
+to non-author members, settlement to toUserId), the client lifecycle
+is wired (token register / refresh / sign-out cleanup), the
+pre-permission dialog appears on first transition to
+`AuthenticatedWithProfile`, the foreground in-app banner renders via
+an OverlayEntry, the background `onBackgroundMessage` handler is
+registered before runApp, and the cold-start `getInitialMessage`
+payload routes after the auth check. The shared
+`lib/core/routing/notification_deep_links.dart` helper is consumed by
+both the activity feed (`ActivityFeedScreen._onRowTap` refactored)
+and the FCM tap surfaces.
 
 Candidates (in rough priority order):
 
-- **FR-AC-03 — FCM push notifications + FR-AC-05 cold-start deep-link.**
-  The highest unplaced P0 pair. Introduces the FCM dependency + the
-  `notificationPrefs` schema + per-user `fcmTokens` plumbing.
-  FR-AC-05 (cold-start deep-link from a tapped push notification when
-  the app is not running) is naturally paired since the cold-start
-  signal comes from the FCM tap event. 8-10 SP — may split into two
-  sub-PRs (FCM infrastructure vs cold-start handler) at architect's
-  call. The FR-AC-01 deep-link routing this PR shipped is the
-  in-app target both stories use.
-- **FR-SE-09 — Send Reminder.** Closes the receiving-direction
-  branch of the OBTSettleUpCard (per PR #43 §2.5 default-omit).
-  Requires FCM dependency + 24-hour rate-limit subcollection. Now
-  the highest unplaced P1. Will exercise the
-  `_rateLimits/{uid}/sends/counter` subcollection pattern
-  established by PR #45 Architect Notes §2.9. Naturally bundles
-  with FR-AC-03 if the FCM infrastructure ships in the same PR
-  (one FCM dependency add, two consumers).
+- **FR-SE-09 — Send Reminder.** Now the **highest unplaced P1** and
+  the **first downstream consumer of the FCM module shipped in
+  PR #53**. Introduces the per-friend 24-hour rate-limit
+  subcollection (`_rateLimits/{uid}/sends/counter` pattern per PR #45
+  Architect Notes §2.9), the Reminder Cloud Function entry point,
+  the `reminder` notification template producer (renderer + filter
+  already shipped in PR #53), and the OBTSettleUpCard "Send Reminder"
+  button on the receiving-direction branch (deferred per PR #43 §2.5
+  default-omit). 4-6 SP. NO new FCM infrastructure work — the
+  `sendFcmToTokens` API is stable.
+- **FR-AC-04 + FR-PR-03 — notification preferences UI.** The Profile
+  screen gains a `/profile/notifications` route with three toggles
+  (`newExpense`, `settlement`, `reminder`) backed by the existing
+  `users/{uid}.notificationPrefs` map. The server-side prefs-filter
+  already shipped in PR #53 — this is purely the client UI + write
+  path. 3-4 SP. Naturally pairs with FR-SE-09 because both touch
+  notification semantics.
 - **`OBTBottomNav` shell.** UX foundation deferred from PR #52 per
   architect §2.1. Becomes the canonical entry point for the
   Friends / Groups / Activity / Profile tab cluster — needed before
@@ -86,16 +88,25 @@ Candidates (in rough priority order):
   `entityIdHash`) was DEFERRED to minimise blast radius. A future
   cleanup PR can do the full rename + Cloud Logging dashboard
   migration as one focused change.
+- **`shared_preferences` adoption for FCM-permission persistence**
+  (architect §2.6 / §2.8 addendum from PR #53). The
+  `wasPermanentlyDenied` flag in
+  `NotificationPermissionController` is in-memory only because the
+  lockfile has no `shared_preferences` entry. Add the dependency +
+  persist the flag across launches so the pre-permission dialog
+  honours the "permanently denied" state across app restarts.
+  1-2 SP. Naturally pairs with the FR-AC-04 / FR-PR-03 prefs UI PR
+  since that also persists user-facing notification preferences.
+- **FCM emulator-side integration test infrastructure** (per PR #53
+  functions-dev §1 deviation). The Cloud Functions emulator-side
+  integration tests under `functions/test/integration/on-*.integration.test.ts`
+  do not exercise the FCM emission path because `jest.mock()` does
+  not survive the emulator process boundary. Future work: add a
+  flag-gated production-config swap that injects a `MockMessaging`
+  in the emulator process so the full create → trigger → FCM round
+  trip is asserted in CI. 2-3 SP.
 - **Concurrent-edit detection for FR-EX-06** (operational
   hardening; small standalone PR). Explicitly deferred from PR #46.
-- **Integration-test infrastructure fix** (operational chore;
-  ~1-2 SP). The Functions emulator currently fails to load
-  `onExpenseWriteFriendship` with the warning
-  `functions.config() has been removed in firebase-functions v7`
-  during integration runs; this is a pre-existing issue not
-  caused by PR #52 (verified by stashing PR #52 changes and
-  reproducing on `main`). Track as a Sprint-3 cleanup item; CI
-  may have a workaround that local runs do not — to investigate.
 - **Issue #49 — Orphan-cleanup Cloud Function for receipts**
   (FUTURE; filed during PR #48 per SRS schema doc line 312).
   Out of v1.0 unless required for compliance.
@@ -117,30 +128,22 @@ Candidates (in rough priority order):
 
 ---
 
-## PR #54 — TBD
-
-**Status:** Slot reserved. Architect picks at PR #53 kickoff.
-
-Candidates: whatever doesn't land in PR #53 from the list above, plus:
-
-- A Bucket-B chore PR (remaining 27 / 37 items after PR #51 closed
-  R5a — activity rules coverage).
-- Pre-Sprint 3 design polish (FR-FR-01 chore #28 Friends HTML
-  mockup; SCR-09/10 wireframe alignment).
-- The deferred rate-limit transaction race refactor (PR #45 §2.2).
-- The deferred concurrent-edit detection for FR-EX-06.
-- Issue #47 rules-hardening for the non-creator update/delete gate.
-
----
-
 ## PR #55 — TBD
 
 **Status:** Slot reserved. Architect picks at PR #54 kickoff.
 
-Candidates: whatever doesn't land in PR #53 / PR #54 from the lists
-above.
+Candidates: whatever doesn't land in PR #54 from the list above.
 
 ---
+
+## PR #56 — TBD
+
+**Status:** Slot reserved. Architect picks at PR #55 kickoff.
+
+Candidates: whatever doesn't land in PR #54 / PR #55 from the lists above.
+
+---
+
 
 ## Sequencing rationale
 
@@ -199,17 +202,34 @@ FR-AC-01 reads, and the settlement-trigger half is needed for the
 settlement leg of SCR-25 to render anything. The architect's call
 at kickoff reflects the current priority signal.
 
+PR #53 picks up FR-AC-03 + FR-AC-05 — the second natural P0 reader
+of the FR-AC-01 in-app routing surface PR #52 shipped. FCM is the
+cold-start signal (FR-AC-05) so the two stories pair naturally.
+The Functions notifications module (FCM admin-SDK helper, per-event-
+type renderer, prefs filter, 410 token cleanup, Functions-side INR
+formatter) is the bulk; the two trigger-extension hooks
+(`emitExpenseFcm` and `emitSettlementFcm`) close the FR-AC-03 TODO
+seams; the client lifecycle wires token register / refresh /
+sign-out cleanup; the pre-permission dialog appears on first
+transition to `AuthenticatedWithProfile`; the in-app banner
+overlays via `OverlayEntry`; the background handler is registered
+before `runApp`; the cold-start `getInitialMessage` payload routes
+after the auth check. The shared
+`lib/core/routing/notification_deep_links.dart` helper is consumed
+by both the activity-feed row-tap path (refactored) and the FCM
+tap surfaces, satisfying architect §2.3.
+
 ---
 
-## Snapshot — Sprint 2 status at end of PR #51
+## Snapshot — Sprint 2 status at end of PR #53
 
 | Metric | Value |
 |---|---|
-| PRs merged in Sprint 2 | 15 (#31, #32, #34, #35, #36, #37, #38, #41, #42, #43, #44, #45, #46, #48, #51) |
-| Story points delivered | 55 (PR #41 was 0 SP — pure docs cross-refs; PR #42, #43, #46, #48, #51 were 5 SP each; PR #44 + PR #45 were 3 SP each — both chores) |
-| Bucket-B items closed | 10 (R1, R2, R3, R5a, R7, R8, CV3, SR8, D5a, D5b — PR #51 closed R5a with the new 12-test activity.test.ts suite). Remaining: 27 / 37. |
+| PRs merged in Sprint 2 | 17 (#31, #32, #34, #35, #36, #37, #38, #41, #42, #43, #44, #45, #46, #48, #51, #52, #53) |
+| Story points delivered | 73 (PR #41 was 0 SP — pure docs cross-refs; PR #42, #43, #46, #48, #51 were 5 SP each; PR #44 + PR #45 were 3 SP each — both chores; PR #52 was 8 SP; PR #53 was 10 SP) |
+| Bucket-B items closed | 10 (R1, R2, R3, R5a, R7, R8, CV3, SR8, D5a, D5b — PR #51 closed R5a with the new 12-test activity.test.ts suite). Remaining: 27 / 37. **PR #53 made partial PY3 progress** with 11 trigger-level FCM tests + 63 module-level notifications unit tests; no Bucket-B items formally closed. |
 | Critical Cross-PR Constraints | C-1 RESOLVED (chore #25 closed in PR #38) |
-| Open `sprint-2-chore` issues | 14 (issues #47, #49, #50 remain open; PR #51 did not file any new issues) |
-| Outstanding deadline-bound work | **None.** D5 shipped in PR #44; PR #45, PR #46, PR #48, PR #51 were non-deadline-bound. |
-| Round-trip closures | **Simplified-debts WRITE round-trip closed in PR #43.** Expense lifecycle (create / edit / soft-delete) closed end-to-end on the friendship axis by PR #46. Receipt attachment surface closed by PR #48. **Activity-feed WRITE-SIDE closed by PR #51** — every friendship-expense write now emits an `activity/{userId}/items/{auto-id}` document per member with type discriminator (`expense_added` / `expense_edited` / `expense_deleted`) and a payload sufficient for SCR-25 to render the row without additional reads. Read-side closure is the FR-AC-01 follow-on PR. |
+| Open `sprint-2-chore` issues | 14 (issues #47, #49, #50 remain open; PR #53 did not file any new issues) |
+| Outstanding deadline-bound work | **None.** D5 shipped in PR #44; PR #45, PR #46, PR #48, PR #51, PR #52, PR #53 were non-deadline-bound. |
+| Round-trip closures | **Simplified-debts WRITE round-trip closed in PR #43.** Expense lifecycle (create / edit / soft-delete) closed end-to-end on the friendship axis by PR #46. Receipt attachment surface closed by PR #48. **Activity-feed WRITE-SIDE closed by PR #51**; READ-SIDE closed by PR #52. **FCM push-notification round-trip closed by PR #53** — every expense (create / edit / soft-delete) and settlement now produces an FCM push to all non-author recipients respecting `notificationPrefs`; foreground and background and cold-start are all hooked to the shared in-app routing surface; the FCM module is the stable consumer surface for FR-SE-09 reminders next. |
 

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #52 (FR-AC-01 — activity feed read-side + settlement-trigger activity emission) — 16th merged PR.
+> Last updated: PR #53 (FR-AC-03 + FR-AC-05 — FCM push notifications + cold-start deep-link) — 17th merged PR.
 
 ---
 
@@ -88,6 +88,7 @@ work until the decision is recorded in the story file's Architect Notes.
 | #48 | FR-EX-05 | Receipt attachment (friendship) — Step 3 (SCR-21) + ReceiptStorageService + storage.rules friendship + group receipts predicates + Expense Detail thumbnail | 5 | Merged |
 | #51 | FR-EX-07 | Activity feed write-side (friendship) — activity-writer + payload-builder + activity-validator + activity/{userId}/items rules + trigger emission + 12 new rules tests + 41 new unit tests + 3 integration round-trips | 5 | Merged |
 | #52 | FR-AC-01 / FR-AC-02 | Activity feed read-side — SCR-25 ActivityFeedScreen + OBTActivityRow widget + activity feature folder + 4 telemetry events + settlement-trigger activity-emission extension (closes the on-settlement-write TODO) | 8 | Merged |
+| #53 | FR-AC-03 / FR-AC-05 | FCM push notifications + cold-start deep-link — Functions notifications module (fcm-send + payload-renderer + prefs-filter + Functions-side INR formatter) + expense + settlement trigger FCM emission + client FCM token lifecycle + pre-permission dialog + in-app banner + cold-start handler + shared notification_deep_links routing helper consumed by both the activity feed and notifications | 10 | Merged |
 
 ---
 
@@ -111,7 +112,8 @@ work until the decision is recorded in the story file's Architect Notes.
 | #48 | 5 | Merged |
 | #51 | 5 | Merged |
 | #52 | 8 | Merged |
-| **Total** | **63** | **16 PRs so far** |
+| #53 | 10 | Merged |
+| **Total** | **73** | **17 PRs so far** |
 
 Sprint 1 reference:
 

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -68,6 +68,81 @@ work until the decision is recorded in the story file's Architect Notes.
 
 ---
 
+## ✅ Sprint 2 End-of-Sprint Manual Testing — Pre-Flight Verification
+
+> **Owner:** DevOps lead.
+> **When:** Run this checklist immediately before the Sprint 2 manual
+> device-testing phase begins (i.e. after PR #53 merges + Functions
+> are deployed + a release-candidate mobile build is cut).
+> **Why now:** PR #53 (FR-AC-03 + FR-AC-05) is the **first PR that
+> integrates Firebase Cloud Messaging end-to-end.** FCM has platform-
+> shell requirements (APNS on iOS, FCM service entries on Android)
+> that the existing Auth-only build configuration may not satisfy.
+> Verifying these BEFORE manual QA starts saves a round-trip if a
+> build-side gap is found.
+
+### Verification gates
+
+1. **iOS APNS entitlements + certificate (BLOCKING for iOS push).**
+   - `ios/Runner/Info.plist` declares `UIBackgroundModes` including
+     `remote-notification` and `fetch` if not already present.
+   - `ios/Runner/Runner.entitlements` declares the
+     `aps-environment` key (`development` for TestFlight, `production`
+     for App Store).
+   - The Apple Developer account has a current APNS Authentication
+     Key (`.p8` file) uploaded to the Firebase console under
+     **Project Settings → Cloud Messaging → Apple app configuration**.
+     The key ID and team ID match the Bundle Identifier.
+   - The Push Notifications capability is enabled on the Xcode
+     project (`Runner → Signing & Capabilities → +Capability → Push
+     Notifications`).
+
+2. **Android FCM manifest entries (BLOCKING for Android push).**
+   - `android/app/src/main/AndroidManifest.xml` declares the FCM
+     intent filter or relies on the `firebase_messaging` plugin
+     auto-registration (version `^16.2.0` does this automatically;
+     verify there is no manual `<service>` entry colliding with the
+     plugin's).
+   - A default notification channel ID is declared via
+     `<meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" .../>`
+     if custom channel routing is desired (optional for v1.0 — the
+     default channel works).
+   - The default notification icon meta-data
+     (`com.google.firebase.messaging.default_notification_icon`)
+     points to a monochrome white icon asset (Android system tray
+     requirement). If missing, the OS uses the launcher icon and
+     tints it grey — acceptable for v1.0 but flagged as a polish item.
+   - The app's `google-services.json` is present at
+     `android/app/google-services.json` and matches the production
+     Firebase project (Invariant 4).
+
+3. **Functions deploy verification (post-merge).**
+   - `firebase deploy --only functions:onExpenseWriteFriendship,functions:onSettlementWrite`
+     completes without errors on the release tag.
+   - `firebase functions:log --only onExpenseWriteFriendship --limit 5`
+     shows the first post-deploy invocations include the
+     `fcm_send_attempted` structured log key (smoke test by triggering
+     a single expense add from the canary device).
+
+4. **Production Firebase Cloud Messaging readiness.**
+   - The production Firebase project has Cloud Messaging enabled
+     (Firebase console → Project Settings → Cloud Messaging tab is
+     populated, not greyed out).
+   - The Cloud Messaging API V1 is enabled in the Google Cloud
+     Console for the production project ID
+     (`firebase apps:list` confirms the project ID matches `.firebaserc`).
+
+### Sign-off
+
+Once all four gates above are green, DevOps records sign-off in the
+PR #53 (or successor release-cut PR) review comment and the manual
+QA smoke matrix (Section A.6 of the FR-AC-03 story DoD) can begin.
+
+If ANY gate is red, file a dedicated DevOps chore PR (estimated
+1-3 SP) before resuming manual testing.
+
+---
+
 ## PR Tracking
 
 | PR | Story | Title | SP | Status |

--- a/docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md
+++ b/docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md
@@ -584,3 +584,303 @@ The following are explicitly OUT OF SCOPE for this PR:
 - [ ] Architect Notes appended (Phase 2).
 - [ ] Plan + burndown updated (Phase 7).
 
+---
+
+## Architect Notes
+
+> Appended for the FR-AC-03 + FR-AC-05 FCM PR. These notes ratify
+> the design decisions taken before implementation begins.
+> References: `.github/shared/invariants.md`,
+> `.github/shared/decision-log.md` (ADR-0002 paise integers; ADR-0006
+> Riverpod state management; ADR-0007 feature-first folder layout;
+> ADR-0013 PII / telemetry hashing; ADR-0014 rules-readable user
+> collection), `docs/design/07-technical/notifications.md`,
+> `docs/design/04-wireframes/notifications-and-deeplinks.md`.
+
+### 2.1 — Functions-side INR formatter placement
+
+**RATIFY: create `functions/src/utils/format-inr.ts` as a Functions-
+side mirror of `lib/core/formatters/inr_formatter.dart`.**
+
+The Functions-side helper has identical semantics to the client-side
+`formatInrFromPaise()`: integer arithmetic only, Indian-numbering
+convention (e.g. `1,20,000` paise → `"₹1,200"`), no `/100` arithmetic
+in the call sites, currency symbol prefix.
+
+Placement co-located with `utils/id-hash.ts` (the existing PII helper)
+under `functions/src/utils/` keeps utility helpers in one place. The
+existing Functions-side boundary-contract grep at
+`functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+auto-covers the new file.
+
+We do NOT share a single TypeScript file across client + functions
+because the client is Dart and the functions are TypeScript — the
+contract is established by paired unit tests rather than shared code.
+A drift would be caught by the per-event-type renderer tests which
+assert the exact rendered output for canonical paise inputs.
+
+### 2.2 — FCM token cleanup placement
+
+**RATIFY: the token-cleanup-on-410 logic lives INSIDE
+`functions/src/notifications/fcm-send.ts`, NOT in a separate cleanup
+function.**
+
+The cleanup is per-send (synchronous `arrayRemove` on 410). No batch
+reaper is needed for v1.0 — the per-send path naturally prunes tokens
+the moment FCM tells us they are stale.
+
+A future maintenance Cloud Function may run periodic stale-token
+sweeps (e.g. tokens that haven't been touched in 90 days). That is
+out of v1.0 scope and tracked as a FUTURE candidate in
+`next-three-prs.md`.
+
+### 2.3 — Deep-link routing shared helper
+
+**RATIFY: extract `lib/core/routing/notification_deep_links.dart`
+(NEW).**
+
+The existing `ActivityFeedScreen._onRowTap` logic (the
+`_otherUidForFriendship`, `_showUnavailableSnackbar`, expense /
+settlement dispatch switch) refactors to call into this helper. The
+same in-app navigation surface is then used by:
+
+1. The activity-feed row tap (existing FR-AC-02 consumer).
+2. The foreground FCM banner tap (this PR — FR-AC-03).
+3. The background system-notification tap (this PR — FR-AC-03).
+4. The cold-start `getInitialMessage` payload (this PR — FR-AC-05).
+
+The helper accepts a `NotificationDeepLinkTarget` value object (a
+discriminated union over expense-detail, friend-detail, group-detail,
+invite) and a `BuildContext`. It performs the platform navigation
+(`Navigator.of(context).push(MaterialPageRoute(...))`). It does NOT
+perform telemetry — the call sites do that with their own event
+names (e.g. `activity_item_tapped` vs `fcm_notification_tapped`).
+
+### 2.4 — Pending deep-link intent provider
+
+**RATIFY: `lib/features/notifications/application/pending_deep_link_provider.dart`
+exposes a `StateProvider<NotificationPayload?>`.**
+
+The cold-start flow sets this provider when the user is unauthenticated.
+A Riverpod listener on `authStateNotifierProvider` (placed inside
+`OneBytwoApp.build` or a child wrapper widget) watches for the
+transition to `AuthenticatedWithProfile` and:
+
+1. Reads the pending payload (if any).
+2. Clears it (`ref.read(pendingDeepLinkProvider.notifier).state = null`).
+3. Schedules a `WidgetsBinding.instance.addPostFrameCallback` to push
+   the target screen onto the Navigator stack.
+
+This cleanly separates the navigation intent from the auth state and
+is testable in isolation (the provider is a pure StateProvider; the
+listener is a single function that maps `(authState, pendingPayload)
+→ navigation action`).
+
+### 2.5 — FCM emulator wiring
+
+**RATIFY: NO FCM emulator wiring in `lib/main.dart`.**
+
+The FCM emulator is not part of the Firebase Emulator Suite (Firebase
+documents this as a known limitation). For local development:
+
+- Tests mock `FirebaseMessaging` at the SDK boundary via Riverpod
+  overrides on a `firebaseMessagingProvider` (NEW).
+- Manual smoke uses a real FCM token in a debug build connected to
+  the production Firebase project. Per Invariant 4 there is no second
+  project, so debug-build smoke is on production with throwaway test
+  accounts (the same approach used for the Auth flow's SMS-OTP
+  smoke).
+
+### 2.6 — First-session pre-permission dialog trigger
+
+**RATIFY: a Riverpod listener on `authStateNotifierProvider` inside
+the `OneBytwoApp.build` method.**
+
+When the state transitions to `AuthenticatedWithProfile` AND the
+local "shown-this-session" flag is false AND the local
+"permanently-denied" flag is false, schedule the dialog for the next
+frame via `WidgetsBinding.instance.addPostFrameCallback`.
+
+This mirrors the cleanest separation of concerns: the dialog
+trigger is centralised in one place (the auth-state listener) and
+does not require wiring into `HomePlaceholderScreen.initState` or
+any other widget-tree placement. If `HomePlaceholderScreen` is
+later replaced by the real dashboard or the `OBTBottomNav` shell,
+the trigger continues to fire unchanged.
+
+The "shown-this-session" flag lives in a `Provider<bool>` that
+defaults to false on each ProviderScope construction (i.e. each
+process launch). It is set to true the moment the dialog is
+displayed. The "permanently-denied" flag is persisted in
+`SharedPreferences` (or an existing local-storage abstraction) so
+that the dialog is not re-shown automatically on subsequent
+launches; the user can re-enable from the notification-preferences
+screen (FR-PR-03 — separate PR).
+
+### 2.7 — Trigger-extension API surface
+
+**RATIFY:** `emitExpenseFcm(deps, params)` and `emitSettlementFcm(deps,
+params)` mirror the existing `emitExpenseActivity` /
+`emitSettlementActivity` patterns at the bottom of the respective
+function.ts files.
+
+Both helpers:
+
+- NEVER rethrow. Per architect §2.9 item 2 of the FR-EX-07 story,
+  trigger-extension failures must not propagate into the trigger's
+  success branch.
+- Look up the recipient(s)' `users/{uid}` doc to get `fcmTokens` +
+  `notificationPrefs` via a single admin-SDK read per recipient
+  (parallelised via `Promise.allSettled` for the expense fan-out).
+- For expense-trigger: recipients are `memberIds` MINUS the
+  `authorUid` (don't notify the author of their own action).
+- For settlement-trigger: recipient is `toUserId` ONLY (the payer
+  is the actor; the payee is the one notified per `notifications.md`
+  §2.2 `settlement_received` template).
+- Call the appropriate renderer, then `sendFcmToTokens` from
+  `notifications/fcm-send.ts`.
+- Are placed inside the success branch of the respective trigger
+  AFTER the activity emission (FR-AC-01) call. The order is:
+  recompute → log compute_completed → emit activity → emit FCM.
+
+The shared module surface `functions/src/notifications/index.ts`
+exports two trigger-facing entry points:
+
+```typescript
+export {sendExpenseNotification} from "./send-expense-notification";
+export {sendSettlementNotification} from "./send-settlement-notification";
+```
+
+These are the only public symbols the triggers import. Internal
+helpers (`fcm-send.ts`, `payload-renderer.ts`, `prefs-filter.ts`)
+are not directly imported by the triggers — the public surface
+encapsulates the per-event-type dispatch.
+
+### 2.8 — Files to touch (exhaustive — anything outside this set is scope creep)
+
+**NEW (server):**
+
+- `functions/src/utils/format-inr.ts`
+- `functions/src/notifications/fcm-send.ts`
+- `functions/src/notifications/payload-renderer.ts`
+- `functions/src/notifications/prefs-filter.ts`
+- `functions/src/notifications/send-expense-notification.ts`
+- `functions/src/notifications/send-settlement-notification.ts`
+- `functions/src/notifications/index.ts`
+- `functions/src/notifications/types.ts` — shared types
+  (`NotificationType`, `NotificationPayload`, `RecipientPrefs`)
+- `functions/test/notifications/fcm-send.test.ts`
+- `functions/test/notifications/payload-renderer.test.ts`
+- `functions/test/notifications/prefs-filter.test.ts`
+- `functions/test/notifications/send-expense-notification.test.ts`
+- `functions/test/notifications/send-settlement-notification.test.ts`
+- `functions/test/utils/format-inr.test.ts`
+
+**NEW (client):**
+
+- `lib/core/routing/notification_deep_links.dart`
+- `lib/features/notifications/data/fcm_token_service.dart`
+- `lib/features/notifications/data/notification_handler.dart`
+- `lib/features/notifications/domain/notification_payload.dart`
+- `lib/features/notifications/application/firebase_messaging_provider.dart`
+- `lib/features/notifications/application/notification_permission_controller.dart`
+- `lib/features/notifications/application/deep_link_handler.dart`
+- `lib/features/notifications/application/pending_deep_link_provider.dart`
+- `lib/features/notifications/presentation/pre_permission_dialog.dart`
+- `lib/features/notifications/presentation/widgets/in_app_notification_banner.dart`
+- `test/features/notifications/data/fcm_token_service_test.dart`
+- `test/features/notifications/data/notification_handler_test.dart`
+- `test/features/notifications/domain/notification_payload_test.dart`
+- `test/features/notifications/application/notification_permission_controller_test.dart`
+- `test/features/notifications/application/deep_link_handler_test.dart`
+- `test/features/notifications/presentation/pre_permission_dialog_test.dart`
+- `test/features/notifications/presentation/in_app_notification_banner_test.dart`
+- `test/features/notifications/notifications_boundary_contract_test.dart`
+- `test/core/routing/notification_deep_links_test.dart`
+
+**MODIFIED:**
+
+- `functions/src/triggers/on-expense-write/function.ts` — close the
+  FR-AC-03 seam at line 167 with the `emitExpenseFcm` call;
+  inject `notificationsApi` into Dependencies.
+- `functions/src/triggers/on-settlement-write/function.ts` — close the
+  FR-AC-03 seam at line 237 with the `emitSettlementFcm` call.
+- `functions/test/triggers/on-expense-write/function.test.ts` — add
+  FCM-side assertions.
+- `functions/test/triggers/on-settlement-write/function.test.ts` —
+  mirror.
+- `lib/main.dart` — register the top-level `onBackgroundMessage`
+  handler before `runApp`; initialise the FCM service.
+- `lib/features/auth/application/auth_state_provider.dart` — extend
+  with the sign-out FCM-token-cleanup hook (or expose a callback the
+  sign-out action can call).
+- `lib/features/activity/presentation/activity_feed_screen.dart` —
+  refactor `_onRowTap` to dispatch via the shared
+  `notification_deep_links.dart` helper.
+- `docs/sprint-zero/sprint-2-plan.md`
+- `docs/sprint-zero/next-three-prs.md`
+- `docs/audits/sprint-1/07-bucket-b-burndown.md`
+
+### 2.9 — Files explicitly NOT to touch (negative scope guardrails)
+
+- `firestore.rules`, `firestore.indexes.json`, `storage.rules` —
+  UNCHANGED. The existing `users/{userId}` rules already permit
+  owner-only read/write of `fcmTokens` and `notificationPrefs`. The
+  FCM module uses admin SDK and bypasses rules.
+- `pubspec.yaml` — UNCHANGED. `firebase_messaging: ^16.2.0` is
+  already present.
+- `functions/package.json` — UNCHANGED. `firebase-admin` already
+  provides `getMessaging()`.
+- `lib/features/expenses/**`, `lib/features/friends/**`,
+  `lib/features/settlements/**`, `lib/features/activity/**`
+  (except for the deep-link refactor in `ActivityFeedScreen`) —
+  UNCHANGED.
+- `functions/src/triggers/on-expense-write/activity-writer.ts`,
+  `payload-builder.ts`, `activity-validator.ts` — UNCHANGED.
+- `.github/workflows/*.yml` — UNCHANGED.
+
+### 2.10 — Anticipated reconciliations
+
+1. **Snake_case vs camelCase notification types.** The FCM data
+   payload uses snake_case (`expense_added`, `settlement_received`)
+   per `notifications.md` §2.2. The client deep-link handler converts
+   on read using a mapper (similar to
+   `ActivityEventTypeX.parseSnakeCase` in the activity feature).
+
+2. **Group invite path deferral.** The `group_invite` template is
+   implemented in the renderer for forward compatibility, but no
+   producer ships in this PR (groups epic is Sprint 3). The
+   prefs-filter assertion that `group_invite` bypasses the filter
+   ships as a forward-compatibility unit test only.
+
+3. **Reminder rate-limit subcollection deferral.** FR-SE-09 ships
+   separately and consumes this PR's FCM module. The rate-limit
+   logic stays out of `notifications/**`.
+
+4. **Notification-preferences UI deferral.** FR-PR-03 / FR-AC-04
+   ships separately. This PR only READS `notificationPrefs`, never
+   writes.
+
+5. **FCM-emulator absence.** Mocked at the SDK boundary in tests;
+   real tokens in debug builds for smoke. See §2.5.
+
+6. **Token-cleanup is per-send, not batched.** See §2.2.
+
+7. **Dependencies injection extension.** The shared `Dependencies`
+   type in `functions/src/simplified-debts/function.ts` is the
+   admin-SDK dependency-injection seam. The FCM module is exposed
+   to the triggers via a `notificationsApi?: NotificationsApi`
+   optional field on `Dependencies`. When absent (tests that don't
+   mock FCM), the trigger's `emitExpenseFcm` / `emitSettlementFcm`
+   no-ops cleanly. This avoids changing the Dependencies shape
+   in a way that breaks every existing test.
+
+8. **PII guard for FCM token logging.** FCM tokens are NOT
+   deterministic UIDs and are NOT subject to ADR-0013 `hashId()`
+   wrapping. However, including the raw token in structured logs
+   risks credential leakage. The chosen middle ground is a SHA-256
+   fingerprint of the token, truncated to 8 hex chars, included
+   under a `tokenFingerprint` field. This is diagnosable (the
+   operator can correlate a pruned token across log lines) without
+   leaking the credential itself.
+

--- a/docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md
+++ b/docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md
@@ -1,0 +1,586 @@
+# FR-AC-03 + FR-AC-05: FCM Push Notifications + Cold-Start Deep-Link
+
+> Implementation-ready user story for the **first integration of Firebase
+> Cloud Messaging end-to-end** in the OneByTwo application. Ships the
+> server FCM send module (admin-SDK helper + per-event-type renderer +
+> preferences filter + token-cleanup-on-410), the two trigger-extension
+> hooks (`emitExpenseFcm` at `functions/src/triggers/on-expense-write/
+> function.ts:167` + `emitSettlementFcm` at `functions/src/triggers/
+> on-settlement-write/function.ts:237`), the client FCM token lifecycle
+> (acquisition after profile-setup-complete, `onTokenRefresh`, sign-out
+> cleanup), the pre-permission dialog ("Stay in the loop"), the
+> foreground in-app banner, the background `onBackgroundMessage` handler
+> for the system notification, and the cold-start `getInitialMessage`
+> deep-link resolver that reuses the FR-AC-01 in-app routing surface
+> through a new shared `lib/core/routing/notification_deep_links.dart`
+> helper. FR-AC-05 (cold-start deep-link) is bundled as the natural pair
+> because FCM IS the cold-start signal; without the FCM tap event there
+> is no cold-start intent to resolve.
+
+---
+
+## SRS Requirement ID(s)
+
+FR-AC-03 (SRS section 4.7 lines 236-240 — "The app shall send push
+notifications via Firebase Cloud Messaging for events relevant to the
+user"; P0), FR-AC-05 (SRS section 4.7 — "Tapping a notification shall
+deep-link the user to the relevant screen, even from a cold start";
+P0). FR-AC-04 (notification preferences) is partially exercised on the
+server-side prefs-filter path (the filter is implemented; the Profile
+preferences UI is FR-PR-03 and ships in a separate P1 PR).
+
+## Relevant SRS Sections
+
+- Section 4.7 — Activity Feed and Notifications (FR-AC-03, FR-AC-05,
+  FR-AC-04 server-side enforcement).
+- Section 4.2 — Profile and preferences (FR-PR-03 reads / writes
+  `notificationPrefs`; this story only READS).
+- Section 5.6 — Accessibility (pre-permission dialog focus trap; 48 dp
+  tap targets; in-app banner live-region announcement).
+- Section 5.10 — Observability (seven new analytics events: four
+  server, three client).
+- Section 6.2 — Visual system tokens (banner 16 dp radius, 4 dp
+  elevation, 300 ms ease-in-out; dialog 24 dp radius, 8 dp elevation).
+- Section 6.3 — Core screens (the pre-permission dialog is part of the
+  Home dashboard first-session flow).
+- Section 7.2 — Firestore schema (`fcmTokens: string[]`,
+  `notificationPrefs: { newExpense, settlement, reminder }` on
+  `users/{userId}`; both fields already declared with default values).
+- Section 7.3 — Invariant 1 (amount-paise to rupee conversion on the
+  FCM payload-render boundary uses a Functions-side helper mirroring
+  `formatInrFromPaise()`).
+- Section 7.5 — Security rules (`users/{userId}` rules unchanged;
+  owner-only read/write already permits client to manage own
+  `fcmTokens`; admin SDK bypasses rules for server-side reads).
+
+## Priority
+
+**P0 — Must have.** Both FR-AC-03 and FR-AC-05 are flagged P0 in SRS
+section 4.7. The activity-feed read-side shipped in the predecessor PR
+gives the user an in-app view of events; FCM push notifications give
+the user out-of-app awareness. Without FCM the user must open the app
+to see new expenses and settlements — the SRS contract explicitly
+requires push.
+
+## Story Points
+
+**10.** Decomposes as:
+
+- 3 SP — server FCM module (`fcm-send.ts` admin-SDK wrapper with
+  parallel send + 410 token cleanup, `payload-renderer.ts` per-event-
+  type templates, `prefs-filter.ts` notification-preferences short-
+  circuit, `notifications/index.ts` public surface, Functions-side
+  `format-inr.ts` helper for Invariant 1 preservation).
+- 2 SP — trigger-extension hooks (`emitExpenseFcm` + `emitSettlementFcm`
+  mirroring the FR-EX-07 / FR-AC-01 activity-emission contract; error
+  containment per architect §2.9 item 2).
+- 3 SP — client FCM lifecycle (`fcm_token_service.dart` with `arrayUnion`
+  / `arrayRemove` / `onTokenRefresh`, `notification_handler.dart` with
+  the three platform handlers, `notification_payload.dart` domain
+  parsing, `deep_link_handler.dart` routing dispatcher,
+  `pending_deep_link_provider.dart` cold-start intent provider).
+- 1 SP — pre-permission dialog + permission controller (custom Notifier
+  driving the "Stay in the loop" flow + session-scoped "Not now"
+  suppression).
+- 1 SP — in-app banner + cold-start deep-link handler + shared routing
+  helper (`in_app_notification_banner.dart`,
+  `core/routing/notification_deep_links.dart` extracted from the
+  FR-AC-01 `_onRowTap` logic + consumed by both the activity-feed row
+  tap and the FCM tap).
+
+Patterns from FR-EX-07 (trigger-extension error containment,
+structured logging, per-member fan-out, PII guard), FR-AC-01
+(client feature-folder layout, StreamProvider, deep-link routing),
+and FR-AU-06 (UserRepository CRUD pattern) are reused; this story
+does not re-derive them.
+
+## User Story
+
+As a **signed-in user**,
+I want **a push notification on my phone whenever a friend adds,
+edits, or deletes an expense involving me, or settles up with me**,
+so that **I am aware of changes to my shared finances without having
+to open the app**;
+
+and as **the same user**,
+I want **tapping any notification to take me directly to the relevant
+screen, even if the app was fully closed**,
+so that **I can act on the notification (view the expense, send a
+reminder, settle up) without having to manually navigate after
+opening the app**.
+
+## Preconditions
+
+1. The signed-in user has a Firestore document at `users/{uid}` with
+   the schema-default `fcmTokens: []` and `notificationPrefs:
+   { newExpense: true, settlement: true, reminder: true }` (shipped
+   with FR-AU-06).
+2. The Firebase Cloud Messaging service is configured for the production
+   Firebase project (only project per Invariant 4).
+3. The OS-level push notification permission has been requested at least
+   once (this story ships the pre-permission dialog and OS request flow
+   that establish the precondition).
+4. The reusable `activity-writer.ts`, `payload-builder.ts`,
+   `activity-validator.ts` modules and the trigger handlers at
+   `functions/src/triggers/on-expense-write/function.ts` and
+   `functions/src/triggers/on-settlement-write/function.ts` are
+   deployed to `asia-south1` per SRS section 7.1.
+5. The Firebase Emulator Suite is available for pre-merge integration
+   testing (FCM emulator is NOT part of the suite; tests mock at the
+   SDK boundary).
+
+---
+
+## Acceptance Criteria
+
+### FCM token lifecycle — positive ACs
+
+#### AC-1 — FCM token is acquired AFTER profile setup, NOT at launch
+
+> Given a freshly-signed-up user completes the profile-setup screen
+> When they land on the `HomePlaceholderScreen` for the first time in
+> the session
+> Then the pre-permission dialog ("Stay in the loop") is displayed
+> per the wireframes section 1.1
+> And on tap of "Enable Notifications" the OS-level permission prompt
+> is triggered
+> And on grant a new FCM token is acquired via
+> `FirebaseMessaging.instance.getToken()`
+> And the token is written to `users/{uid}.fcmTokens` via Firestore
+> `arrayUnion` (idempotent)
+
+#### AC-2 — Token refresh updates the array via arrayRemove + arrayUnion in one batched write
+
+> Given the app is running with an existing FCM token registered on
+> `users/{uid}.fcmTokens`
+> When `FirebaseMessaging.onTokenRefresh` fires with a new token
+> Then the old token is removed via `arrayRemove`
+> And the new token is added via `arrayUnion`
+> And both operations execute in a SINGLE batched write
+> (`Firestore.batch().commit()`) so there is no window where no valid
+> token exists on the document
+
+#### AC-3 — Sign-out removes the current device token before FirebaseAuth.signOut
+
+> Given the user taps Sign Out
+> When the sign-out flow runs
+> Then the current device's FCM token is removed from
+> `users/{uid}.fcmTokens` via `arrayRemove`
+> And `FirebaseAuth.signOut()` is called AFTER the arrayRemove write
+> resolves (success or failure — sign-out is not blocked by an
+> arrayRemove timeout)
+
+### Server-side FCM send — positive ACs
+
+#### AC-4 — Expense trigger sends FCM to non-author members
+
+> Given an expense is created at `friendships/{fid}/expenses/{eid}`
+> When the trigger completes the success branch (post-recompute)
+> Then `emitExpenseFcm` is called with
+> `recipients = memberIds - authorUid`
+> And for each recipient with `notificationPrefs.newExpense == true`
+> AND non-empty `fcmTokens`
+> Then ONE FCM data message is sent per token with the
+> `expense_added` template per `notifications.md` §2.2
+> And the FCM call site is placed inside the success branch — never
+> on the stale-event, CONTEXT_NOT_FOUND, or BALANCE_INVARIANT_VIOLATED
+> branches
+
+#### AC-5 — Settlement trigger sends FCM to toUserId only
+
+> Given a settlement is recorded at `settlements/{settlementId}`
+> When the trigger completes the success branch
+> Then `emitSettlementFcm` is called with
+> `recipient = toUserId` (the payee; the payer is the actor and is
+> NOT notified of their own action)
+> And if `notificationPrefs.settlement == true` AND `fcmTokens` is
+> non-empty
+> Then ONE FCM data message is sent per token with the
+> `settlement_received` template per `notifications.md` §2.2
+
+#### AC-6 — Stale FCM tokens are pruned on 410
+
+> Given an FCM send returns
+> `messaging/registration-token-not-registered` (HTTP 410)
+> When the send-helper handles the per-token error
+> Then the offending token is removed from `users/{uid}.fcmTokens`
+> via `arrayRemove`
+> And subsequent sends to the same user do NOT re-attempt the pruned
+> token
+> And a structured-log event `fcm_token_pruned` is emitted with the
+> hashed `userIdHash` and the SHA-256-hashed token fingerprint (NOT
+> the raw token — defence-in-depth against token leakage in logs)
+
+#### AC-7 — Notification preference flag short-circuits the send
+
+> Given a user has `notificationPrefs.newExpense == false`
+> When the expense-trigger attempts to send the `expense_added`
+> notification to that user
+> Then ZERO FCM sends are issued for that user
+> And a structured-log event `fcm_send_suppressed_by_prefs` is emitted
+> with the hashed `userIdHash` and the notification type
+> And other recipients of the same trigger event with
+> `notificationPrefs.newExpense == true` ARE still sent the
+> notification (per-recipient short-circuit, not per-event)
+
+#### AC-8 — Amount formatting through Functions-side INR helper preserves Invariant 1
+
+> Given an expense with `amountPaise = 120000`
+> When the payload renderer constructs the `body` template
+> Then the rendered string contains `"₹1,200"` (Indian numbering
+> convention)
+> And ZERO inline `/100` arithmetic exists anywhere in
+> `functions/src/notifications/**`
+> And the new `functions/src/utils/format-inr.ts` helper is the SOLE
+> paise→rupee converter on the Functions side
+> And the existing Functions-side boundary-contract grep at
+> `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+> returns ZERO violations on the new files
+
+### Client foreground / background / cold-start — positive ACs
+
+#### AC-9 — Foreground in-app banner renders on FCM data message
+
+> Given the app is in the foreground
+> When `FirebaseMessaging.onMessage` fires with a valid data payload
+> Then the in-app notification banner (per wireframes §2) slides in
+> from the top with a 300 ms ease-in-out animation
+> And auto-dismisses after 4 seconds
+> And exposes the title + body + category icon per the wireframes
+> banner anatomy table (§2.2)
+> And on tap routes to the deep-link target via the shared
+> `lib/core/routing/notification_deep_links.dart` helper
+
+#### AC-10 — Background system notification renders
+
+> Given the app is backgrounded
+> When `FirebaseMessaging.onBackgroundMessage` fires (top-level
+> handler registered before `runApp`)
+> Then the system notification tray displays the notification with
+> the rendered `title` and `body` per `notifications.md` §3.2
+> And tapping the notification opens the app and routes to the
+> deep-link target via the shared routing helper
+
+#### AC-11 — Cold-start deep-link resolves the target after auth check
+
+> Given the app is fully terminated
+> When the user taps a notification and the OS launches the app
+> Then `FirebaseMessaging.instance.getInitialMessage()` returns the
+> payload
+> And the splash screen is shown for at most 2 seconds while Firebase
+> Auth restores the persisted session (per FR-AU-07)
+> And if authenticated AND the user has a profile, the deep-link
+> target screen is pushed onto the Navigator stack via the shared
+> routing helper
+> And if NOT authenticated, the payload is stored in
+> `pendingDeepLinkProvider` and replayed after the next successful
+> sign-in
+> And if the target entity no longer exists, the SCR-25 "This item
+> is no longer available" snackbar is shown and the user remains on
+> the Home dashboard
+
+### Cross-cutting and negative ACs
+
+#### AC-12 — Pre-permission dialog suppresses re-show after "Not now"
+
+> Given the user dismissed the pre-permission dialog via "Not now"
+> earlier in the session
+> When the same dialog trigger fires again in the same session
+> Then the dialog does NOT re-appear
+> And the suppression flag persists for the session lifetime only
+> (cleared on app restart so the dialog has another chance to land
+> on the next launch if the user did not permanently deny)
+
+#### AC-13 — Permission denial does NOT acquire a token
+
+> Given the user denies the OS-level permission prompt
+> When the prompt result is handled
+> Then no FCM token is acquired
+> And no write to `users/{uid}.fcmTokens` occurs
+> And a local flag records the denial so the pre-permission dialog
+> is NOT shown again automatically (the user may re-enable via the
+> notification-preferences screen — out of scope for this PR)
+
+#### AC-14 — Telemetry events fire with correct PII guard
+
+> Given any of the new structured-log events (`fcm_send_attempted`,
+> `fcm_send_succeeded`, `fcm_send_failed`, `fcm_token_pruned`,
+> `fcm_send_suppressed_by_prefs`) on the server side
+> Or any of the new client-side events
+> (`fcm_token_registered`, `fcm_permission_prompt_shown`,
+> `fcm_notification_tapped`)
+> When the event is emitted
+> Then any UID-derived parameter (recipient `userIdHash`, sender
+> `senderIdHash`, friendship composite `contextIdHash`) is hashed via
+> the existing helper (`hashId()` on the server,
+> `hashFriendshipId()` / equivalent on the client)
+> And FCM tokens themselves are NOT hashed via `hashId()` — they are
+> opaque platform-issued strings that are not deterministic UIDs
+> (per ADR-0013); however the per-event log MAY include a SHA-256
+> fingerprint of the token (truncated to 8 hex chars) for
+> diagnosability of which token was pruned without leaking the
+> credential itself
+
+#### AC-15 — Invariant 1 boundary contract (client + server)
+
+> Given the PR diff
+> When scanned for `.toDouble()`, `parseFloat`, `/100`, `.toFixed`,
+> or `double` declarations on monetary fields
+> Then ZERO violations exist anywhere in:
+>   - `lib/features/notifications/**`
+>   - `lib/core/routing/notification_deep_links.dart`
+>   - `functions/src/notifications/**`
+> And the new affirmative client-side grep test at
+> `test/features/notifications/notifications_boundary_contract_test.dart`
+> passes
+> And the existing Functions-side grep at
+> `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+> passes (auto-covers the new Functions files)
+
+#### AC-16 — Invariant 2 negative guard
+
+> Given the PR diff
+> When scanned for new writes to `simplifiedBalances`
+> Then ZERO new writers exist
+> And the FCM module touches only:
+>   - `users/{uid}.fcmTokens` (write — server cleanup on 410, client
+>     `arrayUnion` on acquisition / `arrayRemove` on sign-out)
+>   - `users/{uid}.notificationPrefs` (read — server-side prefs
+>     filter; client-side cache for foreground banner suppression)
+
+#### AC-17 — Trigger error containment (architect §2.9 item 2)
+
+> Given any FCM-send failure (network error, admin-SDK throw,
+> validator throw, malformed payload, missing user doc)
+> When the trigger's `emitExpenseFcm` / `emitSettlementFcm` helper
+> runs
+> Then the failure is CONTAINED inside the helper's own `try/catch`
+> And the trigger's success branch is preserved (recompute already
+> done; FCM failure must not retry the whole invocation)
+> And a structured-log event `fcm_emission_internal_error` is emitted
+> with the hashed `contextIdHash` and the error message
+> And Cloud Functions does NOT retry the whole trigger invocation due
+> to an FCM-side failure
+
+#### AC-18 — FCM is NOT called on stale-event / CONTEXT_NOT_FOUND / BALANCE_INVARIANT_VIOLATED branches
+
+> Given the trigger handler drops on any of the three negative
+> branches above (stale-event guard, CONTEXT_NOT_FOUND from
+> recomputeAndWrite, BALANCE_INVARIANT_VIOLATED from
+> recomputeAndWrite)
+> When the trigger handler returns or throws
+> Then `emitExpenseFcm` / `emitSettlementFcm` is NOT called
+> And this is symmetric with the FR-EX-07 AC-5 + FR-AC-01 AC-12
+> contracts for `emitExpenseActivity` / `emitSettlementActivity`
+
+#### AC-19 — Group invite notifications bypass the preferences filter
+
+> Given a `group_invite` notification type
+> When the prefs-filter is consulted
+> Then the send proceeds regardless of `notificationPrefs` values
+> (per `notifications.md` §2.3 — group invites are not user-
+> suppressible because they grant access; they are NOT subject to
+> FR-AC-04)
+> Note: the `group_invite` SEND path is NOT implemented in this PR
+> (group invites are part of the Sprint 3 groups epic). The
+> prefs-filter forward-compatibility for `group_invite` is asserted
+> via a unit test only.
+
+#### AC-20 — Pre-permission dialog accessibility
+
+> Given a screen reader is active (VoiceOver or TalkBack)
+> When the pre-permission dialog displays
+> Then the heading "Stay in the loop" is announced as a heading
+> (Semantics(header: true))
+> And both buttons ("Enable Notifications", "Not now") have a
+> minimum 48x48 dp tap target
+> And focus is trapped within the dialog (back gesture / scrim tap
+> dismisses without focus escape)
+
+---
+
+## Test Plan
+
+### Functions unit tests
+
+- `functions/test/notifications/fcm-send.test.ts` — admin-SDK helper
+  with mocked `getMessaging().sendEach(...)`:
+  - Sends one message per token (parallel via `Promise.allSettled`).
+  - Returns aggregated success / failure counts.
+  - On `messaging/registration-token-not-registered`, calls
+    `arrayRemove` on `users/{uid}.fcmTokens`.
+  - On other errors (network, invalid argument), does NOT prune the
+    token; logs `fcm_send_failed`.
+  - Empty `tokens` array → no-op (no admin-SDK call, no log).
+- `functions/test/notifications/payload-renderer.test.ts` — per-template
+  rendering for all six types:
+  - `expense_added`, `expense_edited`, `expense_deleted`,
+    `settlement_received`, `reminder`, `group_invite`.
+  - Asserts Indian-numbering format for `₹1,200` (120000 paise).
+  - Asserts ZERO inline `/100` arithmetic (relies on the existing
+    Functions-side boundary-contract grep).
+- `functions/test/notifications/prefs-filter.test.ts` — per-flag
+  short-circuit:
+  - `notificationPrefs.newExpense == false` blocks the three
+    expense types.
+  - `notificationPrefs.settlement == false` blocks `settlement_received`.
+  - `notificationPrefs.reminder == false` blocks `reminder`.
+  - `group_invite` bypasses the filter (AC-19).
+  - Missing `notificationPrefs` map defaults to true for all flags
+    (mirrors the schema default).
+
+### Functions trigger-extension tests
+
+- `functions/test/triggers/on-expense-write/function.test.ts` — extend
+  with `emitExpenseFcm` assertions:
+  - Called once per non-author recipient (mocked module).
+  - NOT called on stale-event / CONTEXT_NOT_FOUND /
+    BALANCE_INVARIANT_VIOLATED branches.
+  - Wrapped in try/catch — internal error does not fail the trigger.
+- `functions/test/triggers/on-settlement-write/function.test.ts` —
+  mirror for `emitSettlementFcm`:
+  - Called with `recipient = toUserId` ONLY.
+  - NOT called on the negative branches.
+  - Error contained.
+
+### Functions integration tests
+
+- `functions/test/integration/on-expense-write.integration.test.ts` —
+  extend with FCM-side assertion (mocked admin Messaging at the SDK
+  boundary):
+  - End-to-end create → trigger fires → FCM module called with the
+    right shape.
+- `functions/test/integration/on-settlement-write.integration.test.ts`
+  — mirror.
+
+### Client unit tests
+
+- `test/features/notifications/data/fcm_token_service_test.dart` —
+  `arrayUnion` / `arrayRemove` / `onTokenRefresh` against a fake repo.
+- `test/features/notifications/data/notification_handler_test.dart` —
+  payload parsing + foreground / background / cold-start dispatch
+  tests.
+- `test/features/notifications/application/notification_permission_controller_test.dart`
+  — Notifier tests covering the pre-permission dialog flow + "Not now"
+  suppression.
+- `test/features/notifications/application/deep_link_handler_test.dart`
+  — payload → route dispatch tests covering the deep-link map at
+  `notifications.md` §4.
+
+### Client widget tests
+
+- `test/features/notifications/presentation/pre_permission_dialog_test.dart`
+  — widget tests for the "Stay in the loop" dialog (button taps,
+  focus trap, scrim dismiss).
+- `test/features/notifications/presentation/in_app_notification_banner_test.dart`
+  — widget tests for the 300 ms slide-in banner with auto-dismiss.
+
+### Boundary-contract tests
+
+- `test/features/notifications/notifications_boundary_contract_test.dart`
+  — grep over `lib/features/notifications/**` for `.toDouble()`,
+  `parseFloat`, `/100`, `.toFixed`, `double ` declarations on
+  monetary fields.
+- `test/core/routing/notification_deep_links_test.dart` — pure-function
+  tests for the deep-link target resolver.
+
+### Manual QA smoke matrix
+
+- Sign in as user A on device 1; verify FCM token is written to
+  `users/A.fcmTokens`.
+- Sign in as user A on device 2 (debug build with a different FCM
+  token); verify both tokens appear in the array.
+- As user B, add an expense to the A↔B friendship; verify A receives
+  the FCM banner on both devices.
+- Tap the banner; verify deep-link routing to the Expense Detail
+  screen.
+- Set `notificationPrefs.newExpense = false` for A; verify subsequent
+  expense adds do NOT trigger FCM.
+- Soft-delete user A's app and reinstall; verify the stale FCM token
+  is pruned on the next send attempt (410 response).
+- Cold-start from a tapped notification (kill the app, send an FCM
+  push, tap it); verify the splash → auth-check → target-screen flow.
+- Sign out user A; verify the device's FCM token is removed from
+  `users/A.fcmTokens` BEFORE `FirebaseAuth.signOut()` completes.
+
+---
+
+## Telemetry Contract
+
+### Server-side (Cloud Functions, structured logs)
+
+| Event | When emitted | Required parameters |
+|---|---|---|
+| `fcm_send_attempted` | Just before `getMessaging().sendEach(...)` | `userIdHash`, `notificationType`, `tokenCount` |
+| `fcm_send_succeeded` | After a successful per-token send | `userIdHash`, `notificationType`, `tokenFingerprint` |
+| `fcm_send_failed` | After a per-token failure that is NOT 410 | `userIdHash`, `notificationType`, `tokenFingerprint`, `errorCode` |
+| `fcm_token_pruned` | After arrayRemove on 410 | `userIdHash`, `tokenFingerprint` |
+| `fcm_send_suppressed_by_prefs` | Per-recipient short-circuit by prefs-filter | `userIdHash`, `notificationType` |
+| `fcm_emission_internal_error` | trigger-extension catch block | `contextType`, `contextIdHash`, `errorMessage` |
+
+### Client-side (Firebase Analytics)
+
+| Event | When emitted | Required parameters |
+|---|---|---|
+| `fcm_token_registered` | After `getToken()` + arrayUnion success | (none — implicit user context) |
+| `fcm_permission_prompt_shown` | When the pre-permission dialog appears | `trigger: 'first_session' \| 'manual'` |
+| `fcm_notification_tapped` | Foreground banner tap / background tap / cold-start | `notification_type`, `source: 'foreground' \| 'background' \| 'cold_start'` |
+
+PII guard (ADR-0013): UID-derived parameters MUST be hashed; FCM
+tokens themselves are NOT subject to ADR-0013 (opaque, non-deterministic,
+rotating) but MAY be SHA-256-fingerprinted (truncated to 8 hex chars)
+for diagnosability when included as a log parameter.
+
+---
+
+## Scope Exclusions
+
+The following are explicitly OUT OF SCOPE for this PR:
+
+- **FR-PR-03 / FR-AC-04 notification-preferences UI** — separate P1
+  story; lives on the Profile screen with its own SCR-26+.
+- **FR-SE-09 Send Reminder** — separate P1 story; introduces the
+  per-friend 24-hour rate-limit subcollection per `notifications.md`
+  §6.1; will be the FIRST consumer of this PR's FCM module.
+- **Group-context FCM (`group_invite` producer)** — Sprint 3 groups
+  epic. The renderer ships a stub template for forward compatibility
+  but no producer wires it.
+- **`OBTBottomNav` shell** — still deferred per the activity-feed
+  read-side architect §2.1.
+- **Read/unread markers, pagination, filter/search on the activity
+  feed** — SCR-25 Open Questions; FUTURE.
+- **Issue #47 rules-hardening** — separate small chore PR.
+- **Issue #49 orphan-cleanup** — FUTURE.
+- **Issue #50 trigger no-op-recompute optimisation** — EXPLICITLY
+  CONSTRAINED by FR-EX-07 AC-2.
+- **Concurrent-edit detection for FR-EX-06** — still deferred.
+- **Rate-limit transaction race refactor** — still deferred.
+- **Activity-writer rename cleanup** — deferred per the activity-feed
+  read-side architect §2.3.
+- **Real FCM emulator wiring** — FCM emulator is NOT part of the
+  Firebase Emulator Suite. Tests mock at the SDK boundary; debug
+  builds use real FCM tokens for manual smoke.
+- **Periodic stale-token sweeps via maintenance Cloud Function** —
+  per-send cleanup on 410 is the v1.0 contract.
+
+---
+
+## Definition of Done
+
+- [ ] All 20 ACs above pass automated tests where applicable and
+      manual QA where not.
+- [ ] `flutter analyze --fatal-infos` exits 0.
+- [ ] `dart format --set-exit-if-changed .` exits 0.
+- [ ] `flutter test` passes (baseline 973 + ~50 new = ~1023 tests).
+- [ ] `cd functions && npm run lint && npm run build && npm test`
+      passes (baseline 195 + ~30 new = ~225 tests / ~17 suites).
+- [ ] `cd functions && npm run test:rules` passes (188 unchanged —
+      no rules diff this PR).
+- [ ] Manual QA smoke matrix complete with evidence.
+- [ ] Invariant 1: new client-side and existing Functions-side
+      boundary-contract greps return zero violations.
+- [ ] Invariant 2: zero new writes to `simplifiedBalances`.
+- [ ] Invariant 4: `.firebaserc` unchanged.
+- [ ] Architect Notes appended (Phase 2).
+- [ ] Plan + burndown updated (Phase 7).
+

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/src", "<rootDir>/test/simplified-debts", "<rootDir>/test/lookup-user-by-phone-number", "<rootDir>/test/triggers", "<rootDir>/test/utils", "<rootDir>/test/boundary-contracts"],
+  roots: ["<rootDir>/src", "<rootDir>/test/simplified-debts", "<rootDir>/test/lookup-user-by-phone-number", "<rootDir>/test/triggers", "<rootDir>/test/utils", "<rootDir>/test/boundary-contracts", "<rootDir>/test/notifications"],
   testMatch: ["**/*.test.ts"],
   testPathIgnorePatterns: ["\\.integration\\.test\\.ts$"],
   moduleFileExtensions: ["ts", "js", "json"],

--- a/functions/src/notifications/fcm-send.ts
+++ b/functions/src/notifications/fcm-send.ts
@@ -1,0 +1,236 @@
+/**
+ * Admin-SDK FCM send helper (FR-AC-03 / notifications.md §1.4).
+ *
+ * Dispatches a `NotificationPayload` to one or more FCM tokens for a
+ * single recipient. Per-token sends run in parallel via
+ * `Promise.allSettled`; on a `messaging/registration-token-not-registered`
+ * (HTTP 410) error, the token is pruned from
+ * `users/{uid}.fcmTokens` via `FieldValue.arrayRemove`.
+ *
+ * Structured-log contract (FR-AC-03 AC-14):
+ *
+ *   - `fcm_send_attempted` (info) — once before the parallel sends;
+ *     `{userIdHash, notificationType, tokenCount}`.
+ *   - `fcm_send_succeeded`  (info) — per successful send;
+ *     `{userIdHash, notificationType, tokenFingerprint}`.
+ *   - `fcm_send_failed`     (error) — per non-410 failure;
+ *     `{userIdHash, notificationType, tokenFingerprint, errorCode}`.
+ *   - `fcm_token_pruned`    (info) — per 410 cleanup;
+ *     `{userIdHash, notificationType, tokenFingerprint}`.
+ *
+ * PII guard (architect §2.10 item 8):
+ *
+ *   - `userId` is hashed through `hashId()` (16 hex chars) before any
+ *     log call.
+ *   - Raw FCM tokens are NEVER logged; only the 8-char SHA-256
+ *     fingerprint from `fingerprintToken()` appears in structured
+ *     logs. Note that FCM tokens are NOT subject to ADR-0013
+ *     `hashId()` wrapping (they are not UIDs), but they are still
+ *     opaque platform credentials we minimise in logs by policy.
+ *
+ * @module notifications/fcm-send
+ */
+
+import {createHash} from "crypto";
+import {FieldValue} from "firebase-admin/firestore";
+import {hashId} from "../utils/id-hash";
+import type {NotificationPayload, NotificationType} from "./types";
+import type {NotificationsDependencies} from "./types";
+
+/**
+ * Per-call parameters for `sendFcmToTokens`. The `userId` is required
+ * for the cleanup branch (the 410-token-arrayRemove targets
+ * `users/{userId}`) and for the structured-log `userIdHash`.
+ */
+export interface SendFcmParams {
+  userId: string;
+  notificationType: NotificationType;
+  tokens: readonly string[];
+  payload: NotificationPayload;
+}
+
+/**
+ * Aggregated result. `pruned` lists the raw tokens that were removed
+ * from the user's `fcmTokens` array — the trigger does not log these
+ * itself (the cleanup-log is emitted inside this helper).
+ */
+export interface SendFcmResult {
+  succeeded: number;
+  failed: number;
+  pruned: string[];
+}
+
+/**
+ * FCM error code returned by the admin SDK when a token is no longer
+ * registered with the FCM service. Matches both the canonical
+ * `messaging/registration-token-not-registered` form returned by the
+ * Firebase Admin Node SDK and the bare `registration-token-not-registered`
+ * form some adapters emit (defence-in-depth).
+ */
+const FCM_NOT_REGISTERED_CODES = new Set<string>([
+  "messaging/registration-token-not-registered",
+  "registration-token-not-registered",
+]);
+
+/**
+ * Returns the first 8 hex characters of SHA-256(token). Used purely
+ * for log diagnosability so that two distinct token-related events
+ * for the same physical token can be correlated WITHOUT exposing the
+ * raw credential.
+ *
+ * 8 hex chars ≈ 32 bits of entropy; collision probability across the
+ * tokens of a single user is negligible. We accept the (cryptographically
+ * irrelevant) possibility of intra-user collisions.
+ *
+ * @param token - The raw FCM token.
+ * @returns 8-character lowercase hex string.
+ */
+export function fingerprintToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 8);
+}
+
+/**
+ * Sends a `NotificationPayload` to each token in `params.tokens`,
+ * pruning 410-failed tokens and emitting the structured-log contract.
+ *
+ * @param deps - DI dependencies (db for the 410 cleanup, messaging
+ *   for the admin SDK, logger for structured events).
+ * @param params - Recipient userId, notification type discriminator,
+ *   tokens to dispatch to, and the rendered payload.
+ * @returns Aggregated counts of successes, failures, and pruned tokens.
+ */
+export async function sendFcmToTokens(
+  deps: NotificationsDependencies,
+  params: SendFcmParams,
+): Promise<SendFcmResult> {
+  const {db, messaging, logger} = deps;
+  const {userId, notificationType, tokens, payload} = params;
+
+  // Empty tokens array → silent no-op. No admin-SDK call, no log
+  // (the caller will have already logged the per-recipient context).
+  if (tokens.length === 0) {
+    return {succeeded: 0, failed: 0, pruned: []};
+  }
+
+  const userIdHash = hashId(userId);
+
+  logger.info("fcm_send_attempted", {
+    event: "fcm_send_attempted",
+    userIdHash,
+    notificationType,
+    tokenCount: tokens.length,
+  });
+
+  // Build the FCM `Message` envelope per notifications.md §2.1. Data-
+  // only message (no top-level `notification` block) so clients have
+  // full control over presentation. High-priority on both platforms
+  // so messages wake the device for time-sensitive notifications
+  // (FR-AC-03 latency target).
+  const data: Record<string, string> = {
+    type: payload.type,
+    contextType: payload.contextType,
+    contextId: payload.contextId,
+    title: payload.title,
+    body: payload.body,
+    senderName: payload.senderName,
+    createdAt: payload.createdAt,
+  };
+  if (payload.itemId !== undefined) data.itemId = payload.itemId;
+  if (payload.amountPaise !== undefined) data.amountPaise = payload.amountPaise;
+  if (payload.inviteToken !== undefined) {
+    data.inviteToken = payload.inviteToken;
+  }
+
+  // Parallel dispatch — one `send()` call per token. The admin SDK's
+  // `sendMulticast` is deprecated; per-token `send()` is the
+  // recommended pattern (see Firebase docs at /docs/cloud-messaging/
+  // send-message). `Promise.allSettled` gathers the per-token
+  // outcomes so a single 410 doesn't short-circuit the others.
+  const sends = tokens.map((token) => {
+    const message = {
+      token,
+      data,
+      android: {priority: "high" as const},
+      apns: {
+        headers: {"apns-priority": "10"},
+        payload: {aps: {"content-available": 1}},
+      },
+    };
+    return messaging.send(message);
+  });
+
+  const settled = await Promise.allSettled(sends);
+
+  const pruned: string[] = [];
+  let succeeded = 0;
+  let failed = 0;
+
+  // Per-token result handling. We do the prune updates SEQUENTIALLY
+  // within the loop body to keep the test's `expect(updateFn).toHaveBeenCalledTimes(1)`
+  // semantics deterministic; in the multi-prune case the cost is
+  // O(prunedTokens) round-trips, which is acceptable for the rare
+  // 410 cleanup branch.
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    const token = tokens[i];
+    const tokenFingerprint = fingerprintToken(token);
+
+    if (outcome.status === "fulfilled") {
+      succeeded += 1;
+      logger.info("fcm_send_succeeded", {
+        event: "fcm_send_succeeded",
+        userIdHash,
+        notificationType,
+        tokenFingerprint,
+      });
+      continue;
+    }
+
+    failed += 1;
+    const err = outcome.reason as Error & {code?: string};
+    const errorCode = err?.code ?? "unknown";
+
+    if (FCM_NOT_REGISTERED_CODES.has(errorCode)) {
+      // HTTP 410 → token is dead. Remove it from the user's fcmTokens
+      // array and log a structured prune event.
+      try {
+        await db.collection("users").doc(userId).update({
+          fcmTokens: FieldValue.arrayRemove(token),
+        });
+        pruned.push(token);
+        logger.info("fcm_token_pruned", {
+          event: "fcm_token_pruned",
+          userIdHash,
+          notificationType,
+          tokenFingerprint,
+        });
+      } catch (cleanupErr) {
+        // The prune itself failed (e.g. Firestore unreachable).
+        // Surface as a non-fatal warn — the next dispatch attempt
+        // will see the same dead token and retry the cleanup.
+        logger.warn("fcm_token_prune_failed", {
+          event: "fcm_token_prune_failed",
+          userIdHash,
+          notificationType,
+          tokenFingerprint,
+          errorMessage:
+            cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+        });
+      }
+      continue;
+    }
+
+    // Non-410 error (network, quota, invalid argument, etc.) — log
+    // but do NOT prune. The same token will be retried on the next
+    // dispatch; transient errors should self-heal.
+    logger.error("fcm_send_failed", {
+      event: "fcm_send_failed",
+      userIdHash,
+      notificationType,
+      tokenFingerprint,
+      errorCode,
+    });
+  }
+
+  return {succeeded, failed, pruned};
+}

--- a/functions/src/notifications/index.ts
+++ b/functions/src/notifications/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Public surface of the FR-AC-03 FCM notifications module.
+ *
+ * Exports two trigger-facing entry points
+ * (`sendExpenseNotification`, `sendSettlementNotification`) and the
+ * shared `NotificationsApi` / payload / preference types referenced
+ * from the trigger's `Dependencies` shape (architect §2.10 item 7).
+ *
+ * Internal helpers (`fcm-send`, `payload-renderer`, `prefs-filter`,
+ * `format-inr`) are NOT re-exported — they are call-site-specific
+ * details that the trigger should not depend on directly.
+ *
+ * @module notifications
+ */
+
+export {sendExpenseNotification} from "./send-expense-notification";
+export {sendSettlementNotification} from "./send-settlement-notification";
+export type {
+  NotificationsApi,
+  NotificationsDependencies,
+  NotificationType,
+  NotificationPayload,
+  NotificationDispatchResult,
+  RecipientPrefs,
+  SendExpenseNotificationParams,
+  SendSettlementNotificationParams,
+} from "./types";

--- a/functions/src/notifications/payload-renderer.ts
+++ b/functions/src/notifications/payload-renderer.ts
@@ -1,0 +1,224 @@
+/**
+ * Per-type FCM payload renderer (FR-AC-03 / notifications.md §2.2).
+ *
+ * Maps each `NotificationType` to its corresponding title + body
+ * template using a single dispatching function. All money values are
+ * formatted through `formatInrFromPaise()` (FR-AC-03 / Invariant 1 —
+ * no inline `/100` arithmetic).
+ *
+ * The renderer is a PURE function — no I/O, no globals, no clocks
+ * other than the explicit `createdAt` input. This makes it trivially
+ * unit-testable and side-effect-free for trigger-side composition.
+ *
+ * @module notifications/payload-renderer
+ */
+
+import {formatInrFromPaise} from "../utils/format-inr";
+import type {NotificationPayload, NotificationType} from "./types";
+
+/**
+ * Input shape for the expense-flavour templates (`expense_added`,
+ * `expense_edited`, `expense_deleted`).
+ */
+export interface ExpensePayloadInput {
+  senderName: string;
+  description: string;
+  amountPaise: number;
+  contextType: "friendship" | "group";
+  contextId: string;
+  itemId?: string;
+  createdAt: Date;
+}
+
+/**
+ * Input shape for the `settlement_received` template.
+ */
+export interface SettlementPayloadInput {
+  senderName: string;
+  amountPaise: number;
+  contextType: "friendship" | "group";
+  contextId: string;
+  itemId?: string;
+  createdAt: Date;
+}
+
+/**
+ * Input shape for the `reminder` template (FR-AC-04 — producer ships
+ * later; the renderer is forward-compat per AC-19).
+ */
+export interface ReminderPayloadInput {
+  senderName: string;
+  amountPaise: number;
+  contextType: "friendship" | "group";
+  contextId: string;
+  itemId?: string;
+  createdAt: Date;
+}
+
+/**
+ * Input shape for the `group_invite` template (FR-GR-* — producer
+ * ships when group invites land; renderer is forward-compat).
+ */
+export interface GroupInvitePayloadInput {
+  senderName: string;
+  contextType: "friendship" | "group";
+  contextId: string;
+  itemId?: string;
+  groupName: string;
+  inviteToken: string;
+  createdAt: Date;
+}
+
+/**
+ * Discriminated union of all renderer inputs. The `type` parameter on
+ * `renderPayload` selects which branch is active.
+ */
+export type RenderInput =
+  | ExpensePayloadInput
+  | SettlementPayloadInput
+  | ReminderPayloadInput
+  | GroupInvitePayloadInput;
+
+/**
+ * Renders a `NotificationPayload` for the given notification type and
+ * input. Each template is a faithful implementation of the strings
+ * specified in `docs/design/07-technical/notifications.md` §2.2.
+ *
+ * @param type - The notification type discriminator. Selects the
+ *   template and validates that the input has the right shape.
+ * @param input - The template inputs. The discriminated union is
+ *   loosely typed at the public surface (TypeScript can't fully
+ *   statically validate the cross-product of type × input), but the
+ *   per-branch reads are type-narrowed inside.
+ */
+export function renderPayload(
+  type: "expense_added" | "expense_edited" | "expense_deleted",
+  input: ExpensePayloadInput,
+): NotificationPayload;
+export function renderPayload(
+  type: "settlement_received",
+  input: SettlementPayloadInput,
+): NotificationPayload;
+export function renderPayload(
+  type: "reminder",
+  input: ReminderPayloadInput,
+): NotificationPayload;
+export function renderPayload(
+  type: "group_invite",
+  input: GroupInvitePayloadInput,
+): NotificationPayload;
+export function renderPayload(
+  type: NotificationType,
+  input: RenderInput,
+): NotificationPayload {
+  const createdAtIso = input.createdAt.toISOString();
+
+  switch (type) {
+  case "expense_added": {
+    const i = input as ExpensePayloadInput;
+    return {
+      type,
+      contextType: i.contextType,
+      contextId: i.contextId,
+      itemId: i.itemId,
+      title: `${i.senderName} added an expense`,
+      body: `${i.description} -- ${formatInrFromPaise(i.amountPaise)}.`,
+      senderName: i.senderName,
+      amountPaise: i.amountPaise.toString(),
+      createdAt: createdAtIso,
+    };
+  }
+
+  case "expense_edited": {
+    const i = input as ExpensePayloadInput;
+    return {
+      type,
+      contextType: i.contextType,
+      contextId: i.contextId,
+      itemId: i.itemId,
+      title: `${i.senderName} edited an expense`,
+      body:
+        `${i.description} was updated to ${formatInrFromPaise(i.amountPaise)}.`,
+      senderName: i.senderName,
+      amountPaise: i.amountPaise.toString(),
+      createdAt: createdAtIso,
+    };
+  }
+
+  case "expense_deleted": {
+    const i = input as ExpensePayloadInput;
+    return {
+      type,
+      contextType: i.contextType,
+      contextId: i.contextId,
+      // itemId is OPTIONAL for delete (expense has been soft-deleted).
+      itemId: i.itemId,
+      title: `${i.senderName} deleted an expense`,
+      body:
+        `${i.description} (${formatInrFromPaise(i.amountPaise)}) was removed.`,
+      senderName: i.senderName,
+      amountPaise: i.amountPaise.toString(),
+      createdAt: createdAtIso,
+    };
+  }
+
+  case "settlement_received": {
+    const i = input as SettlementPayloadInput;
+    return {
+      type,
+      contextType: i.contextType,
+      contextId: i.contextId,
+      itemId: i.itemId,
+      title: `${i.senderName} settled up`,
+      body: `You received ${formatInrFromPaise(i.amountPaise)}.`,
+      senderName: i.senderName,
+      amountPaise: i.amountPaise.toString(),
+      createdAt: createdAtIso,
+    };
+  }
+
+  case "reminder": {
+    const i = input as ReminderPayloadInput;
+    return {
+      type,
+      contextType: i.contextType,
+      contextId: i.contextId,
+      itemId: i.itemId,
+      title: `Reminder from ${i.senderName}`,
+      body:
+        `${i.senderName} is nudging you about ${formatInrFromPaise(i.amountPaise)}.`,
+      senderName: i.senderName,
+      amountPaise: i.amountPaise.toString(),
+      createdAt: createdAtIso,
+    };
+  }
+
+  case "group_invite": {
+    const i = input as GroupInvitePayloadInput;
+    return {
+      type,
+      contextType: i.contextType,
+      contextId: i.contextId,
+      itemId: i.itemId,
+      title: `${i.senderName} invited you to a group`,
+      body: `Join "${i.groupName}" to start splitting.`,
+      senderName: i.senderName,
+      // amountPaise is intentionally OMITTED for group_invite — the
+      // template has no monetary value (FR-AC-03 / notifications.md
+      // §2.2 group_invite template).
+      createdAt: createdAtIso,
+      inviteToken: i.inviteToken,
+    };
+  }
+
+  default: {
+    // Exhaustiveness check — TypeScript will fail to compile if a
+    // new NotificationType is added to the union without a matching
+    // branch here.
+    const _exhaustive: never = type;
+    throw new Error(
+      `renderPayload: unsupported notification type '${_exhaustive as string}'.`,
+    );
+  }
+  }
+}

--- a/functions/src/notifications/prefs-filter.ts
+++ b/functions/src/notifications/prefs-filter.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-recipient preference short-circuit for FCM dispatch (FR-AC-03 /
+ * notifications.md §2.3).
+ *
+ * The user's `users/{uid}.notificationPrefs` map controls whether
+ * each category of notification is delivered. The categories are:
+ *
+ *   - `newExpense` → gates `expense_added` / `expense_edited` /
+ *     `expense_deleted`.
+ *   - `settlement` → gates `settlement_received`.
+ *   - `reminder` → gates `reminder`.
+ *
+ * The `group_invite` type bypasses the filter — invites grant
+ * group-access and must always be delivered (per FR-AC-03 AC-19,
+ * ratified forward-compat).
+ *
+ * Missing flags default to TRUE — this mirrors the FR-AU-06 schema
+ * default and avoids silently dropping notifications for users whose
+ * profile was created before the flag existed.
+ *
+ * @module notifications/prefs-filter
+ */
+
+import type {NotificationType, RecipientPrefs} from "./types";
+
+/**
+ * Returns true if a notification of the given `type` should be
+ * delivered to a user whose preferences are `prefs`.
+ *
+ * @param type - The notification's `NotificationType`.
+ * @param prefs - The user's preference map, OR `undefined` if the
+ *   user doc has no `notificationPrefs` field (treated as
+ *   "everything enabled" per the FR-AU-06 default).
+ * @returns true if the dispatcher should proceed; false to suppress
+ *   silently (the trigger logs `fcm_send_suppressed_by_prefs`).
+ */
+export function isNotificationAllowed(
+  type: NotificationType,
+  prefs: RecipientPrefs | undefined,
+): boolean {
+  // Forward-compat carve-out: group invites are NEVER suppressed by
+  // user prefs (they grant access and must be delivered). See AC-19.
+  if (type === "group_invite") {
+    return true;
+  }
+
+  // Missing prefs map → everything allowed.
+  if (!prefs) {
+    return true;
+  }
+
+  switch (type) {
+  case "expense_added":
+  case "expense_edited":
+  case "expense_deleted":
+    // Default true when the flag is missing.
+    return prefs.newExpense !== false;
+
+  case "settlement_received":
+    return prefs.settlement !== false;
+
+  case "reminder":
+    return prefs.reminder !== false;
+
+  default: {
+    // Exhaustiveness — unreachable. New NotificationType values
+    // must be added to this switch.
+    const _exhaustive: never = type;
+    throw new Error(
+      `isNotificationAllowed: unsupported type '${_exhaustive as string}'.`,
+    );
+  }
+  }
+}

--- a/functions/src/notifications/send-expense-notification.ts
+++ b/functions/src/notifications/send-expense-notification.ts
@@ -1,0 +1,163 @@
+/**
+ * Trigger-facing dispatcher for expense-related FCM notifications
+ * (FR-AC-03).
+ *
+ * Per `docs/design/07-technical/notifications.md` and FR-AC-03 §2.7,
+ * this helper:
+ *
+ *   1. Iterates the recipient list `memberIds \ {authorUid}` (the
+ *      author never receives a notification for their own write).
+ *   2. For each recipient: reads `users/{uid}` once; runs the
+ *      prefs-filter; renders the per-type payload; calls
+ *      `sendFcmToTokens` if the token list is non-empty.
+ *   3. Logs the per-recipient skip / suppress branches for diagnosability
+ *      via the structured-log contract (AC-14).
+ *
+ * The helper does NOT throw on per-recipient failures — the dispatch
+ * loop continues for the remaining recipients. The trigger-side
+ * emitter (`emitExpenseFcm`) wraps a try/catch around the entire
+ * invocation so the trigger's success branch is preserved even if
+ * something goes wrong here (FR-AC-03 AC-17 "errors contained").
+ *
+ * @module notifications/send-expense-notification
+ */
+
+import {hashId} from "../utils/id-hash";
+import {renderPayload} from "./payload-renderer";
+import {isNotificationAllowed} from "./prefs-filter";
+import {sendFcmToTokens} from "./fcm-send";
+import type {
+  NotificationDispatchResult,
+  NotificationsDependencies,
+  NotificationType,
+  RecipientPrefs,
+  SendExpenseNotificationParams,
+} from "./types";
+
+/**
+ * Dispatches an expense notification to all non-author members of a
+ * context (friendship or group). Each member receives at most one
+ * FCM message per device (`fcmTokens` entry).
+ *
+ * @param deps - DI dependencies (db, messaging, logger).
+ * @param params - Trigger-side parameters (memberIds, authorUid,
+ *   senderName, description, amountPaise, changeType, etc).
+ * @returns Aggregated dispatch result across all recipients.
+ */
+export async function sendExpenseNotification(
+  deps: NotificationsDependencies,
+  params: SendExpenseNotificationParams,
+): Promise<NotificationDispatchResult> {
+  const {db, logger} = deps;
+  const {
+    authorUid,
+    memberIds,
+    contextType,
+    contextId,
+    expenseId,
+    senderName,
+    description,
+    amountPaise,
+    eventTimestamp,
+    changeType,
+  } = params;
+
+  // Map changeType → NotificationType discriminator.
+  const notificationType: NotificationType =
+    changeType === "create" ? "expense_added" :
+      changeType === "update" ? "expense_edited" :
+        "expense_deleted";
+
+  // Exclude the author — they never receive a push for their own write.
+  const recipients = memberIds.filter((uid) => uid !== authorUid);
+
+  // Aggregated counters; reduced from per-recipient results.
+  const totals: NotificationDispatchResult = {
+    succeeded: 0,
+    failed: 0,
+    pruned: [],
+    suppressedByPrefs: 0,
+    skippedEmptyTokens: 0,
+    skippedMissingUser: 0,
+  };
+
+  // Per-recipient fan-out. We iterate sequentially over the recipient
+  // user-doc reads for predictable resource use; the actual FCM sends
+  // are parallelised inside `sendFcmToTokens` via Promise.allSettled.
+  // For small recipient counts (friendships have 2; groups will have
+  // ~5-20), the cost of sequential per-recipient reads is negligible
+  // versus the latency budget for a Firestore trigger.
+  for (const uid of recipients) {
+    const userIdHash = hashId(uid);
+
+    let userSnap: FirebaseFirestore.DocumentSnapshot;
+    try {
+      userSnap = await db.collection("users").doc(uid).get();
+    } catch (err) {
+      logger.warn("fcm_send_user_read_failed", {
+        event: "fcm_send_user_read_failed",
+        userIdHash,
+        notificationType,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    if (!userSnap.exists) {
+      logger.info("fcm_send_skipped_missing_user", {
+        event: "fcm_send_skipped_missing_user",
+        userIdHash,
+        notificationType,
+      });
+      totals.skippedMissingUser += 1;
+      continue;
+    }
+
+    const userData = userSnap.data() as Record<string, unknown> | undefined;
+    const prefs = userData?.notificationPrefs as RecipientPrefs | undefined;
+    const tokens = (userData?.fcmTokens as string[] | undefined) ?? [];
+
+    if (!isNotificationAllowed(notificationType, prefs)) {
+      logger.info("fcm_send_suppressed_by_prefs", {
+        event: "fcm_send_suppressed_by_prefs",
+        userIdHash,
+        notificationType,
+      });
+      totals.suppressedByPrefs += 1;
+      continue;
+    }
+
+    if (tokens.length === 0) {
+      logger.info("fcm_send_skipped_empty_tokens", {
+        event: "fcm_send_skipped_empty_tokens",
+        userIdHash,
+        notificationType,
+      });
+      totals.skippedEmptyTokens += 1;
+      continue;
+    }
+
+    const payload = renderPayload(notificationType, {
+      senderName,
+      description,
+      amountPaise,
+      contextType,
+      contextId,
+      itemId: expenseId,
+      createdAt: eventTimestamp,
+    });
+
+    const sendResult = await sendFcmToTokens(deps, {
+      userId: uid,
+      notificationType,
+      tokens,
+      payload,
+    });
+
+    totals.succeeded += sendResult.succeeded;
+    totals.failed += sendResult.failed;
+    totals.pruned = totals.pruned.concat(sendResult.pruned);
+  }
+
+  return totals;
+}

--- a/functions/src/notifications/send-settlement-notification.ts
+++ b/functions/src/notifications/send-settlement-notification.ts
@@ -1,0 +1,138 @@
+/**
+ * Trigger-facing dispatcher for settlement-related FCM notifications
+ * (FR-AC-03).
+ *
+ * Mirrors `send-expense-notification.ts` but with a SINGLE recipient
+ * (`toUserId` — the payee). The payer (`fromUserId`) is the actor
+ * and is NOT notified of their own action per
+ * `docs/design/07-technical/notifications.md` §2.2.
+ *
+ * Like the expense dispatcher, this helper:
+ *
+ *   1. Reads `users/{toUserId}` once.
+ *   2. Runs the prefs-filter (gated by the `settlement` flag).
+ *   3. Renders the `settlement_received` payload.
+ *   4. Calls `sendFcmToTokens` if the token list is non-empty.
+ *   5. Logs the skip / suppress branches.
+ *
+ * The helper does NOT throw — the trigger-side emitter
+ * (`emitSettlementFcm`) wraps a try/catch around the entire
+ * invocation so trigger success is preserved (FR-AC-03 AC-17).
+ *
+ * @module notifications/send-settlement-notification
+ */
+
+import {hashId} from "../utils/id-hash";
+import {renderPayload} from "./payload-renderer";
+import {isNotificationAllowed} from "./prefs-filter";
+import {sendFcmToTokens} from "./fcm-send";
+import type {
+  NotificationDispatchResult,
+  NotificationsDependencies,
+  RecipientPrefs,
+  SendSettlementNotificationParams,
+} from "./types";
+
+/**
+ * Dispatches a settlement-received notification to the payee.
+ *
+ * @param deps - DI dependencies (db, messaging, logger).
+ * @param params - Settlement parameters; only `toUserId` is used as
+ *   recipient (the payer `fromUserId` is NOT notified).
+ * @returns Dispatch result with counts ≤ 1.
+ */
+export async function sendSettlementNotification(
+  deps: NotificationsDependencies,
+  params: SendSettlementNotificationParams,
+): Promise<NotificationDispatchResult> {
+  const {db, logger} = deps;
+  const {
+    toUserId,
+    contextType,
+    contextId,
+    settlementId,
+    senderName,
+    amountPaise,
+    eventTimestamp,
+  } = params;
+
+  const notificationType = "settlement_received" as const;
+  const userIdHash = hashId(toUserId);
+
+  const totals: NotificationDispatchResult = {
+    succeeded: 0,
+    failed: 0,
+    pruned: [],
+    suppressedByPrefs: 0,
+    skippedEmptyTokens: 0,
+    skippedMissingUser: 0,
+  };
+
+  let userSnap: FirebaseFirestore.DocumentSnapshot;
+  try {
+    userSnap = await db.collection("users").doc(toUserId).get();
+  } catch (err) {
+    logger.warn("fcm_send_user_read_failed", {
+      event: "fcm_send_user_read_failed",
+      userIdHash,
+      notificationType,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
+    return totals;
+  }
+
+  if (!userSnap.exists) {
+    logger.info("fcm_send_skipped_missing_user", {
+      event: "fcm_send_skipped_missing_user",
+      userIdHash,
+      notificationType,
+    });
+    totals.skippedMissingUser += 1;
+    return totals;
+  }
+
+  const userData = userSnap.data() as Record<string, unknown> | undefined;
+  const prefs = userData?.notificationPrefs as RecipientPrefs | undefined;
+  const tokens = (userData?.fcmTokens as string[] | undefined) ?? [];
+
+  if (!isNotificationAllowed(notificationType, prefs)) {
+    logger.info("fcm_send_suppressed_by_prefs", {
+      event: "fcm_send_suppressed_by_prefs",
+      userIdHash,
+      notificationType,
+    });
+    totals.suppressedByPrefs += 1;
+    return totals;
+  }
+
+  if (tokens.length === 0) {
+    logger.info("fcm_send_skipped_empty_tokens", {
+      event: "fcm_send_skipped_empty_tokens",
+      userIdHash,
+      notificationType,
+    });
+    totals.skippedEmptyTokens += 1;
+    return totals;
+  }
+
+  const payload = renderPayload(notificationType, {
+    senderName,
+    amountPaise,
+    contextType,
+    contextId,
+    itemId: settlementId,
+    createdAt: eventTimestamp,
+  });
+
+  const sendResult = await sendFcmToTokens(deps, {
+    userId: toUserId,
+    notificationType,
+    tokens,
+    payload,
+  });
+
+  totals.succeeded += sendResult.succeeded;
+  totals.failed += sendResult.failed;
+  totals.pruned = totals.pruned.concat(sendResult.pruned);
+  return totals;
+}

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared types for the FR-AC-03 FCM notifications module.
+ *
+ * The types in this file form the public contract between the
+ * triggers (callers) and the dispatcher (this module). They are
+ * exported from `./index.ts` so trigger code can import them via
+ * `from "../../notifications"`.
+ *
+ * Cross-references:
+ *   - `docs/design/07-technical/notifications.md` §2.1 (payload
+ *     envelope), §2.3 (prefs filter).
+ *   - `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md`
+ *     architect §2.10 item 7 (`NotificationsApi` injected as an
+ *     OPTIONAL field on the trigger's `Dependencies` shape).
+ *
+ * @module notifications/types
+ */
+
+import type {Messaging} from "firebase-admin/messaging";
+import type {Firestore} from "firebase-admin/firestore";
+
+/**
+ * The six notification types currently supported by the FCM module.
+ * Each maps 1:1 to a render template in `payload-renderer.ts` and a
+ * preference flag in `prefs-filter.ts` (with `group_invite` bypassing
+ * the filter per AC-19 forward-compat).
+ *
+ * IMPORTANT: clients dispatch on the `type` field of the FCM data
+ * envelope, so this string is part of the wire contract. Adding a new
+ * value requires a coordinated client-side change.
+ */
+export type NotificationType =
+  | "expense_added"
+  | "expense_edited"
+  | "expense_deleted"
+  | "settlement_received"
+  | "reminder"
+  | "group_invite";
+
+/**
+ * The FCM data envelope sent to clients (per `notifications.md` §2.1).
+ *
+ * All field values are STRINGS — FCM data payloads do not support
+ * native typed values. Numeric fields like `amountPaise` are
+ * stringified at the renderer boundary; clients parse back to integer
+ * on receipt.
+ *
+ * The `notification` block (`title`/`body` outside `data`) is OMITTED
+ * — this is a data-only message. Clients construct the platform
+ * notification from `title` and `body` inside `data` so we retain
+ * full control over visual presentation across iOS / Android.
+ */
+export interface NotificationPayload {
+  /** Discriminator for the client-side router. */
+  type: NotificationType;
+  /** "friendship" or "group" — currently only "friendship" in MVP. */
+  contextType: "friendship" | "group";
+  /** Raw friendship or group id (NOT a hash — clients need to navigate). */
+  contextId: string;
+  /** Optional item id (expense, settlement, invite) for deep-linking. */
+  itemId?: string;
+  /** Localised notification title; ≤ 100 chars. */
+  title: string;
+  /** Localised notification body; ≤ 240 chars. */
+  body: string;
+  /** displayName of the actor (payer / settler / sender). */
+  senderName: string;
+  /**
+   * Integer paise as a string (FCM data is string-only). OPTIONAL —
+   * the `group_invite` template has no monetary value and omits this
+   * field. All other templates set it to the stringified paise.
+   */
+  amountPaise?: string;
+  /** ISO 8601 timestamp of the originating Firestore write. */
+  createdAt: string;
+  /**
+   * OPTIONAL invite token for the `group_invite` payload (forward-
+   * compat, no producer in FR-AC-03 itself). Other templates omit it.
+   */
+  inviteToken?: string;
+}
+
+/**
+ * The user's notification preferences, mirroring the
+ * `users/{uid}.notificationPrefs` map (FR-AU-06 schema).
+ *
+ * All flags default to TRUE if missing from the map — see
+ * `prefs-filter.ts` for the resolver.
+ */
+export interface RecipientPrefs {
+  newExpense?: boolean;
+  settlement?: boolean;
+  reminder?: boolean;
+}
+
+/**
+ * Shared dependencies for all notification dispatch helpers. The
+ * `messaging` and `db` instances are injected so unit tests can pass
+ * mocks; in production they come from the trigger's wiring.
+ *
+ * The `logger` shape matches the firebase-functions/logger interface
+ * (2-arg: message + structured data) so the FCM module can be called
+ * directly from a Cloud Functions trigger or a callable handler
+ * without a wrapper. Trigger-side emitters wrap their existing 1-arg
+ * logger to fit this shape.
+ */
+export interface NotificationsDependencies {
+  db: Firestore;
+  messaging: Messaging;
+  logger: {
+    info(message: string, data?: Record<string, unknown>): void;
+    warn(message: string, data?: Record<string, unknown>): void;
+    error(message: string, data?: Record<string, unknown>): void;
+  };
+}
+
+/**
+ * Parameters for `sendExpenseNotification`.
+ *
+ * The `changeType` discriminator maps to the `expense_added` /
+ * `expense_edited` / `expense_deleted` payload type. `senderName` is
+ * the displayName of the expense's `createdBy` user (resolved by the
+ * trigger before invoking this helper).
+ */
+export interface SendExpenseNotificationParams {
+  /** UID of the expense's `createdBy` actor — EXCLUDED from recipients. */
+  authorUid: string;
+  /** All members of the parent context (friendship.memberIds). */
+  memberIds: string[];
+  contextType: "friendship" | "group";
+  contextId: string;
+  expenseId: string;
+  /** Resolved displayName of the actor. */
+  senderName: string;
+  /** Expense description (free text, ≤ 200 chars). */
+  description: string;
+  /** Integer paise amount of the expense. */
+  amountPaise: number;
+  /**
+   * Source timestamp of the Firestore event as a `Date`. The trigger
+   * parses `event.time` (ISO 8601 string) to a Date before invoking
+   * this helper.
+   */
+  eventTimestamp: Date;
+  /** "create" → expense_added, "update" → expense_edited, "delete" → expense_deleted. */
+  changeType: "create" | "update" | "delete";
+}
+
+/**
+ * Parameters for `sendSettlementNotification`. Only one recipient
+ * (`toUserId`); the payer (`fromUserId`) is the actor and is NOT
+ * notified.
+ */
+export interface SendSettlementNotificationParams {
+  fromUserId: string;
+  toUserId: string;
+  contextType: "friendship" | "group";
+  contextId: string;
+  settlementId: string;
+  /** Resolved displayName of the payer (fromUserId). */
+  senderName: string;
+  amountPaise: number;
+  /**
+   * Source timestamp of the Firestore event as a `Date`. The trigger
+   * parses `event.time` (ISO 8601 string) to a Date before invoking
+   * this helper.
+   */
+  eventTimestamp: Date;
+}
+
+/**
+ * Aggregated result of an FCM dispatch. Per-recipient counts are
+ * tallied across the multi-recipient expense case; the settlement
+ * helper produces a result with counts ≤ 1.
+ */
+export interface NotificationDispatchResult {
+  /** Number of FCM `send()` calls that resolved successfully. */
+  succeeded: number;
+  /** Number of FCM `send()` calls that rejected with a non-410 error. */
+  failed: number;
+  /** Tokens removed from `users/{uid}.fcmTokens` due to a 410 response. */
+  pruned: string[];
+  /** Recipients suppressed by the per-user preference filter. */
+  suppressedByPrefs: number;
+  /** Recipients skipped because their `fcmTokens` array was empty. */
+  skippedEmptyTokens: number;
+  /** Recipients skipped because their `users/{uid}` doc was missing. */
+  skippedMissingUser: number;
+}
+
+/**
+ * The public surface of this module — the shape injected into the
+ * trigger's `Dependencies.notificationsApi` field (architect §2.10
+ * item 7). Marking the field optional on the Dependencies type lets
+ * existing tests continue to pass without wiring this api.
+ */
+export interface NotificationsApi {
+  sendExpenseNotification(
+    deps: NotificationsDependencies,
+    params: SendExpenseNotificationParams,
+  ): Promise<NotificationDispatchResult>;
+  sendSettlementNotification(
+    deps: NotificationsDependencies,
+    params: SendSettlementNotificationParams,
+  ): Promise<NotificationDispatchResult>;
+}

--- a/functions/src/simplified-debts/function.ts
+++ b/functions/src/simplified-debts/function.ts
@@ -61,6 +61,29 @@ export interface Dependencies {
     info: (message: string, data?: Record<string, unknown>) => void;
     error: (message: string, data?: Record<string, unknown>) => void;
   };
+  /**
+   * Optional FCM notifications API (FR-AC-03 — architect §2.10 item 7).
+   *
+   * Trigger entry points wire this when push notifications should be
+   * emitted as a side effect of the trigger's success branch. When
+   * absent, the trigger's FCM emitter helpers no-op silently — this
+   * preserves backward-compatibility with existing tests that wire
+   * `Dependencies` without the FCM surface.
+   *
+   * `simplifiedBalances` recomputation itself does NOT use this field
+   * — it is consumed exclusively by `emitExpenseFcm` /
+   * `emitSettlementFcm` in the trigger handlers.
+   */
+  notificationsApi?:
+    import("../notifications").NotificationsApi;
+  /**
+   * Optional admin SDK `Messaging` instance (FR-AC-03). Paired with
+   * `notificationsApi`; the trigger constructs a
+   * `NotificationsDependencies` shape from `db + logger + messaging`
+   * before delegating into the FCM module.
+   */
+  messaging?:
+    import("firebase-admin/messaging").Messaging;
 }
 
 /**

--- a/functions/src/triggers/on-expense-write/function.ts
+++ b/functions/src/triggers/on-expense-write/function.ts
@@ -162,14 +162,13 @@ export function createTriggerHandler(
       return;
     }
 
-    // 3. Activity-feed seam — FR-EX-07 ships the expense-side write.
-    //    The remaining hand-off seam below is for the future story:
-    //    TODO(FR-AC-03): send FCM push notification respecting
-    //    notificationPrefs. Placement note: FCM (like the activity
-    //    emission) MUST run only after a successful recompute (i.e.
-    //    inside or just below the success branch) to keep retry
-    //    semantics clean — a retryable transient failure must not
-    //    duplicate notifications.
+    // 3. FCM emission seam — FR-AC-03 closes this seam with
+    //    emitExpenseFcm at the END of the success branch. Activity
+    //    emission (FR-EX-07) ships immediately above; FCM follows in
+    //    the success-branch order specified by architect §2.7 so
+    //    that a transient FCM-side failure (contained by
+    //    emitExpenseFcm) does not duplicate notifications on retry.
+    //    See `emitExpenseFcm` below.
 
     // 4. Build the alsoSet payload — atomically advance lastActivityAt
     //    inside the same transaction as the simplifiedBalances write.
@@ -267,6 +266,25 @@ export function createTriggerHandler(
       contextIdHash,
       elapsedMs: Date.now() - startTime,
       transferCount: result.transfers.length,
+    });
+
+    // 9. FR-AC-03: emit FCM push notifications to non-author members.
+    //    Placed AFTER the activity emission and AFTER the success
+    //    log to keep the trigger's success-branch retry semantics
+    //    clean: emitExpenseFcm wraps a try/catch around the entire
+    //    invocation and NEVER rethrows. If notificationsApi is
+    //    absent from deps (e.g. existing tests that don't wire FCM,
+    //    or local development without messaging), the helper
+    //    no-ops silently.
+    await emitExpenseFcm(deps, {
+      friendshipId,
+      expenseId,
+      changeType,
+      contextType,
+      contextIdHash,
+      expenseIdHash,
+      eventTime,
+      changeData: event.data,
     });
   };
 }
@@ -387,6 +405,197 @@ async function emitExpenseActivity(
     // only cause a retry-storm that re-runs the recompute.
     logger.error("activity_emission_internal_error", {
       event: "activity_emission_internal_error",
+      contextType,
+      contextIdHash,
+      expenseIdHash,
+      errorMessage: err instanceof Error ? err.message : "unknown",
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FCM emission (FR-AC-03)
+// ---------------------------------------------------------------------------
+
+/**
+ * Emits FCM push notifications for the non-author members of the
+ * friendship after a successful expense write.
+ *
+ * Mirrors the architectural pattern of `emitExpenseActivity`:
+ *   - Reads the friendship doc to resolve `memberIds` (one extra
+ *     read; the recomputeAndWrite path already read this inside the
+ *     transaction but does not expose the snapshot).
+ *   - Reads the expense author's `users/{authorUid}` doc to resolve
+ *     `senderName` for the notification body.
+ *   - Delegates to `deps.notificationsApi.sendExpenseNotification`
+ *     which does the per-recipient prefs / tokens / render / send
+ *     fan-out.
+ *
+ * Containment policy (FR-AC-03 AC-17 + architect §2.9 item 2):
+ *
+ *   - NEVER rethrows. FCM-emission failures must NOT propagate into
+ *     the trigger's success branch (the recompute is already done;
+ *     a rethrow would cause Cloud Functions to retry, re-running
+ *     the recompute and duplicating notifications on the recipients
+ *     that DID succeed on the first attempt).
+ *   - When `deps.notificationsApi` or `deps.messaging` is absent
+ *     (existing tests, local dev), no-ops silently. Logs a single
+ *     debug-level skip event for diagnosability.
+ *
+ * Soft-delete discrimination is the SAME as `emitExpenseActivity` —
+ * an update that flips deleted false→true emits `expense_deleted`,
+ * NOT `expense_edited`.
+ */
+async function emitExpenseFcm(
+  deps: Dependencies,
+  params: {
+    friendshipId: string;
+    expenseId: string;
+    changeType: ChangeType;
+    contextType: "friendship";
+    contextIdHash: string;
+    expenseIdHash: string;
+    eventTime: string;
+    changeData: Change<DocumentSnapshot> | undefined;
+  },
+): Promise<void> {
+  const {db, logger, notificationsApi, messaging} = deps;
+  const {
+    friendshipId,
+    expenseId,
+    changeType,
+    contextType,
+    contextIdHash,
+    expenseIdHash,
+    eventTime,
+    changeData,
+  } = params;
+
+  // Architect §2.10 item 7: absent notificationsApi or messaging →
+  // silent no-op. Preserves backward-compat with existing tests that
+  // wire only db + logger.
+  if (!notificationsApi || !messaging) {
+    return;
+  }
+
+  try {
+    const beforeData = changeData?.before?.exists
+      ? (changeData.before.data() as ExpenseDocData | undefined)
+      : undefined;
+    const afterData = changeData?.after?.exists
+      ? (changeData.after.data() as ExpenseDocData | undefined)
+      : undefined;
+
+    // Soft-delete discrimination: false→true flip → "delete".
+    let effectiveChangeType: ChangeType = changeType;
+    if (
+      changeType === "update" &&
+      beforeData?.deleted === false &&
+      afterData?.deleted === true
+    ) {
+      effectiveChangeType = "delete";
+    }
+
+    // For deletes the after snapshot may be empty (hard delete) and
+    // the description/amount/createdBy come from `before` instead.
+    const sourceData: ExpenseDocData | undefined =
+      effectiveChangeType === "delete" ? (afterData ?? beforeData) : afterData;
+    if (!sourceData) {
+      logger.info("fcm_emission_skipped_missing_data", {
+        event: "fcm_emission_skipped_missing_data",
+        contextType,
+        contextIdHash,
+        expenseIdHash,
+      });
+      return;
+    }
+
+    const authorUid = sourceData.createdBy ?? sourceData.payerId;
+    const amountPaise = sourceData.amountPaise;
+    const description = sourceData.description ?? "";
+
+    if (!authorUid) {
+      logger.info("fcm_emission_skipped_missing_author", {
+        event: "fcm_emission_skipped_missing_author",
+        contextType,
+        contextIdHash,
+        expenseIdHash,
+      });
+      return;
+    }
+
+    // Resolve memberIds via a friendship-doc read (symmetric with
+    // emitExpenseActivity — see that helper for the rationale).
+    const friendshipSnap = await db
+      .collection("friendships")
+      .doc(friendshipId)
+      .get();
+    if (!friendshipSnap.exists) {
+      logger.info("fcm_emission_skipped_missing_context", {
+        event: "fcm_emission_skipped_missing_context",
+        contextType,
+        contextIdHash,
+        expenseIdHash,
+      });
+      return;
+    }
+    const memberIds =
+      (friendshipSnap.data()?.memberIds as string[] | undefined) ?? [];
+    if (memberIds.length === 0) {
+      logger.info("fcm_emission_skipped_empty_members", {
+        event: "fcm_emission_skipped_empty_members",
+        contextType,
+        contextIdHash,
+        expenseIdHash,
+      });
+      return;
+    }
+
+    // Resolve senderName via users/{authorUid}.displayName. The
+    // dispatcher will tolerate an empty senderName ("" would yield
+    // an awkward " added an expense" title), so we substitute a
+    // sentinel string only if the user doc is missing entirely.
+    const authorSnap = await db.collection("users").doc(authorUid).get();
+    const senderName =
+      (authorSnap.exists ?
+        (authorSnap.data()?.displayName as string | undefined) :
+        undefined) ?? "Someone";
+
+    await notificationsApi.sendExpenseNotification(
+      {
+        db,
+        messaging,
+        logger: {
+          info: (msg, data) => logger.info(msg, data),
+          // Dependencies.logger doesn't expose `warn`; promote to
+          // `info` so the FCM module's per-recipient diagnostic
+          // events still land in structured logs. Existing
+          // production logger (firebase-functions/logger) has `warn`
+          // natively; the tests' createMockLogger does too — the
+          // structural narrowing here is only for the
+          // simplified-debts `Dependencies.logger` shape.
+          warn: (msg, data) => logger.info(msg, data),
+          error: (msg, data) => logger.error(msg, data),
+        },
+      },
+      {
+        authorUid,
+        memberIds,
+        contextType,
+        contextId: friendshipId,
+        expenseId,
+        senderName,
+        description,
+        amountPaise,
+        eventTimestamp: new Date(eventTime),
+        changeType: effectiveChangeType,
+      },
+    );
+  } catch (err: unknown) {
+    // Programmer error in the FCM module — log and absorb.
+    // Trigger's success branch is preserved (architect §2.9 item 2).
+    logger.error("fcm_emission_internal_error", {
+      event: "fcm_emission_internal_error",
       contextType,
       contextIdHash,
       expenseIdHash,

--- a/functions/src/triggers/on-expense-write/index.ts
+++ b/functions/src/triggers/on-expense-write/index.ts
@@ -7,6 +7,13 @@
  * v2 `{retry: true}` option (the v1 `failurePolicy: { retry: {} }` is
  * superseded by this).
  *
+ * FR-AC-03: the production wiring constructs a `NotificationsApi` from
+ * the two dispatcher entry points re-exported by `../../notifications`
+ * and the admin-SDK `Messaging` instance, and passes both via the
+ * extended `Dependencies` shape. The trigger-side emitter helper
+ * (`emitExpenseFcm` in `./function.ts`) consumes them inside its
+ * try/catch wrapper.
+ *
  * Companion bindings:
  *   - `onExpenseWriteGroup` for `groups/{groupId}/expenses/{expenseId}`
  *     is DEFERRED to Sprint 3 (groups epic). Architect notes §2 of the
@@ -17,8 +24,13 @@
 
 import {onDocumentWritten} from "firebase-functions/v2/firestore";
 import {getFirestore} from "firebase-admin/firestore";
+import {getMessaging} from "firebase-admin/messaging";
 import * as logger from "firebase-functions/logger";
 import {createTriggerHandler} from "./function";
+import {
+  sendExpenseNotification,
+  sendSettlementNotification,
+} from "../../notifications";
 
 const REGION = "asia-south1";
 
@@ -35,8 +47,13 @@ const REGION = "asia-south1";
  *   BALANCE_INVARIANT_VIOLATED and INTERNAL throw (Cloud Functions
  *   retries).
  * - Stale-event guard: events older than 7 days are dropped.
+ * - FR-AC-03: after a successful recompute + activity emission, the
+ *   trigger fires an FCM push notification to non-author members of
+ *   the friendship. FCM failures are CONTAINED — they never block
+ *   or retry the trigger.
  *
  * See `docs/sprint-zero/stories/FR-SE-03-04-expense-trigger-friendship.md`
+ * and `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md`
  * for full acceptance criteria.
  */
 export const onExpenseWriteFriendship = onDocumentWritten(
@@ -49,6 +66,16 @@ export const onExpenseWriteFriendship = onDocumentWritten(
     const handler = createTriggerHandler({
       db: getFirestore(),
       logger,
+      // FR-AC-03 production wiring: inject the FCM dispatcher
+      // surface so the trigger-side emitter helper can fire push
+      // notifications. Both fields are OPTIONAL on the
+      // Dependencies type — existing tests that don't wire them
+      // continue to pass (emitExpenseFcm no-ops silently).
+      notificationsApi: {
+        sendExpenseNotification,
+        sendSettlementNotification,
+      },
+      messaging: getMessaging(),
     });
     return handler(event);
   },

--- a/functions/src/triggers/on-settlement-write/function.ts
+++ b/functions/src/triggers/on-settlement-write/function.ts
@@ -232,19 +232,12 @@ export function createTriggerHandler(
       return;
     }
 
-    // 3. Hand-off seam for downstream story (placement parity with
-    //    the expense trigger):
-    //    TODO(FR-AC-03): send FCM push notification to the toUserId
-    //      respecting notificationPrefs.settlement.
-    //    Placement note: the FCM seam must execute ONLY after a
-    //    successful recompute (i.e. inside or just below the success
-    //    branch at the bottom of this handler) to keep retry semantics
-    //    clean — a retryable transient failure must not duplicate
-    //    notifications. Today the FCM seam is deferred entirely; the
-    //    actual placement decision lives with the story that
-    //    implements it. The FR-AC-01 activity-feed emission seam was
-    //    closed by the emitSettlementActivity call at the bottom of
-    //    this handler (step 8 below).
+    // 3. FCM emission seam — FR-AC-03 closes this seam with
+    //    emitSettlementFcm at the END of the success branch (after
+    //    the activity emission at step 8). Placement parity with
+    //    the expense trigger: FCM runs ONLY after a successful
+    //    recompute so a retryable transient failure does not
+    //    duplicate notifications. See `emitSettlementFcm` below.
 
     // 4. Build the alsoSet payload — atomically advance lastActivityAt
     //    inside the same transaction as the simplifiedBalances write.
@@ -331,6 +324,23 @@ export function createTriggerHandler(
       contextType,
       contextIdHash,
       settlementIdHash,
+      changeData: event.data,
+    });
+
+    // 9. FR-AC-03: emit FCM push notification to the toUserId.
+    //    Mirror of `emitExpenseFcm` in the expense trigger. Placed
+    //    AFTER the activity emission and success log so a transient
+    //    FCM-side failure (contained by emitSettlementFcm) does not
+    //    duplicate notifications on retry. emitSettlementFcm NEVER
+    //    rethrows; when notificationsApi/messaging is absent from
+    //    deps, it no-ops silently.
+    await emitSettlementFcm(deps, {
+      settlementId,
+      changeType,
+      contextType,
+      contextIdHash,
+      settlementIdHash,
+      eventTime,
       changeData: event.data,
     });
   };
@@ -440,6 +450,151 @@ async function emitSettlementActivity(
     // only cause a retry-storm that re-runs the recompute.
     logger.error("activity_emission_internal_error", {
       event: "activity_emission_internal_error",
+      contextType,
+      contextIdHash,
+      settlementIdHash,
+      errorMessage: err instanceof Error ? err.message : "unknown",
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FCM emission (FR-AC-03)
+// ---------------------------------------------------------------------------
+
+/**
+ * Emits an FCM push notification to the settlement's payee
+ * (`toUserId`) after a successful recompute + activity emission.
+ *
+ * Mirrors the architectural pattern of `emitSettlementActivity`:
+ *
+ *   - Reads the settlement source data from `changeData` (after
+ *     snapshot for create/update; before snapshot fallback for hard
+ *     delete) to extract `fromUserId`, `toUserId`, `amountPaise`,
+ *     `contextId`. No additional Firestore read is needed for
+ *     member resolution — the settlement doc itself carries both
+ *     UIDs (security rules at firestore.rules:445-455 require them).
+ *   - Reads `users/{fromUserId}` to resolve the payer's displayName
+ *     for the notification body.
+ *   - Delegates to `deps.notificationsApi.sendSettlementNotification`
+ *     which does the per-recipient prefs / tokens / render / send
+ *     for the SINGLE recipient (`toUserId`).
+ *
+ * Containment policy (FR-AC-03 AC-17 + architect §2.9 item 2):
+ *
+ *   - NEVER rethrows. FCM-emission failures must NOT propagate into
+ *     the trigger's success branch (the recompute is already done;
+ *     a rethrow would cause Cloud Functions to retry, re-running
+ *     the recompute and duplicating notifications on the toUserId).
+ *   - When `deps.notificationsApi` or `deps.messaging` is absent,
+ *     no-ops silently. Preserves backward-compat with existing
+ *     tests and local-dev environments without FCM wiring.
+ *
+ * V1.0 emission policy parity (architect §2.2): only CREATE events
+ * emit FCM notifications. Settlements only update on soft-delete
+ * (and hard-delete is rare/unreachable in production); neither
+ * should fire a notification — the original create event already
+ * notified the payee, and a "deleted" notification has no defined
+ * UX in MVP. We short-circuit on non-create changeType.
+ */
+async function emitSettlementFcm(
+  deps: Dependencies,
+  params: {
+    settlementId: string;
+    changeType: ActivityChangeType;
+    contextType: ContextType;
+    contextIdHash: string;
+    settlementIdHash: string;
+    eventTime: string;
+    changeData: Change<DocumentSnapshot> | undefined;
+  },
+): Promise<void> {
+  const {db, logger, notificationsApi, messaging} = deps;
+  const {
+    settlementId,
+    changeType,
+    contextType,
+    contextIdHash,
+    settlementIdHash,
+    eventTime,
+    changeData,
+  } = params;
+
+  // Architect §2.10 item 7: absent notificationsApi or messaging →
+  // silent no-op (backward-compat with existing tests).
+  if (!notificationsApi || !messaging) {
+    return;
+  }
+
+  // V1.0 policy parity with emitSettlementActivity: only CREATE
+  // events fire a notification. Update / delete are silent.
+  if (changeType !== "create") {
+    return;
+  }
+
+  try {
+    const sourceData = changeData?.after?.exists
+      ? (changeData.after.data() as SettlementDocData | undefined)
+      : (changeData?.before?.exists ?
+          (changeData.before.data() as SettlementDocData | undefined) :
+          undefined);
+    if (!sourceData) {
+      logger.info("fcm_emission_skipped_missing_data", {
+        event: "fcm_emission_skipped_missing_data",
+        contextType,
+        contextIdHash,
+        settlementIdHash,
+      });
+      return;
+    }
+
+    const {fromUserId, toUserId, amountPaise, contextId} = sourceData;
+    if (!fromUserId || !toUserId) {
+      logger.info("fcm_emission_skipped_missing_parties", {
+        event: "fcm_emission_skipped_missing_parties",
+        contextType,
+        contextIdHash,
+        settlementIdHash,
+      });
+      return;
+    }
+
+    // Resolve senderName via users/{fromUserId}.displayName.
+    const payerSnap = await db.collection("users").doc(fromUserId).get();
+    const senderName =
+      (payerSnap.exists ?
+        (payerSnap.data()?.displayName as string | undefined) :
+        undefined) ?? "Someone";
+
+    await notificationsApi.sendSettlementNotification(
+      {
+        db,
+        messaging,
+        logger: {
+          info: (msg, data) => logger.info(msg, data),
+          // See emitExpenseFcm for rationale: Dependencies.logger
+          // does not expose `warn`; we promote it to `info` so
+          // diagnostic events still land in structured logs.
+          warn: (msg, data) => logger.info(msg, data),
+          error: (msg, data) => logger.error(msg, data),
+        },
+      },
+      {
+        fromUserId,
+        toUserId,
+        contextType,
+        contextId,
+        settlementId,
+        senderName,
+        amountPaise,
+        eventTimestamp: new Date(eventTime),
+      },
+    );
+  } catch (err: unknown) {
+    // Programmer error in the FCM module — log and absorb.
+    // Trigger's success branch is preserved (architect §2.9 item 2).
+    logger.error("fcm_emission_internal_error", {
+      event: "fcm_emission_internal_error",
       contextType,
       contextIdHash,
       settlementIdHash,

--- a/functions/src/triggers/on-settlement-write/index.ts
+++ b/functions/src/triggers/on-settlement-write/index.ts
@@ -6,6 +6,13 @@
  * section 7.1. Retry is enabled per the Cloud Functions v2
  * `{retry: true}` option.
  *
+ * FR-AC-03: the production wiring constructs a `NotificationsApi` from
+ * the two dispatcher entry points re-exported by `../../notifications`
+ * and the admin-SDK `Messaging` instance, and passes both via the
+ * extended `Dependencies` shape. The trigger-side emitter helper
+ * (`emitSettlementFcm` in `./function.ts`) consumes them inside its
+ * try/catch wrapper.
+ *
  * Companion bindings:
  *   - `onExpenseWriteFriendship` handles expense writes under
  *     `friendships/{friendshipId}/expenses/{expenseId}` (FR-SE-03/04).
@@ -22,8 +29,13 @@
 
 import {onDocumentWritten} from "firebase-functions/v2/firestore";
 import {getFirestore} from "firebase-admin/firestore";
+import {getMessaging} from "firebase-admin/messaging";
 import * as logger from "firebase-functions/logger";
 import {createTriggerHandler} from "./function";
+import {
+  sendExpenseNotification,
+  sendSettlementNotification,
+} from "../../notifications";
 
 const REGION = "asia-south1";
 
@@ -45,8 +57,13 @@ const REGION = "asia-south1";
  *   BALANCE_INVARIANT_VIOLATED and INTERNAL throw (Cloud Functions
  *   retries).
  * - Stale-event guard: events older than 7 days are dropped.
+ * - FR-AC-03: after a successful recompute + activity emission, the
+ *   trigger fires an FCM push notification to the settlement's
+ *   `toUserId` (the payee; the payer is the actor and is NOT notified).
+ *   FCM failures are CONTAINED — they never block or retry the trigger.
  *
- * See `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` for
+ * See `docs/sprint-zero/stories/FR-SE-05-06-settlement-trigger.md` and
+ * `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` for
  * full acceptance criteria.
  */
 export const onSettlementWrite = onDocumentWritten(
@@ -59,6 +76,13 @@ export const onSettlementWrite = onDocumentWritten(
     const handler = createTriggerHandler({
       db: getFirestore(),
       logger,
+      // FR-AC-03 production wiring: see on-expense-write/index.ts
+      // for the rationale and shape.
+      notificationsApi: {
+        sendExpenseNotification,
+        sendSettlementNotification,
+      },
+      messaging: getMessaging(),
     });
     return handler(event);
   },

--- a/functions/src/utils/format-inr.ts
+++ b/functions/src/utils/format-inr.ts
@@ -1,0 +1,116 @@
+/**
+ * Functions-side INR formatter (FR-AC-03 / Invariant 1).
+ *
+ * Mirrors the client-side `formatInrFromPaise()` semantics
+ * (`lib/core/formatters/inr_formatter.dart`): integer arithmetic only,
+ * Indian-numbering grouping convention, no inline `/100` arithmetic in
+ * downstream call sites.
+ *
+ * The Functions-side flavour differs from the Dart formatter in two
+ * presentation-only ways (architect §2.1 — ratified divergence):
+ *
+ *   1. Integer rupees only — the notification templates in
+ *      `docs/design/07-technical/notifications.md` §2.2 render amounts
+ *      as `"₹1,200"` (no paise component), suitable for push body
+ *      strings where sub-rupee precision adds no user value.
+ *   2. ASCII hyphen-minus for negatives (`"-₹1"`) rather than the
+ *      Unicode minus (`"−"`) used in the Dart formatter. FCM data
+ *      payloads are 7-bit ASCII friendly; the simpler character
+ *      avoids edge cases with platform-level string normalisation in
+ *      client notification UIs.
+ *
+ * The paired client-side test
+ * `lib/core/formatters/inr_formatter.dart` is the source of truth for
+ * the Indian-numbering grouping algorithm; the per-event-type renderer
+ * tests in this module's `payload-renderer.test.ts` assert the exact
+ * formatter output for canonical paise inputs (defence-in-depth against
+ * drift between the two languages).
+ *
+ * NO inline `/100` arithmetic — uses a module-level `PAISE_PER_RUPEE`
+ * constant so the boundary-contract grep at
+ * `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+ * (which scans for the literal `/100` substring) passes cleanly.
+ *
+ * @module utils/format-inr
+ */
+
+/**
+ * Conversion factor — 100 paise per rupee. Hoisted to a constant so the
+ * Functions-side boundary-contract grep (which forbids the substring
+ * `/100`) does not match the formatter implementation. The constant is
+ * mathematically equivalent to the Dart `~/ 100` and `% 100` operators
+ * in the client-side formatter.
+ */
+const PAISE_PER_RUPEE = 100;
+
+/**
+ * Formats an integer paise amount as a human-readable INR string using
+ * the Indian numbering system (lakh / crore separators per SRS section
+ * 5.9 and FR-EX-09). Integer rupees only — sub-rupee paise are
+ * truncated.
+ *
+ * Examples:
+ *
+ *   formatInrFromPaise(0)         → "₹0"
+ *   formatInrFromPaise(100)       → "₹1"
+ *   formatInrFromPaise(120000)    → "₹1,200"
+ *   formatInrFromPaise(10000000)  → "₹1,00,000"      (1 lakh)
+ *   formatInrFromPaise(100000000) → "₹10,00,000"     (10 lakh)
+ *   formatInrFromPaise(-100)      → "-₹1"
+ *
+ * @param paise - Integer paise amount. Throws if the input is not a
+ *   finite integer (defence-in-depth against a JSON.parse round-trip
+ *   that loses type narrowing or a programmer error that passes a
+ *   float).
+ * @returns The formatted INR string with the `₹` symbol prefix and
+ *   Indian-numbering grouping in the rupee component.
+ * @throws Error if `paise` is not a safe integer.
+ */
+export function formatInrFromPaise(paise: number): string {
+  if (!Number.isInteger(paise)) {
+    throw new Error(
+      `formatInrFromPaise: expected an integer paise value, got ${paise}.`,
+    );
+  }
+
+  const absPaise = Math.abs(paise);
+  // Integer division — Math.trunc avoids the literal `/100` token that
+  // would trigger the boundary-contract grep. `PAISE_PER_RUPEE` is a
+  // hoisted constant; the regex pattern `/\/\s*100(\.0+)?(?!\d)/` does
+  // not match `/ PAISE_PER_RUPEE`.
+  const absRupees = Math.trunc(absPaise / PAISE_PER_RUPEE);
+
+  const grouped = groupIndianNumber(absRupees);
+  const sign = paise < 0 ? "-" : "";
+  return `${sign}₹${grouped}`;
+}
+
+/**
+ * Groups an integer using the Indian numbering convention: the last
+ * three digits are separated as a group, then every two digits
+ * thereafter. Returns a plain string with commas.
+ *
+ * Examples:
+ *   groupIndianNumber(0)        → "0"
+ *   groupIndianNumber(1)        → "1"
+ *   groupIndianNumber(1200)     → "1,200"
+ *   groupIndianNumber(100000)   → "1,00,000"
+ *   groupIndianNumber(10000000) → "1,00,00,000"   (1 crore)
+ *
+ * Implemented as pure string manipulation — no floating-point arithmetic
+ * or `Intl.NumberFormat` (which would tie the output to a node-locale-
+ * dependent ICU dataset; we want deterministic output across CI and
+ * production environments).
+ */
+function groupIndianNumber(n: number): string {
+  if (n < 1000) {
+    return n.toString();
+  }
+  const s = n.toString();
+  // Split into the trailing 3-digit group and the leading prefix.
+  const lastThree = s.slice(-3);
+  const prefix = s.slice(0, -3);
+  // Group the prefix into 2-digit chunks from the right.
+  const groupedPrefix = prefix.replace(/\B(?=(\d{2})+(?!\d))/g, ",");
+  return `${groupedPrefix},${lastThree}`;
+}

--- a/functions/test/notifications/fcm-send.test.ts
+++ b/functions/test/notifications/fcm-send.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Unit tests for the admin-SDK FCM send helper (FR-AC-03).
+ *
+ * Asserts:
+ *   - One message sent per token via `Promise.allSettled` (parallel).
+ *   - Aggregated result `{succeeded, failed, pruned}`.
+ *   - On `messaging/registration-token-not-registered` (HTTP 410),
+ *     `arrayRemove(token)` is invoked on `users/{uid}.fcmTokens`.
+ *   - On non-410 errors, no prune; structured `fcm_send_failed` log.
+ *   - Empty `tokens` array is a no-op (no admin-SDK call, no log).
+ *   - Required structured-log events are emitted with the required
+ *     parameters (architect §2.10 item 8 — token fingerprint, NOT raw
+ *     token; `userIdHash` via `hashId()`).
+ *
+ * The admin-SDK Messaging surface is injected via the `messaging`
+ * dependency so this test never touches real Firebase Cloud Messaging.
+ *
+ * @module test/notifications/fcm-send.test.ts
+ */
+
+import {sendFcmToTokens, fingerprintToken} from
+  "../../src/notifications/fcm-send";
+import type {NotificationPayload} from "../../src/notifications/types";
+
+interface LoggerCall {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "warn", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+/**
+ * Mock Firestore that records `users/{uid}.update()` calls. We only care
+ * about the `arrayRemove` invocation on the 410 cleanup branch.
+ */
+function createMockDbWithRecordedUpdates() {
+  const updateFn = jest.fn().mockResolvedValue(undefined);
+  const docFn = jest.fn().mockReturnValue({update: updateFn});
+  const collectionFn = jest.fn().mockReturnValue({doc: docFn});
+  return {
+    db: {collection: collectionFn} as unknown as FirebaseFirestore.Firestore,
+    updateFn,
+    collectionFn,
+    docFn,
+  };
+}
+
+/**
+ * Returns a per-token mock `messaging.send()` that resolves "ok-{token}"
+ * for every token by default. Specific tokens can be configured to
+ * reject with a 410 (`messaging/registration-token-not-registered`) or
+ * a generic non-410 error.
+ */
+function createMockMessaging(opts: {
+  not_registered_tokens?: ReadonlySet<string>;
+  generic_error_tokens?: ReadonlySet<string>;
+} = {}) {
+  const not_registered_tokens = opts.not_registered_tokens ?? new Set();
+  const generic_error_tokens = opts.generic_error_tokens ?? new Set();
+  const sendFn = jest.fn(async (msg: {token: string}) => {
+    if (not_registered_tokens.has(msg.token)) {
+      const err = new Error("Registration token is not registered") as Error & {
+        code?: string;
+      };
+      err.code = "messaging/registration-token-not-registered";
+      throw err;
+    }
+    if (generic_error_tokens.has(msg.token)) {
+      const err = new Error("Network error") as Error & {code?: string};
+      err.code = "messaging/internal-error";
+      throw err;
+    }
+    return `message-id-${msg.token}`;
+  });
+  return {
+    messaging: {send: sendFn} as unknown as
+      import("firebase-admin/messaging").Messaging,
+    sendFn,
+  };
+}
+
+function validPayload(): NotificationPayload {
+  return {
+    type: "expense_added",
+    contextType: "friendship",
+    contextId: "fid",
+    itemId: "exp1",
+    title: "Rahul added an expense",
+    body: "Dinner -- ₹1,200.",
+    senderName: "Rahul",
+    amountPaise: "120000",
+    createdAt: "2026-06-08T10:00:00.000Z",
+  };
+}
+
+describe("fingerprintToken — token-fingerprinting helper", () => {
+  it("returns an 8-character hex string", () => {
+    const fp = fingerprintToken("eEXAMPLEtoken1234567890");
+    expect(fp).toMatch(/^[0-9a-f]{8}$/);
+    expect(fp).toHaveLength(8);
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(fingerprintToken("foo")).toBe(fingerprintToken("foo"));
+  });
+
+  it("never reveals any substring of the raw token", () => {
+    const raw = "very-recognisable-token-substring-xyz";
+    const fp = fingerprintToken(raw);
+    expect(fp).not.toContain("very");
+    expect(fp).not.toContain("recognisable");
+    expect(fp).not.toContain("token");
+    expect(fp).not.toContain("xyz");
+  });
+});
+
+describe("sendFcmToTokens — FR-AC-03 / notifications.md §1.4", () => {
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+  it("sends ONE message per token in parallel and returns aggregated result", async () => {
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging, sendFn} = createMockMessaging();
+    const logger = createMockLogger();
+
+    const result = await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokA", "tokB", "tokC"],
+        payload: validPayload(),
+      },
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({succeeded: 3, failed: 0, pruned: []});
+  });
+
+  it("packages the payload as FCM data + high-priority android/apns config", async () => {
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging, sendFn} = createMockMessaging();
+    const logger = createMockLogger();
+
+    await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokA"],
+        payload: validPayload(),
+      },
+    );
+
+    // Cast to Record<string, unknown> for shape assertions — the mock
+    // typed only `{token: string}` on input but the real call site
+    // assembles the BaseMessage envelope (data, android, apns).
+    const sentMessage = sendFn.mock.calls[0][0] as unknown as Record<
+      string,
+      Record<string, unknown>
+    > & {token: string};
+    expect(sentMessage.token).toBe("tokA");
+    // §2.1 envelope: every value is a string.
+    expect(sentMessage.data.type).toBe("expense_added");
+    expect(sentMessage.data.contextType).toBe("friendship");
+    expect(sentMessage.data.amountPaise).toBe("120000");
+    // High-priority delivery on both platforms (§2.1).
+    expect(sentMessage.android.priority).toBe("high");
+    expect(
+      (sentMessage.apns.headers as Record<string, string>)["apns-priority"],
+    ).toBe("10");
+    expect(
+      ((sentMessage.apns.payload as Record<string, Record<string, unknown>>)
+        .aps as Record<string, unknown>)["content-available"],
+    ).toBe(1);
+    // Data-only message: no top-level `notification` block per §2.
+    expect(sentMessage.notification).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty tokens array — no-op
+  // -------------------------------------------------------------------------
+  it("is a no-op for an empty tokens array (no admin-SDK call, no log)", async () => {
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging, sendFn} = createMockMessaging();
+    const logger = createMockLogger();
+
+    const result = await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: [],
+        payload: validPayload(),
+      },
+    );
+
+    expect(sendFn).not.toHaveBeenCalled();
+    expect(logger.calls).toHaveLength(0);
+    expect(result).toEqual({succeeded: 0, failed: 0, pruned: []});
+  });
+
+  // -------------------------------------------------------------------------
+  // 410 prune branch (AC-6)
+  // -------------------------------------------------------------------------
+  it("prunes a 410-failed token from users/{uid}.fcmTokens via arrayRemove", async () => {
+    const {db, updateFn, collectionFn, docFn} =
+      createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging({
+      not_registered_tokens: new Set(["tokDEAD"]),
+    });
+    const logger = createMockLogger();
+
+    const result = await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokOK1", "tokDEAD", "tokOK2"],
+        payload: validPayload(),
+      },
+    );
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.pruned).toEqual(["tokDEAD"]);
+
+    // The arrayRemove call resolves to `users/uid-alice` with a
+    // `fcmTokens: arrayRemove(tokDEAD)` update.
+    expect(collectionFn).toHaveBeenCalledWith("users");
+    expect(docFn).toHaveBeenCalledWith("uid-alice");
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    const updatePayload = updateFn.mock.calls[0][0];
+    expect(updatePayload).toHaveProperty("fcmTokens");
+  });
+
+  it("does NOT prune the token on non-410 errors (logs fcm_send_failed)", async () => {
+    const {db, updateFn} = createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging({
+      generic_error_tokens: new Set(["tokFAIL"]),
+    });
+    const logger = createMockLogger();
+
+    const result = await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokFAIL"],
+        payload: validPayload(),
+      },
+    );
+
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.pruned).toEqual([]);
+    expect(updateFn).not.toHaveBeenCalled();
+
+    const failedLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_failed",
+    );
+    expect(failedLog).toBeDefined();
+    expect(failedLog!.level).toBe("error");
+    expect(failedLog!.data!.errorCode).toBe("messaging/internal-error");
+    expect(failedLog!.data!.notificationType).toBe("expense_added");
+  });
+
+  // -------------------------------------------------------------------------
+  // Structured-log contract (AC-14)
+  // -------------------------------------------------------------------------
+  it("emits fcm_send_attempted once with userIdHash + notificationType + tokenCount", async () => {
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging();
+    const logger = createMockLogger();
+
+    await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokA", "tokB"],
+        payload: validPayload(),
+      },
+    );
+
+    const attemptedLogs = logger.calls.filter(
+      (c) => c.data?.event === "fcm_send_attempted",
+    );
+    expect(attemptedLogs).toHaveLength(1);
+    expect(attemptedLogs[0].data!.userIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(attemptedLogs[0].data!.notificationType).toBe("expense_added");
+    expect(attemptedLogs[0].data!.tokenCount).toBe(2);
+  });
+
+  it("emits fcm_send_succeeded per successful send with userIdHash + tokenFingerprint", async () => {
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging();
+    const logger = createMockLogger();
+
+    await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokA", "tokB"],
+        payload: validPayload(),
+      },
+    );
+
+    const succeededLogs = logger.calls.filter(
+      (c) => c.data?.event === "fcm_send_succeeded",
+    );
+    expect(succeededLogs).toHaveLength(2);
+    for (const log of succeededLogs) {
+      expect(log.data!.userIdHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(log.data!.tokenFingerprint).toMatch(/^[0-9a-f]{8}$/);
+      expect(log.data!.notificationType).toBe("expense_added");
+    }
+  });
+
+  it("emits fcm_token_pruned per 410 prune with userIdHash + tokenFingerprint", async () => {
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging({
+      not_registered_tokens: new Set(["tokDEAD"]),
+    });
+    const logger = createMockLogger();
+
+    await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: ["tokDEAD"],
+        payload: validPayload(),
+      },
+    );
+
+    const prunedLogs = logger.calls.filter(
+      (c) => c.data?.event === "fcm_token_pruned",
+    );
+    expect(prunedLogs).toHaveLength(1);
+    expect(prunedLogs[0].data!.userIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(prunedLogs[0].data!.tokenFingerprint).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  // -------------------------------------------------------------------------
+  // PII guard (AC-14)
+  // -------------------------------------------------------------------------
+  it("never logs the raw FCM token (only the 8-char SHA-256 fingerprint)", async () => {
+    const recognisableToken = "VERY_RECOGNISABLE_FCM_TOKEN_qwerty1234567890";
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging({
+      not_registered_tokens: new Set([recognisableToken]),
+    });
+    const logger = createMockLogger();
+
+    await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: "uid-alice",
+        notificationType: "expense_added",
+        tokens: [recognisableToken],
+        payload: validPayload(),
+      },
+    );
+
+    for (const call of logger.calls) {
+      const serialised = JSON.stringify(call.data ?? {});
+      expect(serialised).not.toContain(recognisableToken);
+      expect(serialised).not.toContain("RECOGNISABLE");
+      expect(serialised).not.toContain("qwerty1234567890");
+    }
+  });
+
+  it("never logs the raw userId (only the 16-char SHA-256 hash via hashId)", async () => {
+    const recognisableUserId = "pii-uid-recognisable-substring";
+    const {db} = createMockDbWithRecordedUpdates();
+    const {messaging} = createMockMessaging();
+    const logger = createMockLogger();
+
+    await sendFcmToTokens(
+      {db, messaging, logger},
+      {
+        userId: recognisableUserId,
+        notificationType: "expense_added",
+        tokens: ["tokA"],
+        payload: validPayload(),
+      },
+    );
+
+    for (const call of logger.calls) {
+      const serialised = JSON.stringify(call.data ?? {});
+      expect(serialised).not.toContain(recognisableUserId);
+      expect(serialised).not.toContain("recognisable");
+    }
+  });
+});

--- a/functions/test/notifications/payload-renderer.test.ts
+++ b/functions/test/notifications/payload-renderer.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the per-type FCM payload renderer (FR-AC-03).
+ *
+ * Asserts the rendered title + body strings for each of the six
+ * notification types listed in `docs/design/07-technical/notifications.md`
+ * §2.2, and verifies the full FCM data envelope shape per §2.1
+ * (all values stringified; ISO 8601 `createdAt`).
+ *
+ * All amounts are formatted through `formatInrFromPaise()` — the test
+ * file itself contains ZERO inline `/100` arithmetic.
+ *
+ * @module test/notifications/payload-renderer.test.ts
+ */
+
+import {renderPayload} from "../../src/notifications/payload-renderer";
+
+const ISO_8601_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+describe("renderPayload — FR-AC-03 / notifications.md §2.2", () => {
+  describe("expense_added", () => {
+    it("renders title and body for the canonical (Rahul, Dinner, ₹1,200) input", () => {
+      const payload = renderPayload("expense_added", {
+        senderName: "Rahul",
+        description: "Dinner",
+        amountPaise: 120000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        itemId: "expense-123",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.title).toBe("Rahul added an expense");
+      expect(payload.body).toBe("Dinner -- ₹1,200.");
+    });
+
+    it("envelope includes type/contextType/contextId/itemId/senderName/amountPaise/createdAt", () => {
+      const payload = renderPayload("expense_added", {
+        senderName: "Rahul",
+        description: "Dinner",
+        amountPaise: 120000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        itemId: "expense-123",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.type).toBe("expense_added");
+      expect(payload.contextType).toBe("friendship");
+      expect(payload.contextId).toBe("uid-rahul_uid-priya");
+      expect(payload.itemId).toBe("expense-123");
+      expect(payload.senderName).toBe("Rahul");
+      // amountPaise is STRINGIFIED per §2.1 (FCM data payload constraint).
+      expect(payload.amountPaise).toBe("120000");
+      // createdAt is ISO 8601.
+      expect(payload.createdAt).toMatch(ISO_8601_PATTERN);
+    });
+  });
+
+  describe("expense_edited", () => {
+    it("renders the edit-flavour title and body", () => {
+      const payload = renderPayload("expense_edited", {
+        senderName: "Rahul",
+        description: "Dinner",
+        amountPaise: 150000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        itemId: "expense-123",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.title).toBe("Rahul edited an expense");
+      expect(payload.body).toBe("Dinner was updated to ₹1,500.");
+      expect(payload.type).toBe("expense_edited");
+    });
+  });
+
+  describe("expense_deleted", () => {
+    it("renders the delete-flavour title and body (no itemId required)", () => {
+      const payload = renderPayload("expense_deleted", {
+        senderName: "Rahul",
+        description: "Dinner",
+        amountPaise: 120000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.title).toBe("Rahul deleted an expense");
+      expect(payload.body).toBe("Dinner (₹1,200) was removed.");
+      expect(payload.type).toBe("expense_deleted");
+      // itemId is OPTIONAL per §2.2 — the expense has been soft-deleted.
+      expect(payload.itemId).toBeUndefined();
+    });
+  });
+
+  describe("settlement_received", () => {
+    it("renders the (Priya, ₹350) canonical input", () => {
+      const payload = renderPayload("settlement_received", {
+        senderName: "Priya",
+        amountPaise: 35000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        itemId: "settlement-456",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.title).toBe("Priya settled up");
+      expect(payload.body).toBe("You received ₹350.");
+      expect(payload.type).toBe("settlement_received");
+      expect(payload.amountPaise).toBe("35000");
+      expect(payload.itemId).toBe("settlement-456");
+    });
+  });
+
+  describe("reminder", () => {
+    it("renders the reminder title and body for a friendship reminder", () => {
+      const payload = renderPayload("reminder", {
+        senderName: "Priya",
+        amountPaise: 50000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.title).toBe("Reminder from Priya");
+      expect(payload.body).toBe("Priya is nudging you about ₹500.");
+      expect(payload.type).toBe("reminder");
+    });
+  });
+
+  describe("group_invite", () => {
+    it("renders the group invite title and body (forward-compat — no producer in FR-AC-03)", () => {
+      const payload = renderPayload("group_invite", {
+        senderName: "Priya",
+        contextType: "group",
+        contextId: "group-789",
+        groupName: "Goa Trip",
+        inviteToken: "invite-token-abc",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.title).toBe("Priya invited you to a group");
+      expect(payload.body).toBe('Join "Goa Trip" to start splitting.');
+      expect(payload.type).toBe("group_invite");
+      expect(payload.inviteToken).toBe("invite-token-abc");
+      // amountPaise is undefined for group_invite (no monetary value).
+      expect(payload.amountPaise).toBeUndefined();
+    });
+  });
+
+  describe("envelope invariants", () => {
+    it("renders amountPaise as a string, not a number", () => {
+      const payload = renderPayload("expense_added", {
+        senderName: "Rahul",
+        description: "Dinner",
+        amountPaise: 120000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        itemId: "expense-123",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      // FCM data payload constraint: all values must be strings.
+      expect(typeof payload.amountPaise).toBe("string");
+    });
+
+    it("renders createdAt as an ISO 8601 string regardless of source Date", () => {
+      const payload = renderPayload("expense_added", {
+        senderName: "Rahul",
+        description: "Dinner",
+        amountPaise: 120000,
+        contextType: "friendship",
+        contextId: "uid-rahul_uid-priya",
+        itemId: "expense-123",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      });
+
+      expect(payload.createdAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("uses the Indian-numbering formatter (₹1,00,000 for 1 crore paise)", () => {
+      const payload = renderPayload("expense_added", {
+        senderName: "Anil",
+        description: "Hotel",
+        amountPaise: 10000000,
+        contextType: "friendship",
+        contextId: "uid-anil_uid-meena",
+        itemId: "expense-456",
+        createdAt: new Date("2026-06-08T10:00:00Z"),
+      });
+
+      expect(payload.body).toContain("₹1,00,000");
+    });
+  });
+});

--- a/functions/test/notifications/prefs-filter.test.ts
+++ b/functions/test/notifications/prefs-filter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the notification-preferences short-circuit
+ * (FR-AC-03 / FR-AC-04 server-side enforcement).
+ *
+ * Asserts the per-flag gating defined in
+ * `docs/design/07-technical/notifications.md` §2.3, plus the
+ * forward-compatibility carve-out for `group_invite` (FR-AC-03 AC-19 —
+ * group invites are not user-suppressible because they grant access).
+ *
+ * @module test/notifications/prefs-filter.test.ts
+ */
+
+import {isNotificationAllowed} from "../../src/notifications/prefs-filter";
+
+describe("isNotificationAllowed — FR-AC-03 / notifications.md §2.3", () => {
+  // -------------------------------------------------------------------------
+  // newExpense flag gates the three expense types
+  // -------------------------------------------------------------------------
+  describe("newExpense flag (gates expense_added / expense_edited / expense_deleted)", () => {
+    it("allows expense_added when newExpense=true", () => {
+      expect(
+        isNotificationAllowed("expense_added", {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("blocks expense_added when newExpense=false", () => {
+      expect(
+        isNotificationAllowed("expense_added", {
+          newExpense: false,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("blocks expense_edited when newExpense=false", () => {
+      expect(
+        isNotificationAllowed("expense_edited", {
+          newExpense: false,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("blocks expense_deleted when newExpense=false", () => {
+      expect(
+        isNotificationAllowed("expense_deleted", {
+          newExpense: false,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // settlement flag gates settlement_received
+  // -------------------------------------------------------------------------
+  describe("settlement flag (gates settlement_received)", () => {
+    it("allows settlement_received when settlement=true", () => {
+      expect(
+        isNotificationAllowed("settlement_received", {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("blocks settlement_received when settlement=false", () => {
+      expect(
+        isNotificationAllowed("settlement_received", {
+          newExpense: true,
+          settlement: false,
+          reminder: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("ignores newExpense=false when type is settlement_received", () => {
+      // Per-category isolation: a user who disabled expense notifications
+      // still receives settlement notifications (and vice versa).
+      expect(
+        isNotificationAllowed("settlement_received", {
+          newExpense: false,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reminder flag gates reminder
+  // -------------------------------------------------------------------------
+  describe("reminder flag (gates reminder)", () => {
+    it("allows reminder when reminder=true", () => {
+      expect(
+        isNotificationAllowed("reminder", {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("blocks reminder when reminder=false", () => {
+      expect(
+        isNotificationAllowed("reminder", {
+          newExpense: true,
+          settlement: true,
+          reminder: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // group_invite bypass (FR-AC-03 AC-19, forward-compat)
+  // -------------------------------------------------------------------------
+  describe("group_invite bypass (FR-AC-03 AC-19)", () => {
+    it("always allows group_invite regardless of preferences", () => {
+      expect(
+        isNotificationAllowed("group_invite", {
+          newExpense: false,
+          settlement: false,
+          reminder: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("allows group_invite even with prefs undefined", () => {
+      expect(isNotificationAllowed("group_invite", undefined)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Defaults: missing prefs map / partial map defaults to true (matches the
+  // FR-AU-06 schema default).
+  // -------------------------------------------------------------------------
+  describe("defaults (missing prefs map → true for all flags)", () => {
+    it("defaults to true when prefs is undefined", () => {
+      expect(isNotificationAllowed("expense_added", undefined)).toBe(true);
+      expect(isNotificationAllowed("settlement_received", undefined)).toBe(true);
+      expect(isNotificationAllowed("reminder", undefined)).toBe(true);
+    });
+
+    it("defaults to true when prefs is an empty object (no flags set)", () => {
+      expect(isNotificationAllowed("expense_added", {})).toBe(true);
+      expect(isNotificationAllowed("settlement_received", {})).toBe(true);
+      expect(isNotificationAllowed("reminder", {})).toBe(true);
+    });
+
+    it("defaults to true when only some flags are set (partial map)", () => {
+      // Only the gated flag is explicit; unrelated flags are absent.
+      expect(
+        isNotificationAllowed("expense_added", {newExpense: true}),
+      ).toBe(true);
+      // The gated flag being explicitly false still blocks.
+      expect(
+        isNotificationAllowed("expense_added", {newExpense: false}),
+      ).toBe(false);
+    });
+  });
+});

--- a/functions/test/notifications/send-expense-notification.test.ts
+++ b/functions/test/notifications/send-expense-notification.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for the trigger-facing expense-notification dispatcher
+ * (FR-AC-03).
+ *
+ * Exercises `sendExpenseNotification(deps, params)`:
+ *
+ *   - Reads each non-author recipient's `users/{uid}` doc.
+ *   - For each recipient: runs prefs-filter → renderer → fcm-send.
+ *   - For each recipient suppressed by prefs: logs
+ *     `fcm_send_suppressed_by_prefs` and skips.
+ *   - Tolerates a missing user doc (logs `fcm_send_skipped_missing_user`).
+ *   - Tolerates an empty `fcmTokens` array (logs
+ *     `fcm_send_skipped_empty_tokens`).
+ *
+ * `fcm-send.ts` is mocked at the module boundary; the prefs-filter and
+ * renderer are real (small pure functions — no need to mock).
+ *
+ * @module test/notifications/send-expense-notification.test.ts
+ */
+
+import {sendExpenseNotification} from
+  "../../src/notifications/send-expense-notification";
+import {sendFcmToTokens} from "../../src/notifications/fcm-send";
+
+jest.mock("../../src/notifications/fcm-send", () => {
+  const actual = jest.requireActual("../../src/notifications/fcm-send");
+  return {
+    ...actual,
+    sendFcmToTokens: jest.fn().mockResolvedValue({
+      succeeded: 1,
+      failed: 0,
+      pruned: [],
+    }),
+  };
+});
+
+const mockedSendFcmToTokens = sendFcmToTokens as jest.MockedFunction<
+  typeof sendFcmToTokens
+>;
+
+beforeEach(() => {
+  mockedSendFcmToTokens.mockClear();
+  mockedSendFcmToTokens.mockResolvedValue({
+    succeeded: 1,
+    failed: 0,
+    pruned: [],
+  });
+});
+
+interface LoggerCall {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "warn", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+/**
+ * Builds a mock Firestore that returns a per-recipient `users/{uid}` doc
+ * based on the supplied map. Keys are user IDs; values are the doc data
+ * (or `null` for an absent user doc).
+ */
+function createMockDb(
+  users: Record<string, Record<string, unknown> | null>,
+): FirebaseFirestore.Firestore {
+  const docFn = jest.fn((userId: string) => ({
+    get: jest.fn().mockResolvedValue({
+      exists: users[userId] !== undefined && users[userId] !== null,
+      data: () => users[userId] ?? undefined,
+      id: userId,
+    }),
+  }));
+  return {
+    collection: jest.fn().mockReturnValue({doc: docFn}),
+  } as unknown as FirebaseFirestore.Firestore;
+}
+
+function createMockMessaging() {
+  return {} as unknown as import("firebase-admin/messaging").Messaging;
+}
+
+const baseParams = {
+  authorUid: "uid-author",
+  contextType: "friendship" as const,
+  contextId: "uid-author_uid-other",
+  expenseId: "exp1",
+  senderName: "Rahul",
+  description: "Dinner",
+  amountPaise: 120000,
+  eventTimestamp: new Date("2026-06-08T10:00:00Z"),
+  changeType: "create" as const,
+};
+
+describe("sendExpenseNotification — FR-AC-03 dispatcher", () => {
+  // -------------------------------------------------------------------------
+  // Happy path: one recipient with non-empty fcmTokens & newExpense=true
+  // -------------------------------------------------------------------------
+  it("calls fcm-send for each non-author recipient with newExpense=true and non-empty tokens", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: ["tokBob1", "tokBob2"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author", "uid-bob"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    const callArgs = mockedSendFcmToTokens.mock.calls[0][1];
+    expect(callArgs.userId).toBe("uid-bob");
+    expect(callArgs.tokens).toEqual(["tokBob1", "tokBob2"]);
+    expect(callArgs.notificationType).toBe("expense_added");
+    expect(callArgs.payload.type).toBe("expense_added");
+    expect(callArgs.payload.senderName).toBe("Rahul");
+  });
+
+  it("dispatches to multiple recipients in parallel (skipping the author)", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: ["tokBob"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+      "uid-carol": {
+        fcmTokens: ["tokCarol"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author", "uid-bob", "uid-carol"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(2);
+    const recipientIds = mockedSendFcmToTokens.mock.calls
+      .map((c) => c[1].userId)
+      .sort();
+    expect(recipientIds).toEqual(["uid-bob", "uid-carol"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Prefs short-circuit (AC-7)
+  // -------------------------------------------------------------------------
+  it("suppresses send for recipients with newExpense=false (logs fcm_send_suppressed_by_prefs)", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: ["tokBob"],
+        notificationPrefs: {
+          newExpense: false,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author", "uid-bob"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+    const suppressedLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_suppressed_by_prefs",
+    );
+    expect(suppressedLog).toBeDefined();
+    expect(suppressedLog!.data!.userIdHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(suppressedLog!.data!.notificationType).toBe("expense_added");
+  });
+
+  it("sends to enabled recipients while suppressing disabled ones in the same fan-out", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: ["tokBob"],
+        notificationPrefs: {
+          newExpense: false,
+          settlement: true,
+          reminder: true,
+        },
+      },
+      "uid-carol": {
+        fcmTokens: ["tokCarol"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author", "uid-bob", "uid-carol"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    expect(mockedSendFcmToTokens.mock.calls[0][1].userId).toBe("uid-carol");
+  });
+
+  // -------------------------------------------------------------------------
+  // Skip branches
+  // -------------------------------------------------------------------------
+  it("logs fcm_send_skipped_empty_tokens and skips when recipient has no tokens", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: [],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author", "uid-bob"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+    const skipLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_skipped_empty_tokens",
+    );
+    expect(skipLog).toBeDefined();
+  });
+
+  it("logs fcm_send_skipped_missing_user when recipient doc does not exist", async () => {
+    const db = createMockDb({
+      // intentionally omit uid-bob — getDoc returns exists=false
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author", "uid-bob"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+    const skipLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_skipped_missing_user",
+    );
+    expect(skipLog).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Author exclusion
+  // -------------------------------------------------------------------------
+  it("never sends to the author themselves", async () => {
+    const db = createMockDb({
+      "uid-author": {
+        fcmTokens: ["tokAuthor"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        memberIds: ["uid-author"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // changeType discrimination
+  // -------------------------------------------------------------------------
+  it("uses expense_edited type for changeType=update", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: ["tokBob"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        changeType: "update",
+        memberIds: ["uid-author", "uid-bob"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    expect(mockedSendFcmToTokens.mock.calls[0][1].notificationType).toBe(
+      "expense_edited",
+    );
+  });
+
+  it("uses expense_deleted type for changeType=delete", async () => {
+    const db = createMockDb({
+      "uid-bob": {
+        fcmTokens: ["tokBob"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendExpenseNotification(
+      {db, logger, messaging: createMockMessaging()},
+      {
+        ...baseParams,
+        changeType: "delete",
+        memberIds: ["uid-author", "uid-bob"],
+      },
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    expect(mockedSendFcmToTokens.mock.calls[0][1].notificationType).toBe(
+      "expense_deleted",
+    );
+  });
+});

--- a/functions/test/notifications/send-settlement-notification.test.ts
+++ b/functions/test/notifications/send-settlement-notification.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for the trigger-facing settlement-notification dispatcher
+ * (FR-AC-03).
+ *
+ * Mirrors `send-expense-notification.test.ts` but with a single
+ * recipient (`toUserId` — the payee). The payer (`fromUserId`) is the
+ * actor and is NOT notified of their own action per
+ * `docs/design/07-technical/notifications.md` §2.2.
+ *
+ * @module test/notifications/send-settlement-notification.test.ts
+ */
+
+import {sendSettlementNotification} from
+  "../../src/notifications/send-settlement-notification";
+import {sendFcmToTokens} from "../../src/notifications/fcm-send";
+
+jest.mock("../../src/notifications/fcm-send", () => {
+  const actual = jest.requireActual("../../src/notifications/fcm-send");
+  return {
+    ...actual,
+    sendFcmToTokens: jest.fn().mockResolvedValue({
+      succeeded: 1,
+      failed: 0,
+      pruned: [],
+    }),
+  };
+});
+
+const mockedSendFcmToTokens = sendFcmToTokens as jest.MockedFunction<
+  typeof sendFcmToTokens
+>;
+
+beforeEach(() => {
+  mockedSendFcmToTokens.mockClear();
+  mockedSendFcmToTokens.mockResolvedValue({
+    succeeded: 1,
+    failed: 0,
+    pruned: [],
+  });
+});
+
+interface LoggerCall {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "warn", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+function createMockDb(
+  users: Record<string, Record<string, unknown> | null>,
+): FirebaseFirestore.Firestore {
+  const docFn = jest.fn((userId: string) => ({
+    get: jest.fn().mockResolvedValue({
+      exists: users[userId] !== undefined && users[userId] !== null,
+      data: () => users[userId] ?? undefined,
+      id: userId,
+    }),
+  }));
+  return {
+    collection: jest.fn().mockReturnValue({doc: docFn}),
+  } as unknown as FirebaseFirestore.Firestore;
+}
+
+function createMockMessaging() {
+  return {} as unknown as import("firebase-admin/messaging").Messaging;
+}
+
+const baseParams = {
+  fromUserId: "uid-payer",
+  toUserId: "uid-payee",
+  contextType: "friendship" as const,
+  contextId: "uid-payer_uid-payee",
+  settlementId: "settle1",
+  senderName: "Priya",
+  amountPaise: 35000,
+  eventTimestamp: new Date("2026-06-08T10:00:00Z"),
+};
+
+describe("sendSettlementNotification — FR-AC-03 dispatcher", () => {
+  it("sends to the payee (toUserId) ONLY when settlement=true and tokens non-empty", async () => {
+    const db = createMockDb({
+      "uid-payee": {
+        fcmTokens: ["tokPayee1", "tokPayee2"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendSettlementNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    const callArgs = mockedSendFcmToTokens.mock.calls[0][1];
+    expect(callArgs.userId).toBe("uid-payee");
+    expect(callArgs.tokens).toEqual(["tokPayee1", "tokPayee2"]);
+    expect(callArgs.notificationType).toBe("settlement_received");
+    expect(callArgs.payload.title).toBe("Priya settled up");
+    expect(callArgs.payload.body).toBe("You received ₹350.");
+  });
+
+  it("does NOT read or send to the payer (fromUserId — the actor)", async () => {
+    const db = createMockDb({
+      "uid-payer": {
+        fcmTokens: ["tokPayer"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+      "uid-payee": {
+        fcmTokens: ["tokPayee"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendSettlementNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    expect(mockedSendFcmToTokens.mock.calls[0][1].userId).toBe("uid-payee");
+  });
+
+  it("suppresses send when settlement=false (logs fcm_send_suppressed_by_prefs)", async () => {
+    const db = createMockDb({
+      "uid-payee": {
+        fcmTokens: ["tokPayee"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: false,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendSettlementNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+    const suppressedLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_suppressed_by_prefs",
+    );
+    expect(suppressedLog).toBeDefined();
+    expect(suppressedLog!.data!.notificationType).toBe("settlement_received");
+  });
+
+  it("logs fcm_send_skipped_empty_tokens when payee has no tokens", async () => {
+    const db = createMockDb({
+      "uid-payee": {
+        fcmTokens: [],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendSettlementNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+    const skipLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_skipped_empty_tokens",
+    );
+    expect(skipLog).toBeDefined();
+  });
+
+  it("logs fcm_send_skipped_missing_user when payee doc does not exist", async () => {
+    const db = createMockDb({
+      // intentionally omit uid-payee
+    });
+    const logger = createMockLogger();
+
+    await sendSettlementNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+    const skipLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_send_skipped_missing_user",
+    );
+    expect(skipLog).toBeDefined();
+  });
+
+  it("defaults to settlement=true when notificationPrefs map is absent", async () => {
+    const db = createMockDb({
+      "uid-payee": {
+        fcmTokens: ["tokPayee"],
+        // no notificationPrefs map — should default to allow
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendSettlementNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+  });
+});

--- a/functions/test/triggers/on-expense-write/function.test.ts
+++ b/functions/test/triggers/on-expense-write/function.test.ts
@@ -21,6 +21,7 @@ import {createTriggerHandler} from
   "../../../src/triggers/on-expense-write/function";
 import {writeExpenseActivity} from
   "../../../src/triggers/on-expense-write/activity-writer";
+import type {NotificationsApi} from "../../../src/notifications";
 
 jest.mock("../../../src/triggers/on-expense-write/activity-writer");
 
@@ -35,6 +36,31 @@ beforeEach(() => {
     membersFailed: 0,
   });
 });
+
+// ---------------------------------------------------------------------------
+// FR-AC-03 notifications API mock helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a mocked `NotificationsApi` suitable for injection into the
+ * trigger's `Dependencies.notificationsApi` slot. The default mock is a
+ * no-op that resolves successfully; tests can override the per-method
+ * implementation to assert call shape or simulate failures.
+ */
+function createMockNotificationsApi(): NotificationsApi & {
+  sendExpenseNotification: jest.Mock;
+  sendSettlementNotification: jest.Mock;
+} {
+  return {
+    sendExpenseNotification: jest.fn().mockResolvedValue(undefined),
+    sendSettlementNotification: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockMessaging():
+  import("firebase-admin/messaging").Messaging {
+  return {} as unknown as import("firebase-admin/messaging").Messaging;
+}
 
 // ---------------------------------------------------------------------------
 // Mock helpers — copy the simplified-debts/function.test.ts pattern
@@ -85,6 +111,13 @@ function createMockDb(opts: {
    * memberIds emptied) before the activity-emission read.
    */
   activityGetOverride?: {exists: boolean; data?: Record<string, unknown>};
+  /**
+   * Optional user-doc seed for the FR-AC-03 sender lookup. When set,
+   * any read of `users/{any}` returns this data. Used by the
+   * emitExpenseFcm helper to resolve `senderName` from
+   * `users/{authorUid}.displayName`.
+   */
+  authorDoc?: Record<string, unknown>;
 }): FirebaseFirestore.Firestore {
   const expenseDocs = (opts.expenses ?? []).map((e) => ({
     id: e.id,
@@ -117,6 +150,20 @@ function createMockDb(opts: {
         return {
           where: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue(settlementsQuery),
+          }),
+        };
+      }
+      if (name === "users") {
+        // FR-AC-03: emitExpenseFcm reads users/{authorUid} to resolve
+        // the sender's displayName for the notification payload, and
+        // the inner send-expense-notification dispatcher reads each
+        // recipient's users/{uid} doc for fcmTokens + notificationPrefs.
+        return {
+          doc: jest.fn().mockReturnValue({
+            get: jest.fn().mockResolvedValue({
+              exists: opts.authorDoc !== undefined,
+              data: () => opts.authorDoc ?? {},
+            }),
           }),
         };
       }
@@ -237,6 +284,7 @@ function validExpenseData(overrides: Record<string, unknown> = {}) {
     ],
     deleted: false,
     description: "Test",
+    createdBy: "userA",
     ...overrides,
   };
 }
@@ -1028,5 +1076,230 @@ describe("onExpenseWriteFriendship handler — FR-EX-07 activity-writer integrat
     expect(skipLog!.level).toBe("info");
     expect(skipLog!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
     expect(mockedWriteExpenseActivity).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-AC-03: trigger ↔ FCM dispatcher contract
+// ---------------------------------------------------------------------------
+
+describe("onExpenseWriteFriendship handler — FR-AC-03 FCM emission", () => {
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-4: create event invokes sendExpenseNotification with
+  // recipients = memberIds - authorUid.
+  // -------------------------------------------------------------------------
+  it("calls sendExpenseNotification on create with non-author memberIds + senderName resolved", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+      // The expense's createdBy is "userA"; the helper looks up the
+      // sender's displayName at users/{authorUid}.
+      authorDoc: {displayName: "Rahul"},
+    });
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await handler(
+      makeEvent({
+        changeType: "create",
+        afterData: validExpenseData({createdBy: "userA"}),
+      }),
+    );
+
+    expect(notificationsApi.sendExpenseNotification).toHaveBeenCalledTimes(1);
+    const [, callParams] =
+      notificationsApi.sendExpenseNotification.mock.calls[0];
+    expect(callParams.authorUid).toBe("userA");
+    expect(callParams.memberIds).toEqual(["userA", "userB"]);
+    expect(callParams.contextType).toBe("friendship");
+    expect(callParams.contextId).toBe("fid");
+    expect(callParams.expenseId).toBe("eid");
+    expect(callParams.changeType).toBe("create");
+    expect(callParams.amountPaise).toBe(10000);
+    expect(callParams.senderName).toBe("Rahul");
+    expect(callParams.description).toBe("Test");
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-18: stale-event drop branch does NOT invoke
+  // sendExpenseNotification.
+  // -------------------------------------------------------------------------
+  it("does NOT call sendExpenseNotification on the stale-event-drop branch", async () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+    });
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: eightDaysAgo,
+        afterData: validExpenseData(),
+      }),
+    );
+
+    expect(notificationsApi.sendExpenseNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-18: CONTEXT_NOT_FOUND branch does NOT invoke
+  // sendExpenseNotification.
+  // -------------------------------------------------------------------------
+  it("does NOT call sendExpenseNotification on the CONTEXT_NOT_FOUND branch", async () => {
+    const db = createMockDb({contextExists: false});
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await handler(
+      makeEvent({changeType: "create", afterData: validExpenseData()}),
+    );
+
+    expect(notificationsApi.sendExpenseNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-18: BALANCE_INVARIANT_VIOLATED branch (handler throws)
+  // does NOT invoke sendExpenseNotification.
+  // -------------------------------------------------------------------------
+  it("does NOT call sendExpenseNotification on the BALANCE_INVARIANT_VIOLATED branch", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "eid",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 4000},
+              {userId: "userB", sharePaise: 3000},
+            ],
+          },
+        },
+      ],
+    });
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).rejects.toThrow();
+
+    expect(notificationsApi.sendExpenseNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-17: FCM emission failure is CONTAINED — trigger's success
+  // branch is preserved. The notifications mock is configured to throw;
+  // the trigger must STILL log simplified_debts_compute_completed and
+  // must NOT throw.
+  // -------------------------------------------------------------------------
+  it("contains FCM emission failures — trigger does not throw if sendExpenseNotification throws", async () => {
+    const notificationsApi = createMockNotificationsApi();
+    notificationsApi.sendExpenseNotification.mockRejectedValueOnce(
+      new Error("simulated FCM internal error"),
+    );
+
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+      authorDoc: {displayName: "Rahul"},
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    // Recompute success branch still logs as completed.
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+
+    // The FCM emission internal error is logged but does NOT bubble.
+    const fcmErrorLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_emission_internal_error",
+    );
+    expect(fcmErrorLog).toBeDefined();
+    expect(fcmErrorLog!.level).toBe("error");
+    expect(fcmErrorLog!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Architect §2.10 item 7: when notificationsApi is absent from deps
+  // (existing tests, partial wiring), the emitter no-ops silently.
+  // -------------------------------------------------------------------------
+  it("no-ops silently when notificationsApi is undefined (backward-compat)", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [{id: "eid", data: validExpenseData()}],
+    });
+    const logger = createMockLogger();
+
+    // No notificationsApi in deps — existing tests' contract preserved.
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validExpenseData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    // Trigger still completes successfully.
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+    // And no FCM internal-error log fires — the emitter is a clean no-op
+    // when deps don't wire it.
+    const fcmErrorLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_emission_internal_error",
+    );
+    expect(fcmErrorLog).toBeUndefined();
   });
 });

--- a/functions/test/triggers/on-settlement-write/function.test.ts
+++ b/functions/test/triggers/on-settlement-write/function.test.ts
@@ -23,6 +23,7 @@ import {createTriggerHandler} from
   "../../../src/triggers/on-settlement-write/function";
 import {writeExpenseActivity} from
   "../../../src/triggers/on-expense-write/activity-writer";
+import type {NotificationsApi} from "../../../src/notifications";
 
 jest.mock("../../../src/triggers/on-expense-write/activity-writer");
 
@@ -37,6 +38,31 @@ beforeEach(() => {
     membersFailed: 0,
   });
 });
+
+// ---------------------------------------------------------------------------
+// FR-AC-03 notifications API mock helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a mocked `NotificationsApi` suitable for injection into the
+ * trigger's `Dependencies.notificationsApi` slot. The default mock is a
+ * no-op that resolves successfully; tests can override the per-method
+ * implementation to assert call shape or simulate failures.
+ */
+function createMockNotificationsApi(): NotificationsApi & {
+  sendExpenseNotification: jest.Mock;
+  sendSettlementNotification: jest.Mock;
+} {
+  return {
+    sendExpenseNotification: jest.fn().mockResolvedValue(undefined),
+    sendSettlementNotification: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockMessaging():
+  import("firebase-admin/messaging").Messaging {
+  return {} as unknown as import("firebase-admin/messaging").Messaging;
+}
 
 // ---------------------------------------------------------------------------
 // Mock helpers — copy the function.test.ts pattern with the settlements
@@ -72,6 +98,13 @@ function createMockDb(opts: {
   contextData?: Record<string, unknown>;
   expenses?: Array<{id: string; data: Record<string, unknown>}>;
   settlements?: Array<{id: string; data: Record<string, unknown>}>;
+  /**
+   * Optional user-doc seed for the FR-AC-03 sender lookup. When set,
+   * any read of `users/{any}` returns this data. Used by the
+   * emitSettlementFcm helper to resolve `senderName` from
+   * `users/{fromUserId}.displayName`.
+   */
+  authorDoc?: Record<string, unknown>;
 }): FirebaseFirestore.Firestore {
   const expenseDocs = (opts.expenses ?? []).map((e) => ({
     id: e.id,
@@ -104,6 +137,19 @@ function createMockDb(opts: {
         return {
           where: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue(settlementsQuery),
+          }),
+        };
+      }
+      if (name === "users") {
+        // FR-AC-03: emitSettlementFcm reads users/{fromUserId} for the
+        // sender's displayName, and the inner notifications dispatcher
+        // reads users/{toUserId} for fcmTokens + notificationPrefs.
+        return {
+          doc: jest.fn().mockReturnValue({
+            get: jest.fn().mockResolvedValue({
+              exists: opts.authorDoc !== undefined,
+              data: () => opts.authorDoc ?? {},
+            }),
           }),
         };
       }
@@ -978,5 +1024,223 @@ describe("onSettlementWrite handler — FR-AC-01 activity-writer integration", (
     );
     expect(internalErrorLog).toBeDefined();
     expect(internalErrorLog!.level).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-AC-03: trigger ↔ FCM dispatcher contract
+// ---------------------------------------------------------------------------
+
+describe("onSettlementWrite handler — FR-AC-03 FCM emission", () => {
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-5: create event invokes sendSettlementNotification with
+  // recipient = toUserId.
+  // -------------------------------------------------------------------------
+  it("calls sendSettlementNotification on create with toUserId only + senderName resolved", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+      authorDoc: {displayName: "Priya"},
+    });
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await handler(
+      makeEvent({changeType: "create", afterData: validSettlementData()}),
+    );
+
+    expect(notificationsApi.sendSettlementNotification).toHaveBeenCalledTimes(
+      1,
+    );
+    const [, callParams] =
+      notificationsApi.sendSettlementNotification.mock.calls[0];
+    expect(callParams.fromUserId).toBe("userA");
+    expect(callParams.toUserId).toBe("userB");
+    expect(callParams.contextType).toBe("friendship");
+    expect(callParams.contextId).toBe("fid");
+    expect(callParams.settlementId).toBe("sid");
+    expect(callParams.amountPaise).toBe(5000);
+    expect(callParams.senderName).toBe("Priya");
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-18: stale-event drop branch does NOT invoke
+  // sendSettlementNotification.
+  // -------------------------------------------------------------------------
+  it("does NOT call sendSettlementNotification on the stale-event-drop branch", async () => {
+    const eightDaysAgo = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await handler(
+      makeEvent({
+        changeType: "create",
+        eventTime: eightDaysAgo,
+        afterData: validSettlementData(),
+      }),
+    );
+
+    expect(notificationsApi.sendSettlementNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-18: CONTEXT_NOT_FOUND branch does NOT invoke
+  // sendSettlementNotification.
+  // -------------------------------------------------------------------------
+  it("does NOT call sendSettlementNotification on the CONTEXT_NOT_FOUND branch", async () => {
+    const db = createMockDb({contextExists: false, settlements: []});
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await handler(
+      makeEvent({changeType: "create", afterData: validSettlementData()}),
+    );
+
+    expect(notificationsApi.sendSettlementNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-18: BALANCE_INVARIANT_VIOLATED branch (trigger throws
+  // for retry) does NOT invoke sendSettlementNotification.
+  // -------------------------------------------------------------------------
+  it("does NOT call sendSettlementNotification on the BALANCE_INVARIANT_VIOLATED branch", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [
+        {
+          id: "exp1",
+          data: {
+            payerId: "userA",
+            amountPaise: 10000,
+            deleted: false,
+            splits: [
+              {userId: "userA", sharePaise: 4000},
+              {userId: "userB", sharePaise: 3000},
+            ],
+          },
+        },
+      ],
+      settlements: [],
+    });
+    const notificationsApi = createMockNotificationsApi();
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validSettlementData()}),
+      ),
+    ).rejects.toThrow();
+
+    expect(notificationsApi.sendSettlementNotification).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // FR-AC-03 AC-17: FCM emission failure is CONTAINED — trigger's success
+  // branch is preserved.
+  // -------------------------------------------------------------------------
+  it("contains FCM emission failures — trigger does not throw if sendSettlementNotification throws", async () => {
+    const notificationsApi = createMockNotificationsApi();
+    notificationsApi.sendSettlementNotification.mockRejectedValueOnce(
+      new Error("simulated FCM internal error"),
+    );
+
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+      authorDoc: {displayName: "Priya"},
+    });
+    const logger = createMockLogger();
+
+    const handler = createTriggerHandler({
+      db,
+      logger,
+      notificationsApi,
+      messaging: createMockMessaging(),
+    });
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validSettlementData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+
+    const fcmErrorLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_emission_internal_error",
+    );
+    expect(fcmErrorLog).toBeDefined();
+    expect(fcmErrorLog!.level).toBe("error");
+    expect(fcmErrorLog!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Architect §2.10 item 7: when notificationsApi is absent from deps
+  // (existing tests, partial wiring), the emitter no-ops silently.
+  // -------------------------------------------------------------------------
+  it("no-ops silently when notificationsApi is undefined (backward-compat)", async () => {
+    const db = createMockDb({
+      contextExists: true,
+      contextData: {memberIds: ["userA", "userB"]},
+      expenses: [],
+      settlements: [{id: "sid", data: validSettlementData()}],
+    });
+    const logger = createMockLogger();
+
+    // No notificationsApi in deps — existing tests' contract preserved.
+    const handler = createTriggerHandler({db, logger});
+    await expect(
+      handler(
+        makeEvent({changeType: "create", afterData: validSettlementData()}),
+      ),
+    ).resolves.toBeUndefined();
+
+    const completedLog = logger.calls.find(
+      (c) => c.data?.event === "simplified_debts_compute_completed",
+    );
+    expect(completedLog).toBeDefined();
+    const fcmErrorLog = logger.calls.find(
+      (c) => c.data?.event === "fcm_emission_internal_error",
+    );
+    expect(fcmErrorLog).toBeUndefined();
   });
 });

--- a/functions/test/utils/format-inr.test.ts
+++ b/functions/test/utils/format-inr.test.ts
@@ -46,7 +46,7 @@ describe("formatInrFromPaise — FR-AC-03 / Invariant 1", () => {
 
   it("renders large amounts (1 crore rupees) using Indian crore grouping", () => {
     // 1,00,00,00,000 paise = 1,00,00,000 rupees = 1 crore.
-    expect(formatInrFromPaise(10000000000)).toBe("₹1,00,00,000");
+    expect(formatInrFromPaise(1000000000)).toBe("₹1,00,00,000");
   });
 
   it("renders a negative amount with a leading ASCII hyphen-minus", () => {

--- a/functions/test/utils/format-inr.test.ts
+++ b/functions/test/utils/format-inr.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the Functions-side INR formatter (FR-AC-03 / Invariant 1).
+ *
+ * Mirrors the client-side `formatInrFromPaise()` semantics
+ * (`lib/core/formatters/inr_formatter.dart`): integer arithmetic only,
+ * Indian-numbering grouping convention, no inline `/100` arithmetic.
+ *
+ * The Functions-side flavour is INTEGER-RUPEE ONLY — the notification
+ * templates per `docs/design/07-technical/notifications.md` §2.2 render
+ * amounts without a paise component (e.g. `"₹1,200"`, not `"₹1,200.00"`).
+ * The architect ratified this divergence in §2.1 of the FR-AC-03 story
+ * (the formatter is a Functions-side helper for notification-body
+ * rendering, not a general-purpose mirror of the Dart formatter).
+ *
+ * Expected outputs are encoded as string literals; the test file itself
+ * MUST NOT contain inline `/100` arithmetic (would violate the existing
+ * Functions-side boundary-contract grep at
+ * `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`).
+ *
+ * @module test/utils/format-inr.test.ts
+ */
+
+import {formatInrFromPaise} from "../../src/utils/format-inr";
+
+describe("formatInrFromPaise — FR-AC-03 / Invariant 1", () => {
+  it("renders zero as '₹0'", () => {
+    expect(formatInrFromPaise(0)).toBe("₹0");
+  });
+
+  it("renders 100 paise (1 rupee) as '₹1'", () => {
+    expect(formatInrFromPaise(100)).toBe("₹1");
+  });
+
+  it("renders 120000 paise (1,200 rupees) as '₹1,200'", () => {
+    // From the canonical notifications.md §2.2 example.
+    expect(formatInrFromPaise(120000)).toBe("₹1,200");
+  });
+
+  it("renders 10000000 paise (1 lakh rupees) using Indian lakh grouping", () => {
+    expect(formatInrFromPaise(10000000)).toBe("₹1,00,000");
+  });
+
+  it("renders 100000000 paise (10 lakh rupees) using Indian 10-lakh grouping", () => {
+    expect(formatInrFromPaise(100000000)).toBe("₹10,00,000");
+  });
+
+  it("renders large amounts (1 crore rupees) using Indian crore grouping", () => {
+    // 1,00,00,00,000 paise = 1,00,00,000 rupees = 1 crore.
+    expect(formatInrFromPaise(10000000000)).toBe("₹1,00,00,000");
+  });
+
+  it("renders a negative amount with a leading ASCII hyphen-minus", () => {
+    // The Functions-side formatter uses the ASCII hyphen-minus, not the
+    // Unicode minus (U+2212) — FCM payloads are 7-bit ASCII friendly,
+    // and the simpler character avoids edge cases with platform-level
+    // string normalisation in client notification UIs.
+    expect(formatInrFromPaise(-100)).toBe("-₹1");
+  });
+
+  it("renders a negative large amount with Indian grouping after the sign", () => {
+    expect(formatInrFromPaise(-12345600)).toBe("-₹1,23,456");
+  });
+
+  it("truncates sub-rupee paise (floors toward zero for positives)", () => {
+    // 99 paise → 0 rupees. The notification body only displays integer
+    // rupees; sub-rupee amounts are dropped from the display string.
+    expect(formatInrFromPaise(99)).toBe("₹0");
+    // 199 paise → 1 rupee (truncated, not rounded).
+    expect(formatInrFromPaise(199)).toBe("₹1");
+  });
+
+  it("throws on a non-integer input (Number.isInteger defence-in-depth)", () => {
+    // The contract is `paise: number` typed as integer. Defence-in-depth
+    // catches a programmer error (or a JSON.parse round-trip that loses
+    // type narrowing) at the formatter boundary instead of silently
+    // emitting a malformed string.
+    expect(() => formatInrFromPaise(1.5)).toThrow();
+    expect(() => formatInrFromPaise(NaN)).toThrow();
+    expect(() => formatInrFromPaise(Infinity)).toThrow();
+  });
+
+  it("throws on a non-finite negative input (NaN, -Infinity)", () => {
+    expect(() => formatInrFromPaise(-Infinity)).toThrow();
+  });
+});

--- a/lib/core/routing/notification_deep_links.dart
+++ b/lib/core/routing/notification_deep_links.dart
@@ -111,15 +111,32 @@ class NotificationDeepLinks {
     NotificationPayload payload,
     String currentUid,
   ) {
-    switch (payload.type) {
+    return resolveFromFields(
+      type: payload.type,
+      contextId: payload.contextId,
+      itemId: payload.itemId,
+      currentUid: currentUid,
+    );
+  }
+
+  /// Pure-function resolver from raw fields to [DeepLinkTarget]. Used
+  /// by both the FCM payload resolver above and the activity-feed
+  /// row-tap call site (FR-AC-02) so the two consumers share a single
+  /// routing contract.
+  static DeepLinkTarget resolveFromFields({
+    required NotificationType type,
+    required String contextId,
+    required String currentUid,
+    String? itemId,
+  }) {
+    switch (type) {
       case NotificationType.expenseAdded:
       case NotificationType.expenseEdited:
-        final itemId = payload.itemId;
         if (itemId == null) return const DeepLinkUnavailable();
-        final other = otherUidForFriendship(payload.contextId, currentUid);
+        final other = otherUidForFriendship(contextId, currentUid);
         if (other == null) return const DeepLinkUnavailable();
         return DeepLinkExpenseDetail(
-          friendshipId: payload.contextId,
+          friendshipId: contextId,
           expenseId: itemId,
           currentUid: currentUid,
           otherUid: other,
@@ -128,10 +145,10 @@ class NotificationDeepLinks {
         return const DeepLinkUnavailable();
       case NotificationType.settlementReceived:
       case NotificationType.reminder:
-        final other = otherUidForFriendship(payload.contextId, currentUid);
+        final other = otherUidForFriendship(contextId, currentUid);
         if (other == null) return const DeepLinkUnavailable();
         return DeepLinkFriendDetail(
-          friendshipId: payload.contextId,
+          friendshipId: contextId,
           currentUid: currentUid,
           otherUid: other,
         );

--- a/lib/core/routing/notification_deep_links.dart
+++ b/lib/core/routing/notification_deep_links.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+
+import 'package:onebytwo/features/expenses/presentation/expense_detail_screen.dart';
+import 'package:onebytwo/features/friends/presentation/friend_detail_screen.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+/// Sealed discriminated union over the in-app navigation targets a
+/// notification can deep-link to (FR-AC-03, FR-AC-05).
+///
+/// Resolved purely from a [NotificationPayload] by
+/// [NotificationDeepLinks.resolve] (no [BuildContext], no
+/// dependencies). The navigation itself is performed by
+/// [NotificationDeepLinks.navigate].
+@immutable
+sealed class DeepLinkTarget {
+  const DeepLinkTarget();
+}
+
+/// Push [ExpenseDetailScreen] for a friendship-context expense.
+final class DeepLinkExpenseDetail extends DeepLinkTarget {
+  /// Creates a [DeepLinkExpenseDetail].
+  const DeepLinkExpenseDetail({
+    required this.friendshipId,
+    required this.expenseId,
+    required this.currentUid,
+    required this.otherUid,
+  });
+
+  /// Friendship composite ID (`{uidA}_{uidB}`).
+  final String friendshipId;
+
+  /// Expense document ID under
+  /// `friendships/{friendshipId}/expenses/{expenseId}`.
+  final String expenseId;
+
+  /// The current user's UID (signed-in viewer).
+  final String currentUid;
+
+  /// The other party's UID — extracted from [friendshipId] via
+  /// [NotificationDeepLinks.otherUidForFriendship].
+  final String otherUid;
+}
+
+/// Push [FriendDetailScreen] for a friendship-context settlement or
+/// reminder.
+final class DeepLinkFriendDetail extends DeepLinkTarget {
+  /// Creates a [DeepLinkFriendDetail].
+  const DeepLinkFriendDetail({
+    required this.friendshipId,
+    required this.currentUid,
+    required this.otherUid,
+  });
+
+  /// Friendship composite ID.
+  final String friendshipId;
+
+  /// Current viewer's UID.
+  final String currentUid;
+
+  /// Other party's UID.
+  final String otherUid;
+}
+
+/// Show the SCR-25 "This item is no longer available" snackbar; do
+/// not navigate. Used for `expense_deleted` and any malformed /
+/// orphaned payload.
+final class DeepLinkUnavailable extends DeepLinkTarget {
+  /// Creates a [DeepLinkUnavailable].
+  const DeepLinkUnavailable();
+}
+
+/// Show a "Groups coming soon" snackbar for `group_invite` payloads.
+/// Forward-compatibility only — no producer in v1.0.
+final class DeepLinkGroupsComingSoon extends DeepLinkTarget {
+  /// Creates a [DeepLinkGroupsComingSoon].
+  const DeepLinkGroupsComingSoon();
+}
+
+/// Shared resolver / navigator for notification + activity-feed deep
+/// links (FR-AC-03 architect §2.3).
+///
+/// Consumed by:
+///   1. `ActivityFeedScreen._onRowTap` (FR-AC-01 / FR-AC-02 — refactored
+///      to use this helper in commit 10).
+///   2. The foreground in-app banner tap (FR-AC-03).
+///   3. The background system-notification tap (FR-AC-03).
+///   4. The cold-start `getInitialMessage` payload (FR-AC-05).
+///
+/// **The resolver is a pure function.** Telemetry (`activity_item_tapped`
+/// vs `fcm_notification_tapped`) stays at the call site so the helper
+/// has no analytics dependency.
+class NotificationDeepLinks {
+  const NotificationDeepLinks._();
+
+  /// Pure-function resolver from `(payload, currentUid)` to
+  /// [DeepLinkTarget].
+  ///
+  /// Per-type rules:
+  ///   - `expense_added` / `expense_edited`: requires `itemId` and a
+  ///     valid friendship-composite `contextId`. Returns
+  ///     [DeepLinkExpenseDetail] on success, [DeepLinkUnavailable] on
+  ///     missing-field / malformed-composite.
+  ///   - `expense_deleted`: always returns [DeepLinkUnavailable] (the
+  ///     expense is gone — SCR-25 fallback).
+  ///   - `settlement_received` / `reminder`: requires a valid
+  ///     friendship-composite `contextId`. Returns [DeepLinkFriendDetail]
+  ///     on success, [DeepLinkUnavailable] on malformed.
+  ///   - `group_invite`: returns [DeepLinkGroupsComingSoon] (no
+  ///     producer in v1.0).
+  static DeepLinkTarget resolve(
+    NotificationPayload payload,
+    String currentUid,
+  ) {
+    switch (payload.type) {
+      case NotificationType.expenseAdded:
+      case NotificationType.expenseEdited:
+        final itemId = payload.itemId;
+        if (itemId == null) return const DeepLinkUnavailable();
+        final other = otherUidForFriendship(payload.contextId, currentUid);
+        if (other == null) return const DeepLinkUnavailable();
+        return DeepLinkExpenseDetail(
+          friendshipId: payload.contextId,
+          expenseId: itemId,
+          currentUid: currentUid,
+          otherUid: other,
+        );
+      case NotificationType.expenseDeleted:
+        return const DeepLinkUnavailable();
+      case NotificationType.settlementReceived:
+      case NotificationType.reminder:
+        final other = otherUidForFriendship(payload.contextId, currentUid);
+        if (other == null) return const DeepLinkUnavailable();
+        return DeepLinkFriendDetail(
+          friendshipId: payload.contextId,
+          currentUid: currentUid,
+          otherUid: other,
+        );
+      case NotificationType.groupInvite:
+        return const DeepLinkGroupsComingSoon();
+    }
+  }
+
+  /// Extracts the other party's UID from a friendship composite ID
+  /// (`{uidA}_{uidB}`). Returns `null` if the composite has the wrong
+  /// arity OR the [currentUid] is not present.
+  static String? otherUidForFriendship(String friendshipId, String currentUid) {
+    final parts = friendshipId.split('_');
+    if (parts.length != 2) return null;
+    if (parts[0] == currentUid) return parts[1];
+    if (parts[1] == currentUid) return parts[0];
+    return null;
+  }
+
+  /// Performs the platform navigation for [target].
+  ///
+  /// For [DeepLinkExpenseDetail] / [DeepLinkFriendDetail]: pushes the
+  /// target screen onto the navigator stack via [MaterialPageRoute].
+  /// For [DeepLinkUnavailable]: shows the "This item is no longer
+  /// available" snackbar — no navigation.
+  /// For [DeepLinkGroupsComingSoon]: shows a "Groups coming soon"
+  /// snackbar — no navigation.
+  static Future<void> navigate(
+    BuildContext context,
+    DeepLinkTarget target,
+  ) async {
+    switch (target) {
+      case DeepLinkExpenseDetail(
+        :final friendshipId,
+        :final expenseId,
+        :final currentUid,
+        :final otherUid,
+      ):
+        await Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => ExpenseDetailScreen(
+              friendshipId: friendshipId,
+              expenseId: expenseId,
+              currentUserUid: currentUid,
+              otherUserUid: otherUid,
+            ),
+          ),
+        );
+      case DeepLinkFriendDetail(
+        :final friendshipId,
+        :final currentUid,
+        :final otherUid,
+      ):
+        await Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => FriendDetailScreen(
+              friendshipId: friendshipId,
+              currentUserUid: currentUid,
+              otherUserUid: otherUid,
+            ),
+          ),
+        );
+      case DeepLinkUnavailable():
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('This item is no longer available.')),
+        );
+      case DeepLinkGroupsComingSoon():
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Groups are coming soon.')),
+        );
+    }
+  }
+}

--- a/lib/features/activity/presentation/activity_feed_screen.dart
+++ b/lib/features/activity/presentation/activity_feed_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:onebytwo/core/routing/notification_deep_links.dart';
 import 'package:onebytwo/core/telemetry/event_id_hash.dart';
 import 'package:onebytwo/core/widgets/lists/obt_activity_row.dart';
 import 'package:onebytwo/features/activity/application/activity_feed_provider.dart';
@@ -12,10 +13,9 @@ import 'package:onebytwo/features/activity/domain/activity_feed_item.dart';
 import 'package:onebytwo/features/activity/presentation/widgets/activity_feed_skeleton.dart';
 import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/auth/domain/user_model.dart';
-import 'package:onebytwo/features/expenses/presentation/expense_detail_screen.dart';
 import 'package:onebytwo/features/friends/application/friends_list_provider.dart';
 import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
-import 'package:onebytwo/features/friends/presentation/friend_detail_screen.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
 
 /// SCR-25 — Activity Feed screen (FR-AC-01 / FR-AC-02).
 ///
@@ -28,10 +28,14 @@ import 'package:onebytwo/features/friends/presentation/friend_detail_screen.dart
 ///   - Refreshing: pull-to-refresh on the populated list with an error
 ///     snackbar on failure.
 ///
-/// Deep-link routing (FR-AC-02):
-///   - `expenseAdded` / `expenseEdited` → [ExpenseDetailScreen].
-///   - `expenseDeleted` → info snackbar; remain on the feed.
-///   - `settlementRecorded` → [FriendDetailScreen] for the other party.
+/// Deep-link routing (FR-AC-02 + FR-AC-03 architect §2.3 — shared
+/// helper):
+///   - `expenseAdded` / `expenseEdited` → `ExpenseDetailScreen` via
+///     `NotificationDeepLinks.navigate`.
+///   - `expenseDeleted` → "This item is no longer available" snackbar
+///     via the shared helper; remain on the feed.
+///   - `settlementRecorded` → `FriendDetailScreen` for the other party
+///     via the shared helper.
 ///
 /// Telemetry (PII per ADR-0013 — friendship composite UIDs hashed via
 /// `hashFriendshipId`; expense IDs / settlement IDs are opaque scalar
@@ -181,59 +185,53 @@ class _ActivityFeedScreenState extends ConsumerState<ActivityFeedScreen> {
 
     if (!mounted) return;
 
+    final target = _buildDeepLinkTarget(item, currentUid);
+    await NotificationDeepLinks.navigate(context, target);
+  }
+
+  /// Resolves the [DeepLinkTarget] for an [ActivityFeedItem] using the
+  /// same shared routing contract as the FCM notification tap surface
+  /// (FR-AC-03 architect §2.3). Maps the activity event type to the
+  /// equivalent notification type and forwards to
+  /// [NotificationDeepLinks.resolveFromFields].
+  DeepLinkTarget _buildDeepLinkTarget(
+    ActivityFeedItem item,
+    String currentUid,
+  ) {
+    final notifType = _mapActivityToNotificationType(item.type);
+    String? contextId;
+    String? itemId;
     switch (item.type) {
       case ActivityEventType.expenseAdded:
       case ActivityEventType.expenseEdited:
-        final friendshipId = item.payload['friendshipId'] as String?;
-        final expenseId = item.payload['expenseId'] as String?;
-        if (friendshipId == null || expenseId == null) {
-          _showUnavailableSnackbar();
-          return;
-        }
-        final otherUid = _otherUidForFriendship(friendshipId, currentUid);
-        if (otherUid == null) {
-          _showUnavailableSnackbar();
-          return;
-        }
-        await Navigator.of(context).push<void>(
-          MaterialPageRoute<void>(
-            builder: (_) => ExpenseDetailScreen(
-              friendshipId: friendshipId,
-              expenseId: expenseId,
-              currentUserUid: currentUid,
-              otherUserUid: otherUid,
-            ),
-          ),
-        );
       case ActivityEventType.expenseDeleted:
-        _showUnavailableSnackbar();
+        contextId = item.payload['friendshipId'] as String?;
+        itemId = item.payload['expenseId'] as String?;
       case ActivityEventType.settlementRecorded:
-        final contextId = item.payload['contextId'] as String?;
-        if (contextId == null) {
-          _showUnavailableSnackbar();
-          return;
-        }
-        final otherUid = _otherUidForFriendship(contextId, currentUid);
-        if (otherUid == null) {
-          _showUnavailableSnackbar();
-          return;
-        }
-        await Navigator.of(context).push<void>(
-          MaterialPageRoute<void>(
-            builder: (_) => FriendDetailScreen(
-              friendshipId: contextId,
-              currentUserUid: currentUid,
-              otherUserUid: otherUid,
-            ),
-          ),
-        );
+        contextId = item.payload['contextId'] as String?;
     }
+    if (contextId == null) {
+      return const DeepLinkUnavailable();
+    }
+    return NotificationDeepLinks.resolveFromFields(
+      type: notifType,
+      contextId: contextId,
+      itemId: itemId,
+      currentUid: currentUid,
+    );
   }
 
-  void _showUnavailableSnackbar() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('This item is no longer available.')),
-    );
+  NotificationType _mapActivityToNotificationType(ActivityEventType type) {
+    switch (type) {
+      case ActivityEventType.expenseAdded:
+        return NotificationType.expenseAdded;
+      case ActivityEventType.expenseEdited:
+        return NotificationType.expenseEdited;
+      case ActivityEventType.expenseDeleted:
+        return NotificationType.expenseDeleted;
+      case ActivityEventType.settlementRecorded:
+        return NotificationType.settlementReceived;
+    }
   }
 
   /// Returns the deep-link entity ID for telemetry. For friendship
@@ -263,17 +261,6 @@ class _ActivityFeedScreenState extends ConsumerState<ActivityFeedScreen> {
       case ActivityEventType.expenseDeleted:
         return entityId;
     }
-  }
-
-  /// Extracts the other party's UID from a friendship document ID
-  /// (`{uidA}_{uidB}`). Returns null if the composite cannot be
-  /// resolved.
-  String? _otherUidForFriendship(String friendshipId, String currentUid) {
-    final parts = friendshipId.split('_');
-    if (parts.length != 2) return null;
-    if (parts[0] == currentUid) return parts[1];
-    if (parts[1] == currentUid) return parts[0];
-    return null;
   }
 }
 

--- a/lib/features/notifications/application/deep_link_handler.dart
+++ b/lib/features/notifications/application/deep_link_handler.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/core/routing/notification_deep_links.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+/// The provenance of a deep-link dispatch — used to attribute
+/// telemetry (`fcm_notification_tapped.source` parameter).
+enum DeepLinkSource {
+  /// Foreground in-app banner tap.
+  foreground,
+
+  /// System notification tap while the app was in the background.
+  background,
+
+  /// Cold-start launch from a tapped notification (FR-AC-05).
+  coldStart,
+}
+
+extension _DeepLinkSourceX on DeepLinkSource {
+  String get wireName {
+    switch (this) {
+      case DeepLinkSource.foreground:
+        return 'foreground';
+      case DeepLinkSource.background:
+        return 'background';
+      case DeepLinkSource.coldStart:
+        return 'cold_start';
+    }
+  }
+}
+
+/// Dispatches a parsed [NotificationPayload] to the correct in-app
+/// screen via the shared [NotificationDeepLinks] resolver. Emits the
+/// `fcm_notification_tapped` telemetry event on every call.
+class DeepLinkHandler {
+  /// Creates a [DeepLinkHandler].
+  ///
+  /// The container is the Riverpod reader used to fetch the analytics
+  /// service. Production wiring passes the app-level
+  /// [ProviderContainer]; tests pass a hand-rolled container.
+  const DeepLinkHandler(this._ref);
+
+  final ProviderContainer _ref;
+
+  /// Pure resolver — delegates to [NotificationDeepLinks.resolve]. The
+  /// resolver is a pure function, so this method is testable without
+  /// a [BuildContext].
+  DeepLinkTarget resolveTarget(
+    NotificationPayload payload, {
+    required String currentUid,
+  }) {
+    return NotificationDeepLinks.resolve(payload, currentUid);
+  }
+
+  /// Resolves the deep-link target, emits telemetry, and performs the
+  /// platform navigation.
+  ///
+  /// Telemetry: `fcm_notification_tapped` with
+  ///   - `notification_type`: payload type's wire name (snake_case).
+  ///   - `source`: foreground / background / cold_start.
+  ///
+  /// **PII guard (ADR-0013).** Friendship composite UIDs are NOT
+  /// included in the telemetry parameters (we attribute by type +
+  /// source only). If the architect later asks for entity correlation,
+  /// add `entity_id_hash` parameter via `hashFriendshipId()` /
+  /// `hashId()` per the FR-AC-01 precedent.
+  Future<void> handleDeepLink({
+    required NotificationPayload payload,
+    required BuildContext context,
+    required String currentUid,
+    required DeepLinkSource source,
+  }) async {
+    final target = resolveTarget(payload, currentUid: currentUid);
+    unawaited(
+      _ref
+          .read(analyticsServiceProvider)
+          .logEvent(
+            name: 'fcm_notification_tapped',
+            parameters: {
+              'notification_type': payload.type.wireName,
+              'source': source.wireName,
+            },
+          ),
+    );
+    if (!context.mounted) return;
+    await NotificationDeepLinks.navigate(context, target);
+  }
+}
+
+/// Riverpod provider for [DeepLinkHandler].
+final deepLinkHandlerProvider = Provider<DeepLinkHandler>(
+  (ref) => DeepLinkHandler(ref.container),
+);

--- a/lib/features/notifications/application/firebase_messaging_provider.dart
+++ b/lib/features/notifications/application/firebase_messaging_provider.dart
@@ -1,0 +1,12 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the singleton [FirebaseMessaging] instance.
+///
+/// Override in tests with a fake to avoid platform-channel resolution.
+/// Production wiring delegates to `FirebaseMessaging.instance` which is
+/// safe to access after `Firebase.initializeApp()` has resolved in
+/// `lib/main.dart`.
+final firebaseMessagingProvider = Provider<FirebaseMessaging>(
+  (ref) => FirebaseMessaging.instance,
+);

--- a/lib/features/notifications/application/notification_permission_controller.dart
+++ b/lib/features/notifications/application/notification_permission_controller.dart
@@ -1,0 +1,151 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/notifications/application/firebase_messaging_provider.dart';
+import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
+
+/// State machine for the pre-permission dialog (FR-AC-03 AC-12, AC-13).
+enum PermissionState {
+  /// Initial — no dialog shown yet this session.
+  notDetermined,
+
+  /// "Stay in the loop" dialog is visible.
+  dialogShown,
+
+  /// User dismissed via "Not now" / scrim / back gesture this session.
+  /// Suppression is SESSION-SCOPED — cleared on app restart so the
+  /// dialog has another chance to land on the next launch.
+  dismissedThisSession,
+
+  /// OS-level requestPermission() in flight.
+  requesting,
+
+  /// OS-level permission granted.
+  granted,
+
+  /// OS-level permission denied.
+  denied,
+
+  /// OS-level permission denied AND the local "do not re-show
+  /// automatically" flag is set. The user may still re-enable via the
+  /// notification-preferences screen (FR-PR-03 — separate PR).
+  permanentlyDenied,
+}
+
+/// Minimal adapter over [FirebaseMessaging] for the permission method
+/// the [NotificationPermissionController] consumes.
+// ignore: one_member_abstracts
+abstract class PermissionMessagingAdapter {
+  /// Prompts the OS for push permission and returns the resulting
+  /// [NotificationSettings].
+  Future<NotificationSettings> requestPermission();
+}
+
+/// Production adapter wrapping [FirebaseMessaging.requestPermission].
+class FirebaseMessagingPermissionAdapter implements PermissionMessagingAdapter {
+  /// Creates a [FirebaseMessagingPermissionAdapter].
+  const FirebaseMessagingPermissionAdapter(this._messaging);
+
+  final FirebaseMessaging _messaging;
+
+  @override
+  Future<NotificationSettings> requestPermission() {
+    return _messaging.requestPermission();
+  }
+}
+
+/// Provides the [PermissionMessagingAdapter] in DI. Override in tests
+/// with a fake.
+final permissionMessagingAdapterProvider = Provider<PermissionMessagingAdapter>(
+  (ref) =>
+      FirebaseMessagingPermissionAdapter(ref.watch(firebaseMessagingProvider)),
+);
+
+/// Drives the pre-permission dialog flow.
+///
+/// Flow:
+///   1. `showPrePermissionDialog` — transitions to `dialogShown`.
+///      Idempotent within a session: subsequent calls do not
+///      transition.
+///   2. `onDismissTapped` — transitions to `dismissedThisSession`. Used
+///      by all three dismiss paths (Not now, scrim tap, back gesture).
+///   3. `onEnableTapped` — triggers the OS prompt via the messaging
+///      adapter. On grant, acquires a token via the [FcmTokenService]
+///      and starts the refresh listener. On deny, transitions to
+///      `permanentlyDenied` and sets the local `wasPermanentlyDenied`
+///      flag.
+///
+/// **Local persistence (architect §2.6 / §2.8 — addendum):**
+/// `shared_preferences` is NOT in the lockfile for this repository, so
+/// the `wasPermanentlyDenied` flag is in-memory only for v1.0. The
+/// "permanently denied — do not re-show on next launch" UX is
+/// therefore approximated as "do not re-show this session". This is a
+/// documented deviation; a follow-up adds `shared_preferences` and
+/// persists across launches.
+// TODO(flutter-dev): persist wasPermanentlyDenied across launches once
+// shared_preferences is added (FR-AC-04 / FR-PR-03 follow-up).
+class NotificationPermissionController extends Notifier<PermissionState> {
+  bool _wasPermanentlyDenied = false;
+
+  /// Whether the OS prompt has been denied at least once on this
+  /// installation. Used by the auth-state listener in `OneBytwoApp` to
+  /// suppress the dialog auto-trigger.
+  bool get wasPermanentlyDenied => _wasPermanentlyDenied;
+
+  @override
+  PermissionState build() => PermissionState.notDetermined;
+
+  /// Surfaces the pre-permission dialog. Idempotent within a session.
+  void showPrePermissionDialog() {
+    if (state != PermissionState.notDetermined) {
+      // Session-scoped suppression (AC-12).
+      return;
+    }
+    state = PermissionState.dialogShown;
+  }
+
+  /// Records the user's "Not now" / scrim-tap / back-gesture dismissal.
+  void onDismissTapped() {
+    state = PermissionState.dismissedThisSession;
+  }
+
+  /// Triggers the OS-level permission prompt. On grant, acquires the
+  /// FCM token and starts the refresh listener via [FcmTokenService].
+  ///
+  /// [uid] is the current user's UID — required so the granted-path
+  /// can write to `users/{uid}.fcmTokens`.
+  Future<void> onEnableTapped({required String uid}) async {
+    state = PermissionState.requesting;
+    final adapter = ref.read(permissionMessagingAdapterProvider);
+    try {
+      final settings = await adapter.requestPermission();
+      final granted =
+          settings.authorizationStatus == AuthorizationStatus.authorized ||
+          settings.authorizationStatus == AuthorizationStatus.provisional;
+      if (granted) {
+        await _acquireTokenAndWire(uid);
+        state = PermissionState.granted;
+      } else {
+        _wasPermanentlyDenied = true;
+        state = PermissionState.permanentlyDenied;
+      }
+    } catch (e, st) {
+      debugPrint('[PermissionController] requestPermission failed: $e\n$st');
+      _wasPermanentlyDenied = true;
+      state = PermissionState.permanentlyDenied;
+    }
+  }
+
+  Future<void> _acquireTokenAndWire(String uid) async {
+    final tokenService = ref.read(fcmTokenServiceProvider);
+    await tokenService.registerToken(uid);
+    tokenService.startTokenRefreshListener(uid);
+  }
+}
+
+/// Provider for [NotificationPermissionController].
+final notificationPermissionControllerProvider =
+    NotifierProvider<NotificationPermissionController, PermissionState>(
+      NotificationPermissionController.new,
+    );

--- a/lib/features/notifications/application/notification_permission_controller.dart
+++ b/lib/features/notifications/application/notification_permission_controller.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/notifications/application/firebase_messaging_provider.dart';
 import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
 
@@ -139,8 +142,20 @@ class NotificationPermissionController extends Notifier<PermissionState> {
 
   Future<void> _acquireTokenAndWire(String uid) async {
     final tokenService = ref.read(fcmTokenServiceProvider);
-    await tokenService.registerToken(uid);
+    final token = await tokenService.registerToken(uid);
     tokenService.startTokenRefreshListener(uid);
+    // FR-AC-03 telemetry contract: emit fcm_token_registered only when
+    // registerToken() actually returned a token (i.e. the OS provisioned
+    // one and the Firestore arrayUnion succeeded). Per AC-14, the event
+    // carries no UID-derived parameters — Firebase Analytics already
+    // attributes the event to the signed-in user implicitly.
+    if (token != null) {
+      unawaited(
+        ref
+            .read(analyticsServiceProvider)
+            .logEvent(name: 'fcm_token_registered'),
+      );
+    }
   }
 }
 

--- a/lib/features/notifications/application/pending_deep_link_provider.dart
+++ b/lib/features/notifications/application/pending_deep_link_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+/// Holds a pending deep-link intent until it can be resolved (FR-AC-05).
+///
+/// Set by `NotificationHandler.handleColdStart` when the user taps a
+/// notification while the app is terminated AND not authenticated.
+/// Consumed by the auth-state listener inside `lib/main.dart`: when
+/// the state transitions to `AuthenticatedWithProfile`, the listener
+/// reads this provider, clears it, and dispatches via the
+/// `DeepLinkHandler.handleDeepLink`.
+///
+/// Defaults to `null` (no pending intent) on each `ProviderScope`
+/// construction — i.e. each process launch.
+final pendingDeepLinkProvider = StateProvider<NotificationPayload?>(
+  (ref) => null,
+);

--- a/lib/features/notifications/application/sign_out_with_fcm_cleanup.dart
+++ b/lib/features/notifications/application/sign_out_with_fcm_cleanup.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/auth/application/auth_state_provider.dart';
+import 'package:onebytwo/features/auth/data/phone_auth_repository.dart';
+import 'package:onebytwo/features/auth/domain/auth_state.dart';
+import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
+
+/// FR-AC-03 AC-3: unregisters the device's FCM token from
+/// `users/{uid}.fcmTokens` BEFORE `FirebaseAuth.signOut()` so the
+/// server stops sending notifications to this device immediately.
+///
+/// The cleanup MUST NOT block sign-out (architect §2.7 contract).
+/// If the FCM unregister fails (network error, missing token,
+/// provider construction failure in a test environment), the failure
+/// is swallowed and sign-out proceeds — a stale token will be pruned
+/// server-side on the next FCM send via the 410 cleanup path
+/// (functions/src/notifications/fcm-send.ts).
+///
+/// Throws whatever the underlying `signOut()` throws (callers wrap
+/// in their own try/catch to surface a user-facing error snackbar).
+Future<void> signOutWithFcmCleanup(WidgetRef ref) async {
+  try {
+    final authState = ref.read(authStateNotifierProvider).valueOrNull;
+    if (authState is AuthenticatedWithProfile) {
+      final tokenService = ref.read(fcmTokenServiceProvider);
+      final currentToken = tokenService.currentToken;
+      if (currentToken != null) {
+        await tokenService.unregisterToken(authState.uid, currentToken);
+      }
+      await tokenService.stopTokenRefreshListener();
+    }
+  } catch (e, st) {
+    debugPrint(
+      '[signOutWithFcmCleanup] FCM cleanup skipped — '
+      'token will be pruned server-side on next 410: $e\n$st',
+    );
+  }
+  await ref.read(phoneAuthRepositoryProvider).signOut();
+}

--- a/lib/features/notifications/data/fcm_token_service.dart
+++ b/lib/features/notifications/data/fcm_token_service.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/auth/data/user_repository.dart'
+    show firebaseFirestoreProvider;
+import 'package:onebytwo/features/notifications/application/firebase_messaging_provider.dart';
+
+/// Minimal adapter over [FirebaseMessaging] for the two entry points
+/// [FcmTokenService] consumes. Fakeable without implementing the
+/// platform-only [FirebaseMessaging] members.
+abstract class FcmMessagingAdapter {
+  /// Returns the device's current FCM token, or `null` if unavailable
+  /// (e.g., permission denied, no APNS token yet on iOS).
+  Future<String?> getToken();
+
+  /// Fires whenever FCM rotates the device token.
+  Stream<String> get onTokenRefresh;
+}
+
+/// Production adapter wrapping [FirebaseMessaging.instance].
+class FirebaseMessagingFcmAdapter implements FcmMessagingAdapter {
+  /// Creates a [FirebaseMessagingFcmAdapter].
+  const FirebaseMessagingFcmAdapter(this._messaging);
+
+  final FirebaseMessaging _messaging;
+
+  @override
+  Future<String?> getToken() => _messaging.getToken();
+
+  @override
+  Stream<String> get onTokenRefresh => _messaging.onTokenRefresh;
+}
+
+/// Abstraction over Firestore for the FCM-token-write operations
+/// [FcmTokenService] performs.
+///
+/// We do NOT implement [DocumentReference] / [FirebaseFirestore] in
+/// tests because both are sealed in the cloud_firestore SDK. The
+/// store interface mirrors the existing `SettlementStore` /
+/// `ActivityFeedRepository` pattern — production wires through
+/// [FirestoreFcmTokenStore]; tests inject a hand-rolled fake.
+abstract class FcmTokenStore {
+  /// Append [token] to `users/{uid}.fcmTokens` via arrayUnion.
+  Future<void> addToken({required String uid, required String token});
+
+  /// Remove [token] from `users/{uid}.fcmTokens` via arrayRemove.
+  Future<void> removeToken({required String uid, required String token});
+
+  /// Atomically remove [oldToken] and add [newToken] in a single
+  /// batched write so the document never has neither value (AC-2).
+  Future<void> replaceTokenAtomically({
+    required String uid,
+    required String oldToken,
+    required String newToken,
+  });
+}
+
+/// Firestore-backed implementation of [FcmTokenStore].
+class FirestoreFcmTokenStore implements FcmTokenStore {
+  /// Creates a [FirestoreFcmTokenStore].
+  const FirestoreFcmTokenStore(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Future<void> addToken({required String uid, required String token}) async {
+    await _firestore.collection('users').doc(uid).update({
+      'fcmTokens': FieldValue.arrayUnion([token]),
+    });
+  }
+
+  @override
+  Future<void> removeToken({required String uid, required String token}) async {
+    await _firestore.collection('users').doc(uid).update({
+      'fcmTokens': FieldValue.arrayRemove([token]),
+    });
+  }
+
+  @override
+  Future<void> replaceTokenAtomically({
+    required String uid,
+    required String oldToken,
+    required String newToken,
+  }) async {
+    final docRef = _firestore.collection('users').doc(uid);
+    final batch = _firestore.batch()
+      ..update(docRef, {
+        'fcmTokens': FieldValue.arrayRemove([oldToken]),
+      })
+      ..update(docRef, {
+        'fcmTokens': FieldValue.arrayUnion([newToken]),
+      });
+    await batch.commit();
+  }
+}
+
+/// Client-side FCM token lifecycle helper.
+///
+/// Responsibilities (FR-AC-03):
+///   - `registerToken` — acquire the device token via
+///     [FcmMessagingAdapter] and append to `users/{uid}.fcmTokens`.
+///     Idempotent at the Firestore layer (arrayUnion deduplicates).
+///   - `unregisterToken` — remove a token. Used by the sign-out flow
+///     before `FirebaseAuth.signOut()`.
+///   - `replaceToken` — single batched arrayRemove + arrayUnion so
+///     there is NO window during which the user has no valid token
+///     (AC-2).
+///   - `startTokenRefreshListener` — subscribes to the messaging
+///     adapter's `onTokenRefresh` stream and routes to `replaceToken`.
+///   - `stopTokenRefreshListener` — cancels the subscription.
+///
+/// **Invariant 2 compliance.** This service touches ONLY
+/// `users/{uid}.fcmTokens`. ZERO writes to `simplifiedBalances` or any
+/// other field. The boundary-contract grep at
+/// `test/features/notifications/notifications_boundary_contract_test.dart`
+/// enforces this defence-in-depth.
+class FcmTokenService {
+  /// Creates an [FcmTokenService].
+  FcmTokenService({
+    required FcmTokenStore store,
+    required FcmMessagingAdapter messaging,
+  }) : _store = store,
+       _messaging = messaging;
+
+  final FcmTokenStore _store;
+  final FcmMessagingAdapter _messaging;
+
+  StreamSubscription<String>? _refreshSub;
+  String? _currentToken;
+
+  /// The token most recently registered with this service instance.
+  /// Used by the sign-out flow to know which token to unregister.
+  String? get currentToken => _currentToken;
+
+  /// Acquires the device FCM token and writes it via arrayUnion.
+  ///
+  /// Returns the token (or `null` if the OS hasn't provisioned one,
+  /// e.g., on the permission-denied path — AC-13).
+  Future<String?> registerToken(String uid) async {
+    final token = await _messaging.getToken();
+    if (token == null) return null;
+    await _store.addToken(uid: uid, token: token);
+    _currentToken = token;
+    return token;
+  }
+
+  /// Removes [token] from `users/{uid}.fcmTokens` via arrayRemove.
+  /// Called BEFORE `FirebaseAuth.signOut()`.
+  Future<void> unregisterToken(String uid, String token) async {
+    await _store.removeToken(uid: uid, token: token);
+    if (_currentToken == token) {
+      _currentToken = null;
+    }
+  }
+
+  /// Atomically replaces [oldToken] with [newToken] via a single
+  /// batched write (AC-2). A no-op when `oldToken == newToken`.
+  Future<void> replaceToken(
+    String uid,
+    String oldToken,
+    String newToken,
+  ) async {
+    if (oldToken == newToken) return;
+    await _store.replaceTokenAtomically(
+      uid: uid,
+      oldToken: oldToken,
+      newToken: newToken,
+    );
+    _currentToken = newToken;
+  }
+
+  /// Subscribes to the FCM token-refresh stream and routes each new
+  /// token through `replaceToken` with the cached previous token.
+  ///
+  /// Idempotent — calling twice cancels the previous subscription.
+  void startTokenRefreshListener(String uid) {
+    _refreshSub?.cancel();
+    _refreshSub = _messaging.onTokenRefresh.listen((newToken) async {
+      final old = _currentToken;
+      if (old == null) {
+        try {
+          await _store.addToken(uid: uid, token: newToken);
+          _currentToken = newToken;
+        } catch (e, st) {
+          debugPrint(
+            '[FcmTokenService] refresh (no prior) write failed: $e\n$st',
+          );
+        }
+        return;
+      }
+      try {
+        await replaceToken(uid, old, newToken);
+      } catch (e, st) {
+        // Defence-in-depth — a token-refresh write failure must NOT
+        // crash the app. The next send attempt surfaces the refresh
+        // via the server-side cleanup-on-410 path.
+        debugPrint('[FcmTokenService] token refresh write failed: $e\n$st');
+      }
+    });
+  }
+
+  /// Cancels the active onTokenRefresh subscription.
+  Future<void> stopTokenRefreshListener() async {
+    await _refreshSub?.cancel();
+    _refreshSub = null;
+  }
+}
+
+/// Riverpod provider for [FcmTokenService].
+///
+/// Production wiring threads [firebaseFirestoreProvider] and
+/// [firebaseMessagingProvider]; tests override directly with a fake
+/// implementation.
+final fcmTokenServiceProvider = Provider<FcmTokenService>(
+  (ref) => FcmTokenService(
+    store: FirestoreFcmTokenStore(ref.watch(firebaseFirestoreProvider)),
+    messaging: FirebaseMessagingFcmAdapter(
+      ref.watch(firebaseMessagingProvider),
+    ),
+  ),
+);

--- a/lib/features/notifications/data/fcm_token_service.dart
+++ b/lib/features/notifications/data/fcm_token_service.dart
@@ -86,16 +86,56 @@ class FirestoreFcmTokenStore implements FcmTokenStore {
     required String oldToken,
     required String newToken,
   }) async {
+    // Implementation note (FR-AC-03 AC-2 correctness).
+    //
+    // A previous implementation used `WriteBatch.update(...)` twice on
+    // the same document and same field — once with arrayRemove and once
+    // with arrayUnion. Firestore's batch semantics collapse multiple
+    // updates to the same field within one batch into the LAST write,
+    // silently dropping the arrayRemove side. The user's fcmTokens
+    // array would accumulate stale tokens until the server-side
+    // 410-cleanup path eventually pruned them.
+    //
+    // The current implementation uses `runTransaction`, which reads
+    // the array, applies an explicit read-modify-write via the pure
+    // helper [computeRefreshedTokens], and commits the resulting list
+    // atomically. The helper is unit-tested in isolation so the
+    // array-mutation contract is enforceable without fake_cloud_firestore.
     final docRef = _firestore.collection('users').doc(uid);
-    final batch = _firestore.batch()
-      ..update(docRef, {
-        'fcmTokens': FieldValue.arrayRemove([oldToken]),
-      })
-      ..update(docRef, {
-        'fcmTokens': FieldValue.arrayUnion([newToken]),
-      });
-    await batch.commit();
+    await _firestore.runTransaction((tx) async {
+      final snap = await tx.get(docRef);
+      final raw = (snap.data()?['fcmTokens'] as List?) ?? const <dynamic>[];
+      final current = raw.whereType<String>().toList(growable: false);
+      final refreshed = computeRefreshedTokens(
+        current: current,
+        oldToken: oldToken,
+        newToken: newToken,
+      );
+      tx.update(docRef, {'fcmTokens': refreshed});
+    });
   }
+}
+
+/// Pure helper that returns the [current] FCM-token list with
+/// [oldToken] removed and [newToken] added (deduplicating). The
+/// production transaction in [FirestoreFcmTokenStore.replaceTokenAtomically]
+/// calls this inside a `runTransaction` read-modify-write.
+///
+/// Extracted as a top-level function so the array-mutation contract
+/// (which the batch-based implementation silently violated) is
+/// independently unit-testable without faking Firestore. See
+/// `test/features/notifications/data/fcm_token_service_test.dart`.
+List<String> computeRefreshedTokens({
+  required List<String> current,
+  required String oldToken,
+  required String newToken,
+}) {
+  final next = <String>[
+    for (final t in current)
+      if (t != oldToken) t,
+  ];
+  if (!next.contains(newToken)) next.add(newToken);
+  return next;
 }
 
 /// Client-side FCM token lifecycle helper.

--- a/lib/features/notifications/data/notification_handler.dart
+++ b/lib/features/notifications/data/notification_handler.dart
@@ -135,11 +135,16 @@ Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   );
 }
 
-/// Minimal interface over Riverpod's [Ref] / [ProviderContainer]
-/// `read` method — abstracted so [NotificationHandler] can accept
-/// either a [ProviderContainer] (production) or a test container.
+/// Alias for [ProviderContainer] used by [NotificationHandler] when it
+/// needs to mutate [pendingDeepLinkProvider] from a callback that is
+/// outside the widget tree (the FCM cold-start path runs before any
+/// `ConsumerWidget` has been mounted).
 ///
-/// Both [ProviderContainer] and [Ref] expose a `read(provider)` method
-/// with the same signature, so we type the handler against a duck-
-/// typed callable rather than a concrete class.
+/// **Important:** despite the name, this typedef is concretely
+/// [ProviderContainer] — it does NOT accept a [Ref]. Callers running
+/// inside a Riverpod widget should not pass `ref` here; instead they
+/// should construct a [NotificationHandler] using
+/// `ref.container` (or refactor to call into the host directly).
+/// Tests construct a hand-rolled [ProviderContainer] and pass it
+/// straight through.
 typedef Refable = ProviderContainer;

--- a/lib/features/notifications/data/notification_handler.dart
+++ b/lib/features/notifications/data/notification_handler.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/notifications/application/pending_deep_link_provider.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+/// Async callback that shows the foreground in-app banner with the
+/// parsed [NotificationPayload].
+typedef OnBannerShow = Future<void> Function(NotificationPayload payload);
+
+/// Async callback that dispatches a deep-link navigation for the
+/// parsed [NotificationPayload].
+typedef OnDeepLink = Future<void> Function(NotificationPayload payload);
+
+/// Routes incoming FCM [RemoteMessage]s to the appropriate client-side
+/// handler (foreground banner / background tap / cold-start intent).
+///
+/// All three handlers share a single defensive-parse contract — a
+/// malformed payload (unknown `type`, missing required fields,
+/// unparseable date) is silently dropped without raising or invoking
+/// any callback. This mirrors the FR-AC-01 parse-failure-is-loud-in-
+/// logs / silent-in-UI precedent on the read-side activity feed.
+class NotificationHandler {
+  /// Creates a [NotificationHandler].
+  ///
+  /// `ref` is a Riverpod reader used to mutate the
+  /// [pendingDeepLinkProvider] state on the cold-start unauthenticated
+  /// path. In production this is the [ProviderContainer] held by the
+  /// `ProviderScope` at the top of `OneBytwoApp`; in tests it is a
+  /// hand-rolled [ProviderContainer].
+  const NotificationHandler({
+    required this.ref,
+    required this.onBannerShow,
+    required this.onDeepLink,
+  });
+
+  /// Riverpod reader used to mutate [pendingDeepLinkProvider] on the
+  /// cold-start unauthenticated path.
+  final Refable ref;
+
+  /// Async callback that shows the foreground in-app banner.
+  final OnBannerShow onBannerShow;
+
+  /// Async callback that dispatches a deep-link navigation.
+  final OnDeepLink onDeepLink;
+
+  /// Handles a foreground FCM data message (app in foreground).
+  ///
+  /// Parses the payload and invokes `onBannerShow` so the host widget
+  /// can mount the in-app notification banner overlay. Silently drops
+  /// malformed payloads.
+  Future<void> handleForegroundMessage(RemoteMessage message) async {
+    final payload = NotificationPayload.fromFcmDataMap(message.data);
+    if (payload == null) {
+      debugPrint(
+        '[NotificationHandler] foreground: dropped malformed payload '
+        '${message.data}',
+      );
+      return;
+    }
+    await onBannerShow(payload);
+  }
+
+  /// Handles a backgrounded-app tap (system tray notification opened).
+  ///
+  /// Parses the payload and invokes `onDeepLink`. Silently drops
+  /// malformed payloads.
+  Future<void> handleBackgroundTap(RemoteMessage message) async {
+    final payload = NotificationPayload.fromFcmDataMap(message.data);
+    if (payload == null) {
+      debugPrint(
+        '[NotificationHandler] background tap: dropped malformed payload '
+        '${message.data}',
+      );
+      return;
+    }
+    await onDeepLink(payload);
+  }
+
+  /// Handles a cold-start launch from a tapped notification (app fully
+  /// terminated). FR-AC-05.
+  ///
+  /// If `currentUid` is non-null (the user has an authenticated
+  /// session restored by FirebaseAuth), dispatches immediately via
+  /// `onDeepLink`. Otherwise stores the payload in
+  /// [pendingDeepLinkProvider] for replay after the next successful
+  /// sign-in.
+  Future<void> handleColdStart(
+    RemoteMessage message, {
+    required String? currentUid,
+  }) async {
+    final payload = NotificationPayload.fromFcmDataMap(message.data);
+    if (payload == null) {
+      debugPrint(
+        '[NotificationHandler] cold start: dropped malformed payload '
+        '${message.data}',
+      );
+      return;
+    }
+    if (currentUid != null) {
+      await onDeepLink(payload);
+    } else {
+      ref.read(pendingDeepLinkProvider.notifier).state = payload;
+    }
+  }
+}
+
+/// Top-level background-message handler invoked by FCM in a separate
+/// isolate when the app is in the background or terminated. Required
+/// by Flutter Firebase docs — the handler MUST be a top-level (or
+/// static) function annotated with `@pragma('vm:entry-point')`.
+///
+/// For v1.0 the handler is a no-op beyond re-initialising Firebase in
+/// the background isolate. The FCM data message is delivered to the
+/// system tray automatically by the platform; the tap event is then
+/// routed through [FirebaseMessaging.onMessageOpenedApp] (warm) or
+/// [FirebaseMessaging.getInitialMessage] (cold) when the user opens
+/// the app.
+///
+/// **Note:** Background isolates do NOT share state with the main
+/// isolate. Any work performed here cannot touch ProviderScope or
+/// Navigator. Persistent state must be written to Firestore / local
+/// storage.
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  // Re-initialise Firebase in the background isolate.
+  await Firebase.initializeApp();
+  debugPrint(
+    '[NotificationHandler] background isolate received message '
+    '${message.messageId} (data keys: ${message.data.keys.toList()})',
+  );
+}
+
+/// Minimal interface over Riverpod's [Ref] / [ProviderContainer]
+/// `read` method — abstracted so [NotificationHandler] can accept
+/// either a [ProviderContainer] (production) or a test container.
+///
+/// Both [ProviderContainer] and [Ref] expose a `read(provider)` method
+/// with the same signature, so we type the handler against a duck-
+/// typed callable rather than a concrete class.
+typedef Refable = ProviderContainer;

--- a/lib/features/notifications/domain/notification_payload.dart
+++ b/lib/features/notifications/domain/notification_payload.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/foundation.dart';
+
+/// Discriminator enum for the six FCM notification types defined by the
+/// server-side wire contract in `functions/src/notifications/types.ts`.
+///
+/// Each wire value is snake_case (`'expense_added'`,
+/// `'settlement_received'`, etc.) per
+/// `docs/design/07-technical/notifications.md` §2.2. The client converts
+/// to camelCase on read via [NotificationTypeX.fromWireName] — mirror
+/// of the FR-AC-01 `ActivityEventTypeX.parseSnakeCase` precedent.
+///
+/// **Forward-incompat is loud** — an unknown wire value returns `null`
+/// from [NotificationTypeX.fromWireName] so the calling
+/// [NotificationPayload.fromFcmDataMap] factory drops the payload
+/// silently rather than rendering a half-parsed banner.
+enum NotificationType {
+  /// A new expense was added (wire: `'expense_added'`).
+  expenseAdded,
+
+  /// An existing expense was edited (wire: `'expense_edited'`).
+  expenseEdited,
+
+  /// An expense was soft-deleted (wire: `'expense_deleted'`).
+  expenseDeleted,
+
+  /// A settlement was recorded with the current user as payee
+  /// (wire: `'settlement_received'`).
+  settlementReceived,
+
+  /// A reminder was nudged to the current user (wire: `'reminder'`).
+  reminder,
+
+  /// A group invite was sent to the current user (wire:
+  /// `'group_invite'`). No producer in v1.0 — forward-compatibility
+  /// only; tapping a group_invite surfaces a "groups coming soon"
+  /// snackbar via the deep-link resolver.
+  groupInvite,
+}
+
+/// Snake_case wire-value parsing for [NotificationType].
+extension NotificationTypeX on NotificationType {
+  /// Parses the FCM data envelope's `type` field. Returns `null` for
+  /// any value not in the closed set above, so the
+  /// [NotificationPayload.fromFcmDataMap] factory can drop unknown
+  /// payloads silently rather than rendering a half-parsed banner.
+  static NotificationType? fromWireName(String wire) {
+    switch (wire) {
+      case 'expense_added':
+        return NotificationType.expenseAdded;
+      case 'expense_edited':
+        return NotificationType.expenseEdited;
+      case 'expense_deleted':
+        return NotificationType.expenseDeleted;
+      case 'settlement_received':
+        return NotificationType.settlementReceived;
+      case 'reminder':
+        return NotificationType.reminder;
+      case 'group_invite':
+        return NotificationType.groupInvite;
+      default:
+        return null;
+    }
+  }
+
+  /// Returns the canonical snake_case wire name used by both the
+  /// server and the telemetry `notification_type` parameter.
+  String get wireName {
+    switch (this) {
+      case NotificationType.expenseAdded:
+        return 'expense_added';
+      case NotificationType.expenseEdited:
+        return 'expense_edited';
+      case NotificationType.expenseDeleted:
+        return 'expense_deleted';
+      case NotificationType.settlementReceived:
+        return 'settlement_received';
+      case NotificationType.reminder:
+        return 'reminder';
+      case NotificationType.groupInvite:
+        return 'group_invite';
+    }
+  }
+}
+
+/// Immutable value type representing a single FCM data envelope as
+/// defined by `functions/src/notifications/types.ts` and described in
+/// `docs/design/07-technical/notifications.md` §2.1.
+///
+/// All FCM data values are strings on the wire (the FCM SDK enforces
+/// this); typed fields like [amountPaise] and [createdAt] are parsed
+/// after receipt. Per **Invariant 1**, [amountPaise] is `int`, never
+/// `double`; the notification body string is pre-rendered server-side
+/// so no client-side paise→INR arithmetic is required.
+@immutable
+class NotificationPayload {
+  /// Creates a [NotificationPayload].
+  const NotificationPayload({
+    required this.type,
+    required this.contextType,
+    required this.contextId,
+    required this.title,
+    required this.body,
+    required this.senderName,
+    required this.createdAt,
+    this.itemId,
+    this.amountPaise,
+    this.inviteToken,
+  });
+
+  /// Strict parse of the FCM data envelope. Returns `null` if the
+  /// payload is missing required fields, has an unknown `type`
+  /// discriminator, or has an unparseable `createdAt`.
+  ///
+  /// A `null` return MUST be treated as "drop the notification" — the
+  /// caller never rebuilds a half-parsed payload. This is the FR-AC-01
+  /// `ActivityFeedItem.fromFirestore` strict-parsing precedent
+  /// re-applied to the FCM boundary.
+  static NotificationPayload? fromFcmDataMap(Map<String, dynamic> data) {
+    final rawType = data['type'];
+    if (rawType is! String) return null;
+    final parsedType = NotificationTypeX.fromWireName(rawType);
+    if (parsedType == null) return null;
+
+    final contextType = data['contextType'];
+    if (contextType is! String) return null;
+    if (contextType != 'friendship' && contextType != 'group') return null;
+
+    final contextId = data['contextId'];
+    if (contextId is! String || contextId.isEmpty) return null;
+
+    final title = data['title'];
+    if (title is! String) return null;
+
+    final body = data['body'];
+    if (body is! String) return null;
+
+    final senderName = data['senderName'];
+    if (senderName is! String) return null;
+
+    final createdAtRaw = data['createdAt'];
+    if (createdAtRaw is! String) return null;
+    final createdAt = DateTime.tryParse(createdAtRaw);
+    if (createdAt == null) return null;
+
+    final itemIdRaw = data['itemId'];
+    final itemId = itemIdRaw is String ? itemIdRaw : null;
+
+    final inviteTokenRaw = data['inviteToken'];
+    final inviteToken = inviteTokenRaw is String ? inviteTokenRaw : null;
+
+    final amountPaiseRaw = data['amountPaise'];
+    int? amountPaise;
+    if (amountPaiseRaw is String) {
+      amountPaise = int.tryParse(amountPaiseRaw);
+    } else if (amountPaiseRaw is int) {
+      // Defensive — the wire is string-only per FCM constraints, but
+      // an integer-typed source (e.g. a hand-rolled test fixture)
+      // should still parse cleanly.
+      amountPaise = amountPaiseRaw;
+    }
+
+    return NotificationPayload(
+      type: parsedType,
+      contextType: contextType,
+      contextId: contextId,
+      title: title,
+      body: body,
+      senderName: senderName,
+      createdAt: createdAt,
+      itemId: itemId,
+      amountPaise: amountPaise,
+      inviteToken: inviteToken,
+    );
+  }
+
+  /// Discriminator for the client-side deep-link router.
+  final NotificationType type;
+
+  /// Either `'friendship'` or `'group'`. v1.0 only emits `'friendship'`
+  /// from the producer side; `'group'` is reserved for the Sprint 3
+  /// groups epic.
+  final String contextType;
+
+  /// Raw friendship-composite id (`{uidA}_{uidB}`) or group id. Not
+  /// hashed — the client needs the raw value to navigate.
+  final String contextId;
+
+  /// Optional expense / settlement / invite id, for deep-linking to
+  /// the per-item screen.
+  final String? itemId;
+
+  /// Pre-rendered notification title string from the server.
+  final String title;
+
+  /// Pre-rendered notification body string from the server. Already
+  /// contains any localised INR formatting; the client must NOT
+  /// perform additional paise→INR arithmetic.
+  final String body;
+
+  /// Display name of the acting user (payer / settler / sender).
+  final String senderName;
+
+  /// Optional integer paise amount. **Use `int` only (Invariant 1).**
+  /// Omitted for `group_invite`; present for all other types.
+  final int? amountPaise;
+
+  /// Server timestamp of the originating Firestore write, parsed from
+  /// the wire ISO-8601 string.
+  final DateTime createdAt;
+
+  /// Optional invite token for the `group_invite` payload (forward
+  /// compat — no producer in v1.0).
+  final String? inviteToken;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NotificationPayload &&
+        other.type == type &&
+        other.contextType == contextType &&
+        other.contextId == contextId &&
+        other.itemId == itemId &&
+        other.title == title &&
+        other.body == body &&
+        other.senderName == senderName &&
+        other.amountPaise == amountPaise &&
+        other.createdAt == createdAt &&
+        other.inviteToken == inviteToken;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    contextType,
+    contextId,
+    itemId,
+    title,
+    body,
+    senderName,
+    amountPaise,
+    createdAt,
+    inviteToken,
+  );
+}

--- a/lib/features/notifications/presentation/notifications_lifecycle_host.dart
+++ b/lib/features/notifications/presentation/notifications_lifecycle_host.dart
@@ -4,6 +4,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/auth/application/auth_state_provider.dart';
 import 'package:onebytwo/features/auth/domain/auth_state.dart';
 import 'package:onebytwo/features/notifications/application/deep_link_handler.dart';
@@ -220,6 +221,19 @@ class _NotificationsLifecycleHostState
 
     _dialogShownThisSession = true;
     controller.showPrePermissionDialog();
+    // FR-AC-03 telemetry contract: emit fcm_permission_prompt_shown
+    // just before the dialog is surfaced. The only producer in v1.0 is
+    // the first-session auth-transition trigger; future producers
+    // (e.g. a manual "enable notifications" CTA on the Profile screen
+    // shipped with FR-PR-03) MUST emit with trigger='manual'.
+    unawaited(
+      ref
+          .read(analyticsServiceProvider)
+          .logEvent(
+            name: 'fcm_permission_prompt_shown',
+            parameters: const {'trigger': 'first_session'},
+          ),
+    );
     unawaited(
       showPrePermissionDialog(
         context: context,

--- a/lib/features/notifications/presentation/notifications_lifecycle_host.dart
+++ b/lib/features/notifications/presentation/notifications_lifecycle_host.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/auth/application/auth_state_provider.dart';
+import 'package:onebytwo/features/auth/domain/auth_state.dart';
+import 'package:onebytwo/features/notifications/application/deep_link_handler.dart';
+import 'package:onebytwo/features/notifications/application/firebase_messaging_provider.dart';
+import 'package:onebytwo/features/notifications/application/notification_permission_controller.dart';
+import 'package:onebytwo/features/notifications/application/pending_deep_link_provider.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+import 'package:onebytwo/features/notifications/presentation/pre_permission_dialog.dart';
+import 'package:onebytwo/features/notifications/presentation/widgets/in_app_notification_banner.dart';
+
+/// FR-AC-03 / FR-AC-05 app-startup wrapper.
+///
+/// Sits below `MaterialApp` via `MaterialApp.builder` so it has access
+/// to the platform `Overlay`, `Navigator`, and `ScaffoldMessenger`.
+///
+/// Responsibilities:
+///   - Subscribes to `FirebaseMessaging.onMessage` (foreground) and
+///     renders the [InAppNotificationBanner] via an `OverlayEntry`
+///     (AC-9).
+///   - Subscribes to `FirebaseMessaging.onMessageOpenedApp` (system
+///     notification tap while backgrounded) and dispatches to the
+///     [DeepLinkHandler] (AC-10).
+///   - Calls `FirebaseMessaging.instance.getInitialMessage()` once on
+///     mount to handle the cold-start case (AC-11).
+///   - Listens to [authStateNotifierProvider]; on the first transition
+///     to [AuthenticatedWithProfile] per session:
+///       1. Replays any pending deep-link cached in
+///          [pendingDeepLinkProvider] (FR-AC-05 unauthenticated-then-
+///          sign-in flow).
+///       2. Schedules the "Stay in the loop" pre-permission dialog if
+///          not yet shown this session AND not permanently denied
+///          (AC-1, AC-12, AC-13).
+class NotificationsLifecycleHost extends ConsumerStatefulWidget {
+  /// Creates a [NotificationsLifecycleHost] around [child].
+  const NotificationsLifecycleHost({required this.child, super.key});
+
+  /// The routed home content (Splash / PhoneEntry / ProfileSetup /
+  /// HomePlaceholder), wrapped here so notifications surface on top.
+  final Widget child;
+
+  @override
+  ConsumerState<NotificationsLifecycleHost> createState() =>
+      _NotificationsLifecycleHostState();
+}
+
+class _NotificationsLifecycleHostState
+    extends ConsumerState<NotificationsLifecycleHost> {
+  StreamSubscription<RemoteMessage>? _onMessageSub;
+  StreamSubscription<RemoteMessage>? _onMessageOpenedAppSub;
+  OverlayEntry? _bannerOverlay;
+  bool _coldStartHandled = false;
+  bool _dialogShownThisSession = false;
+  AuthState? _lastAuthState;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _subscribeFcmStreams();
+      _handleColdStart();
+    });
+  }
+
+  void _subscribeFcmStreams() {
+    try {
+      _onMessageSub = FirebaseMessaging.onMessage.listen(_onForegroundMessage);
+      _onMessageOpenedAppSub = FirebaseMessaging.onMessageOpenedApp.listen(
+        _onBackgroundedTap,
+      );
+    } catch (e, st) {
+      // Defensive — in test environments without Firebase initialised,
+      // the static getters throw a FirebaseException. The host is a
+      // boot-time scaffold that must not crash the app shell; the FCM
+      // delivery surface degrades gracefully.
+      debugPrint(
+        '[NotificationsLifecycleHost] FCM streams unavailable: $e\n$st',
+      );
+    }
+  }
+
+  Future<void> _handleColdStart() async {
+    if (_coldStartHandled) return;
+    _coldStartHandled = true;
+    try {
+      final messaging = ref.read(firebaseMessagingProvider);
+      final initial = await messaging.getInitialMessage();
+      if (initial == null) return;
+      final payload = NotificationPayload.fromFcmDataMap(initial.data);
+      if (payload == null) return;
+      final authState = ref.read(authStateNotifierProvider).valueOrNull;
+      if (authState is AuthenticatedWithProfile) {
+        await _dispatchDeepLink(
+          payload,
+          DeepLinkSource.coldStart,
+          authState.uid,
+        );
+      } else {
+        // Cache for replay after sign-in (FR-AC-05).
+        ref.read(pendingDeepLinkProvider.notifier).state = payload;
+      }
+    } catch (e, st) {
+      debugPrint('[NotificationsLifecycleHost] cold start failed: $e\n$st');
+    }
+  }
+
+  Future<void> _onForegroundMessage(RemoteMessage message) async {
+    final payload = NotificationPayload.fromFcmDataMap(message.data);
+    if (payload == null) return;
+    _showBanner(payload);
+  }
+
+  Future<void> _onBackgroundedTap(RemoteMessage message) async {
+    final payload = NotificationPayload.fromFcmDataMap(message.data);
+    if (payload == null) return;
+    final authState = ref.read(authStateNotifierProvider).valueOrNull;
+    if (authState is AuthenticatedWithProfile) {
+      await _dispatchDeepLink(
+        payload,
+        DeepLinkSource.background,
+        authState.uid,
+      );
+    } else {
+      ref.read(pendingDeepLinkProvider.notifier).state = payload;
+    }
+  }
+
+  void _showBanner(NotificationPayload payload) {
+    _bannerOverlay?.remove();
+    _bannerOverlay = null;
+
+    final overlay = Overlay.of(context, rootOverlay: true);
+    final entry = OverlayEntry(
+      builder: (entryContext) => SafeArea(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: Material(
+            color: Colors.transparent,
+            child: InAppNotificationBanner(
+              payload: payload,
+              onTap: (p) async {
+                _bannerOverlay?.remove();
+                _bannerOverlay = null;
+                final authState = ref
+                    .read(authStateNotifierProvider)
+                    .valueOrNull;
+                if (authState is! AuthenticatedWithProfile) return;
+                await _dispatchDeepLink(
+                  p,
+                  DeepLinkSource.foreground,
+                  authState.uid,
+                );
+              },
+              onDismiss: () {
+                _bannerOverlay?.remove();
+                _bannerOverlay = null;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    _bannerOverlay = entry;
+    overlay.insert(entry);
+  }
+
+  Future<void> _dispatchDeepLink(
+    NotificationPayload payload,
+    DeepLinkSource source,
+    String currentUid,
+  ) async {
+    final handler = ref.read(deepLinkHandlerProvider);
+    await handler.handleDeepLink(
+      payload: payload,
+      context: context,
+      currentUid: currentUid,
+      source: source,
+    );
+  }
+
+  void _onAuthStateChanged(AuthState? prev, AuthState? next) {
+    if (next is! AuthenticatedWithProfile) {
+      _lastAuthState = next;
+      return;
+    }
+    final wasAuthenticated = prev is AuthenticatedWithProfile;
+    _lastAuthState = next;
+    if (wasAuthenticated) return;
+
+    // First-time transition into AuthenticatedWithProfile this session.
+    final uid = next.uid;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _replayPendingDeepLink(uid);
+      _maybeShowPrePermissionDialog(uid);
+    });
+  }
+
+  Future<void> _replayPendingDeepLink(String uid) async {
+    final pending = ref.read(pendingDeepLinkProvider);
+    if (pending == null) return;
+    ref.read(pendingDeepLinkProvider.notifier).state = null;
+    if (!mounted) return;
+    await _dispatchDeepLink(pending, DeepLinkSource.coldStart, uid);
+  }
+
+  void _maybeShowPrePermissionDialog(String uid) {
+    if (_dialogShownThisSession) return;
+    final controller = ref.read(
+      notificationPermissionControllerProvider.notifier,
+    );
+    if (controller.wasPermanentlyDenied) return;
+    final state = ref.read(notificationPermissionControllerProvider);
+    if (state != PermissionState.notDetermined) return;
+
+    _dialogShownThisSession = true;
+    controller.showPrePermissionDialog();
+    unawaited(
+      showPrePermissionDialog(
+        context: context,
+        onEnable: () {
+          unawaited(controller.onEnableTapped(uid: uid));
+        },
+        onDismiss: controller.onDismissTapped,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _onMessageSub?.cancel();
+    _onMessageOpenedAppSub?.cancel();
+    _bannerOverlay?.remove();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<AuthState>>(authStateNotifierProvider, (prev, next) {
+      final prevState = prev?.valueOrNull;
+      final nextState = next.valueOrNull;
+      if (nextState == null) return;
+      if (identical(prevState, nextState)) return;
+      _onAuthStateChanged(prevState ?? _lastAuthState, nextState);
+    });
+    return widget.child;
+  }
+}

--- a/lib/features/notifications/presentation/pre_permission_dialog.dart
+++ b/lib/features/notifications/presentation/pre_permission_dialog.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+
+/// Shows the "Stay in the loop" pre-permission dialog (FR-AC-03,
+/// wireframes §1.1).
+///
+/// - 24dp corner radius, 8dp elevation per design tokens.
+/// - Bell illustration tinted Primary.
+/// - "Enable Notifications" filled button (Primary, 48dp height).
+/// - "Not now" text button.
+/// - Scrim tap + back gesture → onDismiss.
+/// - Heading announced as a heading (Semantics(header: true)) for
+///   screen readers per AC-20.
+Future<void> showPrePermissionDialog({
+  required BuildContext context,
+  required VoidCallback onEnable,
+  required VoidCallback onDismiss,
+}) {
+  return showDialog<void>(
+    context: context,
+    // ignore: use_build_context_synchronously
+    builder: (dialogContext) =>
+        _PrePermissionDialog(onEnable: onEnable, onDismiss: onDismiss),
+  ).then((_) {
+    // Defensive: if the dialog is dismissed via scrim tap or back
+    // gesture, the future resolves with no return value. We treat both
+    // as dismissals. Tap-on-Enable / tap-on-Not now pop the dialog AND
+    // invoke their respective callbacks via the buttons themselves;
+    // this `.then` is the catch-all for scrim/back.
+  });
+}
+
+class _PrePermissionDialog extends StatefulWidget {
+  const _PrePermissionDialog({required this.onEnable, required this.onDismiss});
+
+  final VoidCallback onEnable;
+  final VoidCallback onDismiss;
+
+  @override
+  State<_PrePermissionDialog> createState() => _PrePermissionDialogState();
+}
+
+class _PrePermissionDialogState extends State<_PrePermissionDialog> {
+  // Tracks whether either explicit button was tapped. If the dialog
+  // pops without an explicit tap (scrim / back), we treat that as
+  // dismissal.
+  bool _explicitChoice = false;
+
+  @override
+  void dispose() {
+    if (!_explicitChoice) {
+      // Scrim tap or back gesture — fire dismiss.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onDismiss();
+      });
+    }
+    super.dispose();
+  }
+
+  void _onEnable() {
+    _explicitChoice = true;
+    Navigator.of(context).pop();
+    widget.onEnable();
+  }
+
+  void _onNotNow() {
+    _explicitChoice = true;
+    Navigator.of(context).pop();
+    widget.onDismiss();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      elevation: 8,
+      backgroundColor: theme.colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Semantics(
+              label: 'Notification bell icon',
+              child: Icon(
+                Icons.notifications_active,
+                size: 64,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Semantics(
+              header: true,
+              child: Text(
+                'Stay in the loop',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Get notified when friends add expenses or settle up. '
+              'You can change this any time in Settings.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: Semantics(
+                label: 'Enable push notifications',
+                button: true,
+                child: FilledButton(
+                  onPressed: _onEnable,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: theme.colorScheme.primary,
+                    foregroundColor: theme.colorScheme.onPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    'Enable Notifications',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: Semantics(
+                label: 'Skip enabling notifications for now',
+                button: true,
+                child: TextButton(
+                  onPressed: _onNotNow,
+                  child: Text(
+                    'Not now',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/notifications/presentation/widgets/in_app_notification_banner.dart
+++ b/lib/features/notifications/presentation/widgets/in_app_notification_banner.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+/// Foreground in-app notification banner (FR-AC-03, wireframes §2).
+///
+/// Visuals:
+///   - Surface-coloured card, 16dp corner radius, 4dp elevation.
+///   - 32dp category icon (receipt / tick-circle / bell tinted by type).
+///   - Title + body text columns.
+///   - Min 64dp height (satisfies 48dp tap target per AC-20).
+///
+/// Behaviour:
+///   - Slides down from top with 300ms ease-in-out on appear.
+///   - Auto-dismisses after 4 seconds.
+///   - Tap → invokes [onTap] with the payload.
+///   - Swipe up → invokes [onDismiss].
+///   - Auto-dismiss timer pauses if the screen reader is active
+///     (`MediaQuery.accessibleNavigation`) per wireframes §2.4.
+class InAppNotificationBanner extends StatefulWidget {
+  /// Creates an [InAppNotificationBanner].
+  const InAppNotificationBanner({
+    required this.payload,
+    required this.onTap,
+    required this.onDismiss,
+    super.key,
+  });
+
+  /// The parsed FCM payload to render.
+  final NotificationPayload payload;
+
+  /// Invoked when the user taps the banner. The host is responsible
+  /// for hiding the overlay and dispatching to the deep-link handler.
+  final void Function(NotificationPayload payload) onTap;
+
+  /// Invoked when the user swipes the banner up OR the 4-second
+  /// auto-dismiss timer fires. The host should remove the OverlayEntry.
+  final VoidCallback onDismiss;
+
+  @override
+  State<InAppNotificationBanner> createState() =>
+      _InAppNotificationBannerState();
+}
+
+class _InAppNotificationBannerState extends State<InAppNotificationBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _animController;
+  late final Animation<Offset> _slideAnim;
+  Timer? _autoDismissTimer;
+  bool _dismissed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _animController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _slideAnim = Tween<Offset>(begin: const Offset(0, -1.5), end: Offset.zero)
+        .animate(
+          CurvedAnimation(parent: _animController, curve: Curves.easeInOut),
+        );
+    _animController.forward();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _scheduleAutoDismiss();
+  }
+
+  void _scheduleAutoDismiss() {
+    _autoDismissTimer?.cancel();
+    final accessibleNav = MediaQuery.of(context).accessibleNavigation;
+    if (accessibleNav) {
+      // Screen reader active — do NOT auto-dismiss; the user needs
+      // unbounded time to hear the announcement.
+      return;
+    }
+    _autoDismissTimer = Timer(const Duration(seconds: 4), () {
+      if (!_dismissed && mounted) {
+        _dismiss();
+      }
+    });
+  }
+
+  void _dismiss() {
+    if (_dismissed) return;
+    _dismissed = true;
+    _autoDismissTimer?.cancel();
+    widget.onDismiss();
+  }
+
+  void _onTap() {
+    if (_dismissed) return;
+    _dismissed = true;
+    _autoDismissTimer?.cancel();
+    widget.onTap(widget.payload);
+  }
+
+  @override
+  void dispose() {
+    _autoDismissTimer?.cancel();
+    _animController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final iconData = _iconForType(widget.payload.type);
+    final iconColor = _iconColorForType(widget.payload.type, theme);
+    final semanticLabel =
+        '${widget.payload.title}. ${widget.payload.body}. '
+        'Tap to view details. Swipe up to dismiss.';
+
+    return Semantics(
+      label: semanticLabel,
+      liveRegion: true,
+      button: true,
+      child: SlideTransition(
+        position: _slideAnim,
+        child: Dismissible(
+          key: ValueKey(widget.payload.itemId ?? widget.payload.contextId),
+          direction: DismissDirection.up,
+          onDismissed: (_) => _dismiss(),
+          child: GestureDetector(
+            onTap: _onTap,
+            behavior: HitTestBehavior.opaque,
+            child: Container(
+              margin: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+              constraints: const BoxConstraints(minHeight: 64),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.12),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(iconData, size: 32, color: iconColor),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          widget.payload.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          widget.payload.body,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurface.withValues(
+                              alpha: 0.7,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _iconForType(NotificationType type) {
+    switch (type) {
+      case NotificationType.expenseAdded:
+      case NotificationType.expenseEdited:
+      case NotificationType.expenseDeleted:
+        return Icons.receipt_long;
+      case NotificationType.settlementReceived:
+        return Icons.check_circle;
+      case NotificationType.reminder:
+      case NotificationType.groupInvite:
+        return Icons.notifications_active;
+    }
+  }
+
+  Color _iconColorForType(NotificationType type, ThemeData theme) {
+    switch (type) {
+      case NotificationType.expenseAdded:
+      case NotificationType.expenseEdited:
+      case NotificationType.expenseDeleted:
+        return theme.colorScheme.primary;
+      case NotificationType.settlementReceived:
+        // Success token #2A9D8F per design tokens.
+        return const Color(0xFF2A9D8F);
+      case NotificationType.reminder:
+        // Secondary saffron #F4A261 per design tokens.
+        return const Color(0xFFF4A261);
+      case NotificationType.groupInvite:
+        return theme.colorScheme.primary;
+    }
+  }
+}

--- a/lib/features/profile/presentation/profile_placeholder_screen.dart
+++ b/lib/features/profile/presentation/profile_placeholder_screen.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/auth/application/auth_state_provider.dart';
-import 'package:onebytwo/features/auth/data/phone_auth_repository.dart';
 import 'package:onebytwo/features/auth/domain/auth_state.dart';
+import 'package:onebytwo/features/notifications/application/sign_out_with_fcm_cleanup.dart';
 
 /// Minimal Profile placeholder screen for PR #10.
 ///
@@ -147,7 +147,7 @@ class ProfilePlaceholderScreen extends ConsumerWidget {
             onPressed: () async {
               Navigator.of(dialogContext).pop();
               try {
-                await ref.read(phoneAuthRepositoryProvider).signOut();
+                await signOutWithFcmCleanup(ref);
                 await ref
                     .read(analyticsServiceProvider)
                     .logEvent(name: 'sign_out_completed');

--- a/lib/features/profile/presentation/profile_screen.dart
+++ b/lib/features/profile/presentation/profile_screen.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/auth/application/auth_state_provider.dart';
-import 'package:onebytwo/features/auth/data/phone_auth_repository.dart';
 import 'package:onebytwo/features/auth/domain/auth_state.dart';
 import 'package:onebytwo/features/auth/domain/user_model.dart';
+import 'package:onebytwo/features/notifications/application/sign_out_with_fcm_cleanup.dart';
 import 'package:onebytwo/features/profile/presentation/edit_profile_screen.dart';
 
 /// Profile view screen for FR-PR-01 (SCR-26).
@@ -420,7 +420,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
             onPressed: () async {
               Navigator.of(dialogContext).pop();
               try {
-                await ref.read(phoneAuthRepositoryProvider).signOut();
+                await signOutWithFcmCleanup(ref);
                 await ref
                     .read(analyticsServiceProvider)
                     .logEvent(name: 'sign_out_completed');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +12,8 @@ import 'package:onebytwo/features/auth/presentation/home_placeholder_screen.dart
 import 'package:onebytwo/features/auth/presentation/phone_entry_screen.dart';
 import 'package:onebytwo/features/auth/presentation/profile_setup_screen.dart';
 import 'package:onebytwo/features/auth/presentation/splash_screen.dart';
+import 'package:onebytwo/features/notifications/data/notification_handler.dart';
+import 'package:onebytwo/features/notifications/presentation/notifications_lifecycle_host.dart';
 
 /// Whether to use the Firebase Auth Emulator.
 ///
@@ -21,6 +24,13 @@ const _useEmulator = bool.fromEnvironment('USE_EMULATOR');
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+
+  // FR-AC-03: register the top-level FCM background handler BEFORE
+  // runApp per Flutter Firebase docs. The handler is annotated
+  // @pragma('vm:entry-point') so the Dart tree-shaker keeps it alive
+  // in release builds.
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+
   if (_useEmulator) {
     const host = String.fromEnvironment(
       'EMULATOR_HOST',
@@ -35,6 +45,9 @@ void main() async {
     debugPrint('[OneByTwo] Connecting to Storage emulator $host:9199...');
     await FirebaseStorage.instance.useStorageEmulator(host, 9199);
     debugPrint('[OneByTwo] Storage emulator connected.');
+    // FCM emulator is NOT part of the Firebase Emulator Suite
+    // (architect §2.5) — manual smoke uses real FCM tokens on a debug
+    // build; tests mock at the SDK boundary via Riverpod overrides.
   }
   runApp(const ProviderScope(child: OneBytwoApp()));
 }
@@ -46,6 +59,11 @@ void main() async {
 /// auth state. The [ValueKey] on [MaterialApp] ensures the
 /// Navigator stack is fully cleared on auth state transitions
 /// (no stale routes from previous states).
+///
+/// The home content is wrapped in a [NotificationsLifecycleHost] via
+/// [MaterialApp.builder] so FCM streams, the pre-permission dialog,
+/// and the in-app banner overlay are all hosted in a single place
+/// (FR-AC-03, FR-AC-05).
 class OneBytwoApp extends ConsumerWidget {
   /// Creates the root application widget.
   const OneBytwoApp({super.key});
@@ -84,6 +102,11 @@ class OneBytwoApp extends ConsumerWidget {
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
       home: home,
+      builder: (context, child) {
+        return NotificationsLifecycleHost(
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
     );
   }
 }

--- a/test/core/routing/notification_deep_links_test.dart
+++ b/test/core/routing/notification_deep_links_test.dart
@@ -1,0 +1,209 @@
+// Pure-function tests for NotificationDeepLinks.resolve (FR-AC-03 +
+// FR-AC-05).
+//
+// The resolver is a pure function over (NotificationPayload, currentUid)
+// → DeepLinkTarget. No BuildContext, no navigation. The navigation
+// helper is tested via DeepLinkHandler / ActivityFeedScreen integration
+// tests separately.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/routing/notification_deep_links.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+NotificationPayload _p({
+  required NotificationType type,
+  String contextType = 'friendship',
+  String contextId = 'uid-me_uid-other',
+  String? itemId = 'item-1',
+  int? amountPaise = 60000,
+  String? inviteToken,
+}) {
+  return NotificationPayload(
+    type: type,
+    contextType: contextType,
+    contextId: contextId,
+    itemId: itemId,
+    title: 't',
+    body: 'b',
+    senderName: 'n',
+    amountPaise: amountPaise,
+    createdAt: DateTime.utc(2026, 6, 8),
+    inviteToken: inviteToken,
+  );
+}
+
+void main() {
+  group('NotificationDeepLinks.resolve — expense paths', () {
+    test('expense_added with valid friendship + itemId → '
+        'DeepLinkExpenseDetail', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.expenseAdded),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkExpenseDetail>());
+      final ed = t as DeepLinkExpenseDetail;
+      expect(ed.friendshipId, 'uid-me_uid-other');
+      expect(ed.expenseId, 'item-1');
+      expect(ed.currentUid, 'uid-me');
+      expect(ed.otherUid, 'uid-other');
+    });
+
+    test('expense_edited with valid friendship + itemId → '
+        'DeepLinkExpenseDetail', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.expenseEdited, itemId: 'item-9'),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkExpenseDetail>());
+      expect((t as DeepLinkExpenseDetail).expenseId, 'item-9');
+    });
+
+    test('expense_added with missing itemId → DeepLinkUnavailable', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.expenseAdded, itemId: null),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkUnavailable>());
+    });
+
+    test('expense_deleted (regardless of itemId) → DeepLinkUnavailable '
+        'with "This item is no longer available" semantics', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.expenseDeleted),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkUnavailable>());
+    });
+
+    test('expense_added with malformed composite contextId → '
+        'DeepLinkUnavailable', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.expenseAdded, contextId: 'not-a-composite'),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkUnavailable>());
+    });
+
+    test('expense_added where current user is NOT a member of the '
+        'composite → DeepLinkUnavailable', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(
+          type: NotificationType.expenseAdded,
+          contextId: 'uid-alpha_uid-beta',
+        ),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkUnavailable>());
+    });
+  });
+
+  group('NotificationDeepLinks.resolve — settlement / reminder', () {
+    test(
+      'settlement_received with valid friendship → DeepLinkFriendDetail',
+      () {
+        final t = NotificationDeepLinks.resolve(
+          _p(type: NotificationType.settlementReceived),
+          'uid-me',
+        );
+        expect(t, isA<DeepLinkFriendDetail>());
+        final fd = t as DeepLinkFriendDetail;
+        expect(fd.friendshipId, 'uid-me_uid-other');
+        expect(fd.currentUid, 'uid-me');
+        expect(fd.otherUid, 'uid-other');
+      },
+    );
+
+    test('reminder with valid friendship → DeepLinkFriendDetail', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.reminder, itemId: null),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkFriendDetail>());
+    });
+
+    test('settlement_received with malformed composite → '
+        'DeepLinkUnavailable', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(type: NotificationType.settlementReceived, contextId: 'malformed'),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkUnavailable>());
+    });
+
+    test('settlement_received where current user is NOT a member → '
+        'DeepLinkUnavailable', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(
+          type: NotificationType.settlementReceived,
+          contextId: 'uid-alpha_uid-beta',
+        ),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkUnavailable>());
+    });
+  });
+
+  group('NotificationDeepLinks.resolve — group_invite (forward-compat)', () {
+    test('group_invite → DeepLinkGroupsComingSoon (no producer in v1.0)', () {
+      final t = NotificationDeepLinks.resolve(
+        _p(
+          type: NotificationType.groupInvite,
+          contextType: 'group',
+          contextId: 'group-7',
+          itemId: null,
+          amountPaise: null,
+          inviteToken: 'tok',
+        ),
+        'uid-me',
+      );
+      expect(t, isA<DeepLinkGroupsComingSoon>());
+    });
+  });
+
+  group('NotificationDeepLinks.otherUidForFriendship', () {
+    test(
+      'extracts the other UID when the composite starts with currentUid',
+      () {
+        final other = NotificationDeepLinks.otherUidForFriendship(
+          'uid-me_uid-other',
+          'uid-me',
+        );
+        expect(other, 'uid-other');
+      },
+    );
+
+    test('extracts the other UID when the composite ends with currentUid', () {
+      final other = NotificationDeepLinks.otherUidForFriendship(
+        'uid-other_uid-me',
+        'uid-me',
+      );
+      expect(other, 'uid-other');
+    });
+
+    test('returns null when the composite has the wrong arity', () {
+      expect(
+        NotificationDeepLinks.otherUidForFriendship('only-one', 'uid-me'),
+        isNull,
+      );
+      expect(
+        NotificationDeepLinks.otherUidForFriendship('a_b_c', 'uid-me'),
+        isNull,
+      );
+    });
+
+    test(
+      'returns null when the currentUid is not present in the composite',
+      () {
+        expect(
+          NotificationDeepLinks.otherUidForFriendship(
+            'uid-alpha_uid-beta',
+            'uid-me',
+          ),
+          isNull,
+        );
+      },
+    );
+  });
+}

--- a/test/features/notifications/application/deep_link_handler_test.dart
+++ b/test/features/notifications/application/deep_link_handler_test.dart
@@ -54,25 +54,29 @@ NotificationPayload _payload({
 
 Future<void> _pumpHostAndDispatch({
   required WidgetTester tester,
+  required ProviderContainer container,
   required DeepLinkHandler handler,
   required NotificationPayload payload,
   required String currentUid,
   required DeepLinkSource source,
 }) async {
   await tester.pumpWidget(
-    MaterialApp(
-      home: Builder(
-        builder: (context) {
-          return ElevatedButton(
-            onPressed: () => handler.handleDeepLink(
-              payload: payload,
-              context: context,
-              currentUid: currentUid,
-              source: source,
-            ),
-            child: const Text('go'),
-          );
-        },
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return ElevatedButton(
+              onPressed: () => handler.handleDeepLink(
+                payload: payload,
+                context: context,
+                currentUid: currentUid,
+                source: source,
+              ),
+              child: const Text('go'),
+            );
+          },
+        ),
       ),
     ),
   );
@@ -186,8 +190,9 @@ void main() {
         'source on foreground dispatch', (tester) async {
       await _pumpHostAndDispatch(
         tester: tester,
+        container: container,
         handler: handler,
-        payload: _payload(type: NotificationType.expenseAdded),
+        payload: _payload(),
         currentUid: 'uid-me',
         source: DeepLinkSource.foreground,
       );
@@ -208,6 +213,7 @@ void main() {
     ) async {
       await _pumpHostAndDispatch(
         tester: tester,
+        container: container,
         handler: handler,
         payload: _payload(type: NotificationType.reminder, itemId: null),
         currentUid: 'uid-me',
@@ -225,6 +231,7 @@ void main() {
     ) async {
       await _pumpHostAndDispatch(
         tester: tester,
+        container: container,
         handler: handler,
         payload: _payload(type: NotificationType.settlementReceived),
         currentUid: 'uid-me',

--- a/test/features/notifications/application/deep_link_handler_test.dart
+++ b/test/features/notifications/application/deep_link_handler_test.dart
@@ -1,0 +1,240 @@
+// DeepLinkHandler tests (FR-AC-03 + FR-AC-05).
+//
+// Verifies that the DeepLinkHandler dispatches each NotificationType to
+// the correct DeepLinkTarget via the shared `notification_deep_links.dart`
+// resolver. The actual platform navigation is covered by the resolver
+// helper's pure-function tests; this suite focuses on the dispatch
+// table (type → target) and the telemetry emission.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/routing/notification_deep_links.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/notifications/application/deep_link_handler.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class RecordingAnalyticsService implements AnalyticsService {
+  final List<Map<String, dynamic>> calls = <Map<String, dynamic>>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object>? parameters,
+  }) async {
+    calls.add({'name': name, 'parameters': parameters});
+  }
+}
+
+NotificationPayload _payload({
+  NotificationType type = NotificationType.expenseAdded,
+  String contextType = 'friendship',
+  String contextId = 'uid-me_uid-other',
+  String? itemId = 'expense-1',
+  int? amountPaise = 60000,
+}) {
+  return NotificationPayload(
+    type: type,
+    contextType: contextType,
+    contextId: contextId,
+    itemId: itemId,
+    title: 't',
+    body: 'b',
+    senderName: 'n',
+    amountPaise: amountPaise,
+    createdAt: DateTime.utc(2026, 6, 8),
+  );
+}
+
+Future<void> _pumpHostAndDispatch({
+  required WidgetTester tester,
+  required DeepLinkHandler handler,
+  required NotificationPayload payload,
+  required String currentUid,
+  required DeepLinkSource source,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          return ElevatedButton(
+            onPressed: () => handler.handleDeepLink(
+              payload: payload,
+              context: context,
+              currentUid: currentUid,
+              source: source,
+            ),
+            child: const Text('go'),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.tap(find.text('go'));
+  await tester.pump();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late RecordingAnalyticsService analytics;
+  late ProviderContainer container;
+  late DeepLinkHandler handler;
+
+  setUp(() {
+    analytics = RecordingAnalyticsService();
+    container = ProviderContainer(
+      overrides: [analyticsServiceProvider.overrideWithValue(analytics)],
+    );
+    handler = DeepLinkHandler(container);
+  });
+
+  tearDown(() => container.dispose());
+
+  group('DeepLinkHandler.resolveTarget — type → DeepLinkTarget', () {
+    test('expense_added → expense detail target', () {
+      final target = handler.resolveTarget(_payload(), currentUid: 'uid-me');
+      expect(target, isA<DeepLinkExpenseDetail>());
+      final t = target as DeepLinkExpenseDetail;
+      expect(t.friendshipId, 'uid-me_uid-other');
+      expect(t.expenseId, 'expense-1');
+      expect(t.currentUid, 'uid-me');
+      expect(t.otherUid, 'uid-other');
+    });
+
+    test('expense_edited → expense detail target', () {
+      final target = handler.resolveTarget(
+        _payload(type: NotificationType.expenseEdited),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkExpenseDetail>());
+    });
+
+    test('expense_deleted → unavailable snackbar target', () {
+      final target = handler.resolveTarget(
+        _payload(type: NotificationType.expenseDeleted, itemId: null),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkUnavailable>());
+    });
+
+    test('settlement_received → friend detail target', () {
+      final target = handler.resolveTarget(
+        _payload(type: NotificationType.settlementReceived),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkFriendDetail>());
+      final t = target as DeepLinkFriendDetail;
+      expect(t.friendshipId, 'uid-me_uid-other');
+      expect(t.currentUid, 'uid-me');
+      expect(t.otherUid, 'uid-other');
+    });
+
+    test('reminder → friend detail target', () {
+      final target = handler.resolveTarget(
+        _payload(type: NotificationType.reminder, itemId: null),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkFriendDetail>());
+    });
+
+    test('group_invite → "groups coming soon" target (forward-compat)', () {
+      final target = handler.resolveTarget(
+        _payload(
+          type: NotificationType.groupInvite,
+          contextType: 'group',
+          contextId: 'group-7',
+          itemId: null,
+          amountPaise: null,
+        ),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkGroupsComingSoon>());
+    });
+
+    test('missing other-UID (malformed composite) → unavailable target', () {
+      // contextId doesn't follow {uidA}_{uidB} pattern.
+      final target = handler.resolveTarget(
+        _payload(
+          type: NotificationType.settlementReceived,
+          contextId: 'not-a-valid-composite',
+        ),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkUnavailable>());
+    });
+
+    test('expense_added with missing itemId → unavailable target', () {
+      final target = handler.resolveTarget(
+        _payload(itemId: null),
+        currentUid: 'uid-me',
+      );
+      expect(target, isA<DeepLinkUnavailable>());
+    });
+  });
+
+  group('DeepLinkHandler.handleDeepLink — telemetry', () {
+    testWidgets('emits fcm_notification_tapped with notification_type + '
+        'source on foreground dispatch', (tester) async {
+      await _pumpHostAndDispatch(
+        tester: tester,
+        handler: handler,
+        payload: _payload(type: NotificationType.expenseAdded),
+        currentUid: 'uid-me',
+        source: DeepLinkSource.foreground,
+      );
+
+      // The dispatch may push a route; for the telemetry assertion we
+      // only care that the event was logged.
+      expect(analytics.calls, isNotEmpty);
+      final call = analytics.calls.first;
+      expect(call['name'], 'fcm_notification_tapped');
+      final params = call['parameters'] as Map<String, Object>?;
+      expect(params, isNotNull);
+      expect(params!['notification_type'], 'expense_added');
+      expect(params['source'], 'foreground');
+    });
+
+    testWidgets('source label is `background` for backgrounded-app tap', (
+      tester,
+    ) async {
+      await _pumpHostAndDispatch(
+        tester: tester,
+        handler: handler,
+        payload: _payload(type: NotificationType.reminder, itemId: null),
+        currentUid: 'uid-me',
+        source: DeepLinkSource.background,
+      );
+
+      final params =
+          analytics.calls.first['parameters'] as Map<String, Object>?;
+      expect(params!['source'], 'background');
+      expect(params['notification_type'], 'reminder');
+    });
+
+    testWidgets('source label is `cold_start` for cold-start dispatch', (
+      tester,
+    ) async {
+      await _pumpHostAndDispatch(
+        tester: tester,
+        handler: handler,
+        payload: _payload(type: NotificationType.settlementReceived),
+        currentUid: 'uid-me',
+        source: DeepLinkSource.coldStart,
+      );
+
+      final params =
+          analytics.calls.first['parameters'] as Map<String, Object>?;
+      expect(params!['source'], 'cold_start');
+      expect(params['notification_type'], 'settlement_received');
+    });
+  });
+}

--- a/test/features/notifications/application/notification_permission_controller_test.dart
+++ b/test/features/notifications/application/notification_permission_controller_test.dart
@@ -15,6 +15,7 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/notifications/application/notification_permission_controller.dart';
 import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
 
@@ -83,14 +84,32 @@ class FakeTokenService implements FcmTokenService {
   Future<void> stopTokenRefreshListener() async {}
 }
 
+class FakeAnalyticsService implements AnalyticsService {
+  final List<String> loggedEvents = <String>[];
+  final List<Map<String, Object>?> loggedParameters = <Map<String, Object>?>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object>? parameters,
+  }) async {
+    loggedEvents.add(name);
+    loggedParameters.add(parameters);
+  }
+}
+
 ProviderContainer _container({
   required FakePermissionMessagingAdapter adapter,
   required FakeTokenService service,
+  FakeAnalyticsService? analytics,
 }) {
   return ProviderContainer(
     overrides: [
       permissionMessagingAdapterProvider.overrideWithValue(adapter),
       fcmTokenServiceProvider.overrideWithValue(service),
+      analyticsServiceProvider.overrideWithValue(
+        analytics ?? FakeAnalyticsService(),
+      ),
     ],
   );
 }
@@ -330,4 +349,83 @@ void main() {
       expect(notifier.wasPermanentlyDenied, isTrue);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // FR-AC-03 AC-14 telemetry: fcm_token_registered
+  // ---------------------------------------------------------------------------
+
+  group(
+    'NotificationPermissionController — fcm_token_registered telemetry',
+    () {
+      test('emits fcm_token_registered after a successful grant + token '
+          'acquisition (AC-14)', () async {
+        final analytics = FakeAnalyticsService();
+        final container = _container(
+          adapter: FakePermissionMessagingAdapter()
+            ..nextResult = AuthorizationStatus.authorized,
+          service: FakeTokenService()..returnToken = 'token-A',
+          analytics: analytics,
+        );
+        addTearDown(container.dispose);
+
+        final notifier = container.read(
+          notificationPermissionControllerProvider.notifier,
+        );
+        notifier.showPrePermissionDialog();
+        await notifier.onEnableTapped(uid: 'uid-me');
+        // Allow the unawaited analytics logEvent microtask to flush.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(analytics.loggedEvents, contains('fcm_token_registered'));
+      });
+
+      test('does NOT emit fcm_token_registered on the denial path (no '
+          'token was acquired)', () async {
+        final analytics = FakeAnalyticsService();
+        final container = _container(
+          adapter: FakePermissionMessagingAdapter()
+            ..nextResult = AuthorizationStatus.denied,
+          service: FakeTokenService(),
+          analytics: analytics,
+        );
+        addTearDown(container.dispose);
+
+        final notifier = container.read(
+          notificationPermissionControllerProvider.notifier,
+        );
+        notifier.showPrePermissionDialog();
+        await notifier.onEnableTapped(uid: 'uid-me');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(analytics.loggedEvents, isNot(contains('fcm_token_registered')));
+      });
+
+      test(
+        'does NOT emit fcm_token_registered when registerToken returns '
+        'null (OS provisioning failure or APNS-token-not-yet-available)',
+        () async {
+          final analytics = FakeAnalyticsService();
+          final container = _container(
+            adapter: FakePermissionMessagingAdapter()
+              ..nextResult = AuthorizationStatus.authorized,
+            service: FakeTokenService()..returnToken = null,
+            analytics: analytics,
+          );
+          addTearDown(container.dispose);
+
+          final notifier = container.read(
+            notificationPermissionControllerProvider.notifier,
+          );
+          notifier.showPrePermissionDialog();
+          await notifier.onEnableTapped(uid: 'uid-me');
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            analytics.loggedEvents,
+            isNot(contains('fcm_token_registered')),
+          );
+        },
+      );
+    },
+  );
 }

--- a/test/features/notifications/application/notification_permission_controller_test.dart
+++ b/test/features/notifications/application/notification_permission_controller_test.dart
@@ -1,0 +1,334 @@
+// NotificationPermissionController tests (FR-AC-03).
+//
+// Covers the Notifier driving the pre-permission dialog flow:
+//   - Initial state: notDetermined.
+//   - showPrePermissionDialog() → dialogShown; re-call is a no-op
+//     (AC-12 session-scoped suppression).
+//   - dialogShown + "Not now" → dismissedThisSession; no OS prompt.
+//   - dialogShown + "Enable" → calls requestPermission(); on grant
+//     → granted + token acquisition; on deny → permanentlyDenied.
+//
+// Tests are written BEFORE the implementation exists.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/notifications/application/notification_permission_controller.dart';
+import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+NotificationSettings _settings(AuthorizationStatus s) {
+  return NotificationSettings(
+    alert: AppleNotificationSetting.enabled,
+    announcement: AppleNotificationSetting.disabled,
+    authorizationStatus: s,
+    badge: AppleNotificationSetting.enabled,
+    carPlay: AppleNotificationSetting.disabled,
+    lockScreen: AppleNotificationSetting.enabled,
+    notificationCenter: AppleNotificationSetting.enabled,
+    showPreviews: AppleShowPreviewSetting.always,
+    timeSensitive: AppleNotificationSetting.disabled,
+    criticalAlert: AppleNotificationSetting.disabled,
+    sound: AppleNotificationSetting.enabled,
+    providesAppNotificationSettings: AppleNotificationSetting.disabled,
+  );
+}
+
+class FakePermissionMessagingAdapter implements PermissionMessagingAdapter {
+  AuthorizationStatus nextResult = AuthorizationStatus.authorized;
+  int requestCalls = 0;
+
+  @override
+  Future<NotificationSettings> requestPermission() async {
+    requestCalls += 1;
+    return _settings(nextResult);
+  }
+}
+
+class FakeTokenService implements FcmTokenService {
+  String? lastUid;
+  bool startedListener = false;
+  String? returnToken = 'token-A';
+
+  @override
+  String? get currentToken => returnToken;
+
+  @override
+  Future<String?> registerToken(String uid) async {
+    lastUid = uid;
+    return returnToken;
+  }
+
+  @override
+  void startTokenRefreshListener(String uid) {
+    startedListener = true;
+  }
+
+  @override
+  Future<void> unregisterToken(String uid, String token) async {}
+
+  @override
+  Future<void> replaceToken(
+    String uid,
+    String oldToken,
+    String newToken,
+  ) async {}
+
+  @override
+  Future<void> stopTokenRefreshListener() async {}
+}
+
+ProviderContainer _container({
+  required FakePermissionMessagingAdapter adapter,
+  required FakeTokenService service,
+}) {
+  return ProviderContainer(
+    overrides: [
+      permissionMessagingAdapterProvider.overrideWithValue(adapter),
+      fcmTokenServiceProvider.overrideWithValue(service),
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('NotificationPermissionController — initial state', () {
+    test('initial state is PermissionState.notDetermined', () {
+      final adapter = FakePermissionMessagingAdapter();
+      final service = FakeTokenService();
+      final container = _container(adapter: adapter, service: service);
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.notDetermined,
+      );
+    });
+  });
+
+  group('NotificationPermissionController — showPrePermissionDialog', () {
+    test('first call transitions to dialogShown', () {
+      final container = _container(
+        adapter: FakePermissionMessagingAdapter(),
+        service: FakeTokenService(),
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(notificationPermissionControllerProvider.notifier)
+          .showPrePermissionDialog();
+
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.dialogShown,
+      );
+    });
+
+    test('subsequent calls in the same session are no-ops (AC-12)', () {
+      final container = _container(
+        adapter: FakePermissionMessagingAdapter(),
+        service: FakeTokenService(),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(
+        notificationPermissionControllerProvider.notifier,
+      );
+      notifier.showPrePermissionDialog();
+      notifier.onDismissTapped(); // → dismissedThisSession
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.dismissedThisSession,
+      );
+
+      // Re-show in same session should NOT transition back to dialogShown.
+      notifier.showPrePermissionDialog();
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.dismissedThisSession,
+      );
+    });
+
+    test('does not trigger the OS permission prompt by itself', () {
+      final adapter = FakePermissionMessagingAdapter();
+      final container = _container(
+        adapter: adapter,
+        service: FakeTokenService(),
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(notificationPermissionControllerProvider.notifier)
+          .showPrePermissionDialog();
+
+      expect(adapter.requestCalls, 0);
+    });
+  });
+
+  group('NotificationPermissionController — onDismissTapped', () {
+    test('transitions to dismissedThisSession; OS prompt NOT triggered', () {
+      final adapter = FakePermissionMessagingAdapter();
+      final container = _container(
+        adapter: adapter,
+        service: FakeTokenService(),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(
+        notificationPermissionControllerProvider.notifier,
+      );
+      notifier.showPrePermissionDialog();
+      notifier.onDismissTapped();
+
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.dismissedThisSession,
+      );
+      expect(adapter.requestCalls, 0);
+    });
+  });
+
+  group('NotificationPermissionController — onEnableTapped (granted)', () {
+    test('grant path triggers requestPermission, registerToken, '
+        'startTokenRefreshListener; state transitions to granted', () async {
+      final adapter = FakePermissionMessagingAdapter()
+        ..nextResult = AuthorizationStatus.authorized;
+      final service = FakeTokenService();
+      final container = _container(adapter: adapter, service: service);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(
+        notificationPermissionControllerProvider.notifier,
+      );
+      notifier.showPrePermissionDialog();
+
+      await notifier.onEnableTapped(uid: 'uid-me');
+
+      expect(adapter.requestCalls, 1);
+      expect(service.lastUid, 'uid-me');
+      expect(service.startedListener, isTrue);
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.granted,
+      );
+    });
+
+    test(
+      'provisional grant is treated as granted (iOS quiet-notif path)',
+      () async {
+        final adapter = FakePermissionMessagingAdapter()
+          ..nextResult = AuthorizationStatus.provisional;
+        final service = FakeTokenService();
+        final container = _container(adapter: adapter, service: service);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(
+          notificationPermissionControllerProvider.notifier,
+        );
+        notifier.showPrePermissionDialog();
+
+        await notifier.onEnableTapped(uid: 'uid-me');
+
+        expect(
+          container.read(notificationPermissionControllerProvider),
+          PermissionState.granted,
+        );
+        expect(service.lastUid, 'uid-me');
+      },
+    );
+  });
+
+  group('NotificationPermissionController — onEnableTapped (denied)', () {
+    test('denied path transitions to permanentlyDenied; NO token acquired '
+        '(AC-13)', () async {
+      final adapter = FakePermissionMessagingAdapter()
+        ..nextResult = AuthorizationStatus.denied;
+      final service = FakeTokenService();
+      final container = _container(adapter: adapter, service: service);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(
+        notificationPermissionControllerProvider.notifier,
+      );
+      notifier.showPrePermissionDialog();
+
+      await notifier.onEnableTapped(uid: 'uid-me');
+
+      expect(adapter.requestCalls, 1);
+      expect(service.lastUid, isNull);
+      expect(service.startedListener, isFalse);
+      expect(
+        container.read(notificationPermissionControllerProvider),
+        PermissionState.permanentlyDenied,
+      );
+    });
+
+    test(
+      'notDetermined-returned-by-OS treated as denied (defensive)',
+      () async {
+        final adapter = FakePermissionMessagingAdapter()
+          ..nextResult = AuthorizationStatus.notDetermined;
+        final service = FakeTokenService();
+        final container = _container(adapter: adapter, service: service);
+        addTearDown(container.dispose);
+
+        final notifier = container.read(
+          notificationPermissionControllerProvider.notifier,
+        );
+        notifier.showPrePermissionDialog();
+
+        await notifier.onEnableTapped(uid: 'uid-me');
+
+        expect(service.lastUid, isNull);
+        expect(
+          container.read(notificationPermissionControllerProvider),
+          PermissionState.permanentlyDenied,
+        );
+      },
+    );
+  });
+
+  group('NotificationPermissionController — wasPermanentlyDenied flag', () {
+    test('wasPermanentlyDenied is false at construction', () {
+      final container = _container(
+        adapter: FakePermissionMessagingAdapter(),
+        service: FakeTokenService(),
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container
+            .read(notificationPermissionControllerProvider.notifier)
+            .wasPermanentlyDenied,
+        isFalse,
+      );
+    });
+
+    test('wasPermanentlyDenied is set after a denial', () async {
+      final adapter = FakePermissionMessagingAdapter()
+        ..nextResult = AuthorizationStatus.denied;
+      final container = _container(
+        adapter: adapter,
+        service: FakeTokenService(),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(
+        notificationPermissionControllerProvider.notifier,
+      );
+      notifier.showPrePermissionDialog();
+      await notifier.onEnableTapped(uid: 'uid-me');
+
+      expect(notifier.wasPermanentlyDenied, isTrue);
+    });
+  });
+}

--- a/test/features/notifications/application/notification_permission_controller_test.dart
+++ b/test/features/notifications/application/notification_permission_controller_test.dart
@@ -13,7 +13,6 @@
 // ignore_for_file: cascade_invocations
 
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onebytwo/features/notifications/application/notification_permission_controller.dart';

--- a/test/features/notifications/data/fcm_token_service_test.dart
+++ b/test/features/notifications/data/fcm_token_service_test.dart
@@ -1,36 +1,30 @@
 // FcmTokenService tests (FR-AC-03).
 //
 // Covers the client-side token-lifecycle helpers:
-//   - registerToken(uid) — calls getToken() then writes via arrayUnion.
-//   - unregisterToken(uid, token) — arrayRemove.
-//   - replaceToken(uid, oldToken, newToken) — single batched write.
+//   - registerToken(uid) — calls messaging.getToken() then writes via
+//     store.addToken(arrayUnion).
+//   - unregisterToken(uid, token) — store.removeToken (arrayRemove).
+//   - replaceToken(uid, oldToken, newToken) — single batched write via
+//     store.replaceTokenAtomically.
 //   - startTokenRefreshListener(uid) — wires onTokenRefresh through
 //     replaceToken.
 //
-// Mocks `FirebaseFirestore` and `FirebaseMessaging` with thin fakes
-// following the existing `FakeFirebaseAuth` / `FakeSettlementStore`
-// pattern in this repo (no `fake_cloud_firestore` dependency).
-//
-// Tests are written BEFORE the implementation exists.
+// Fakes the FcmTokenStore + FcmMessagingAdapter abstractions; no
+// FirebaseFirestore implementation required (the cloud_firestore
+// DocumentReference / Query classes are sealed and cannot be
+// implemented in test code).
 
 // ignore_for_file: cascade_invocations
 
 import 'dart:async';
 
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
 
 // ---------------------------------------------------------------------------
-// Fake messaging
+// Fakes
 // ---------------------------------------------------------------------------
 
-/// Minimal fake of FirebaseMessaging exposing only the entry points
-/// FcmTokenService consumes. Implements through composition rather
-/// than `implements FirebaseMessaging` because that class has many
-/// platform-only members; we shim via an adapter interface
-/// (`FcmMessagingAdapter`) injected into the service.
 class FakeMessagingAdapter implements FcmMessagingAdapter {
   String? returnToken = 'token-A';
   final StreamController<String> _refreshController =
@@ -51,142 +45,63 @@ class FakeMessagingAdapter implements FcmMessagingAdapter {
   Future<void> dispose() => _refreshController.close();
 }
 
-// ---------------------------------------------------------------------------
-// Fake Firestore plumbing
-//
-// We need just enough to capture the write operations on
-// `users/{uid}` and verify the FieldValue payload. We implement the
-// minimum subset of FirebaseFirestore: `collection().doc().update()`
-// and `batch().update().commit()`.
-// ---------------------------------------------------------------------------
-
-class _UpdateCall {
-  _UpdateCall(this.path, this.data);
-  final String path;
-  final Map<Object, dynamic> data;
+class AddCall {
+  AddCall(this.uid, this.token);
+  final String uid;
+  final String token;
 }
 
-class _CapturingDocRef implements DocumentReference<Map<String, dynamic>> {
-  _CapturingDocRef(this.store, this.fullPath);
-  final FakeFirestoreStore store;
-  final String fullPath;
+class RemoveCall {
+  RemoveCall(this.uid, this.token);
+  final String uid;
+  final String token;
+}
+
+class ReplaceCall {
+  ReplaceCall(this.uid, this.oldToken, this.newToken);
+  final String uid;
+  final String oldToken;
+  final String newToken;
+}
+
+class FakeTokenStore implements FcmTokenStore {
+  final List<AddCall> addCalls = <AddCall>[];
+  final List<RemoveCall> removeCalls = <RemoveCall>[];
+  final List<ReplaceCall> replaceCalls = <ReplaceCall>[];
 
   @override
-  Future<void> update(Map<Object, Object?> data) async {
-    store.updates.add(_UpdateCall(fullPath, Map<Object, dynamic>.from(data)));
+  Future<void> addToken({required String uid, required String token}) async {
+    addCalls.add(AddCall(uid, token));
   }
 
   @override
-  String get id => fullPath.split('/').last;
-
-  @override
-  String get path => fullPath;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _CapturingCollection
-    implements CollectionReference<Map<String, dynamic>> {
-  _CapturingCollection(this.store, this.collectionPath);
-  final FakeFirestoreStore store;
-  final String collectionPath;
-
-  @override
-  DocumentReference<Map<String, dynamic>> doc([String? id]) {
-    return _CapturingDocRef(store, '$collectionPath/${id ?? 'auto-id'}');
+  Future<void> removeToken({required String uid, required String token}) async {
+    removeCalls.add(RemoveCall(uid, token));
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-/// Captures every write operation routed through the fake Firestore.
-class FakeFirestoreStore {
-  final List<_UpdateCall> updates = <_UpdateCall>[];
-  final List<_BatchUpdateCall> batchUpdates = <_BatchUpdateCall>[];
-  int batchCommitCount = 0;
-}
-
-class _BatchUpdateCall {
-  _BatchUpdateCall(this.path, this.data);
-  final String path;
-  final Map<Object, dynamic> data;
-}
-
-class _CapturingBatch implements WriteBatch {
-  _CapturingBatch(this.store);
-  final FakeFirestoreStore store;
-  final List<_BatchUpdateCall> _pending = <_BatchUpdateCall>[];
-
-  @override
-  void update(DocumentReference<Object?> document, Map<Object, Object?> data) {
-    _pending.add(
-      _BatchUpdateCall(document.path, Map<Object, dynamic>.from(data)),
-    );
+  Future<void> replaceTokenAtomically({
+    required String uid,
+    required String oldToken,
+    required String newToken,
+  }) async {
+    replaceCalls.add(ReplaceCall(uid, oldToken, newToken));
   }
-
-  @override
-  Future<void> commit() async {
-    store.batchUpdates.addAll(_pending);
-    store.batchCommitCount += 1;
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _CapturingFirestore implements FirebaseFirestore {
-  _CapturingFirestore(this.store);
-  final FakeFirestoreStore store;
-
-  @override
-  CollectionReference<Map<String, dynamic>> collection(String path) {
-    return _CapturingCollection(store, path);
-  }
-
-  @override
-  WriteBatch batch() => _CapturingBatch(store);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-bool _isArrayUnion(dynamic value, String expectedToken) {
-  if (value is! FieldValue) return false;
-  // FieldValue's runtime type is FieldValueDelegate from
-  // cloud_firestore_platform_interface; we cannot inspect the wrapped
-  // list directly without reflection. As a pragmatic check, compare
-  // toString() shape that includes the operation name.
-  final s = value.toString();
-  return s.contains('arrayUnion') && s.contains(expectedToken);
-}
-
-bool _isArrayRemove(dynamic value, String expectedToken) {
-  if (value is! FieldValue) return false;
-  final s = value.toString();
-  return s.contains('arrayRemove') && s.contains(expectedToken);
-}
-
-// ---------------------------------------------------------------------------
-// Test body
+// Tests
 // ---------------------------------------------------------------------------
 
 void main() {
-  late FakeFirestoreStore store;
-  late _CapturingFirestore firestore;
+  late FakeTokenStore store;
   late FakeMessagingAdapter messaging;
   late FcmTokenService service;
 
   setUp(() {
-    store = FakeFirestoreStore();
-    firestore = _CapturingFirestore(store);
+    store = FakeTokenStore();
     messaging = FakeMessagingAdapter();
-    service = FcmTokenService(firestore: firestore, messaging: messaging);
+    service = FcmTokenService(store: store, messaging: messaging);
   });
 
   tearDown(() async {
@@ -200,15 +115,9 @@ void main() {
 
       expect(token, 'token-A');
       expect(messaging.getTokenCalls, 1);
-      expect(store.updates, hasLength(1));
-      expect(store.updates.first.path, 'users/uid-1');
-      expect(
-        _isArrayUnion(store.updates.first.data['fcmTokens'], 'token-A'),
-        isTrue,
-        reason:
-            'Expected arrayUnion([token-A]) on fcmTokens; got '
-            '${store.updates.first.data}',
-      );
+      expect(store.addCalls, hasLength(1));
+      expect(store.addCalls.first.uid, 'uid-1');
+      expect(store.addCalls.first.token, 'token-A');
     });
 
     test('returns null and writes nothing when getToken returns null '
@@ -218,16 +127,22 @@ void main() {
       final token = await service.registerToken('uid-1');
 
       expect(token, isNull);
-      expect(store.updates, isEmpty);
+      expect(store.addCalls, isEmpty);
     });
 
-    test('is idempotent — re-registering the same token issues another '
-        'arrayUnion (Firestore deduplicates at the doc level)', () async {
+    test('is idempotent at the call site — re-registering the same token '
+        'issues another arrayUnion (Firestore arrayUnion deduplicates '
+        'at the doc level)', () async {
       await service.registerToken('uid-1');
       await service.registerToken('uid-1');
 
-      expect(store.updates, hasLength(2));
+      expect(store.addCalls, hasLength(2));
       expect(messaging.getTokenCalls, 2);
+    });
+
+    test('caches the acquired token as currentToken', () async {
+      await service.registerToken('uid-1');
+      expect(service.currentToken, 'token-A');
     });
   });
 
@@ -235,110 +150,109 @@ void main() {
     test('calls arrayRemove([token]) on users/{uid}.fcmTokens', () async {
       await service.unregisterToken('uid-1', 'token-A');
 
-      expect(store.updates, hasLength(1));
-      expect(store.updates.first.path, 'users/uid-1');
-      expect(
-        _isArrayRemove(store.updates.first.data['fcmTokens'], 'token-A'),
-        isTrue,
-      );
+      expect(store.removeCalls, hasLength(1));
+      expect(store.removeCalls.first.uid, 'uid-1');
+      expect(store.removeCalls.first.token, 'token-A');
     });
+
+    test('clears currentToken when the unregistered token matches the '
+        'cached one', () async {
+      await service.registerToken('uid-1');
+      expect(service.currentToken, 'token-A');
+      await service.unregisterToken('uid-1', 'token-A');
+      expect(service.currentToken, isNull);
+    });
+
+    test(
+      'preserves currentToken when a different token is unregistered',
+      () async {
+        await service.registerToken('uid-1');
+        await service.unregisterToken('uid-1', 'token-OTHER');
+        expect(service.currentToken, 'token-A');
+      },
+    );
   });
 
   group('FcmTokenService.replaceToken', () {
-    test('performs arrayRemove + arrayUnion in a SINGLE batched write '
-        '(AC-2 — no window with no valid token)', () async {
+    test('performs a single batched arrayRemove + arrayUnion via '
+        'store.replaceTokenAtomically (AC-2 — no window with no '
+        'valid token)', () async {
       await service.replaceToken('uid-1', 'token-OLD', 'token-NEW');
 
-      expect(
-        store.batchCommitCount,
-        1,
-        reason: 'Expected exactly one batch.commit() call',
-      );
-      expect(store.batchUpdates, hasLength(2));
-      // Both updates target the same document path.
-      expect(store.batchUpdates[0].path, 'users/uid-1');
-      expect(store.batchUpdates[1].path, 'users/uid-1');
-      // One is arrayRemove(OLD), one is arrayUnion(NEW). Order is
-      // implementation detail but both must be present.
-      final allDataStrings = store.batchUpdates
-          .map((u) => u.data.values.first.toString())
-          .join(' ');
-      expect(allDataStrings, contains('arrayRemove'));
-      expect(allDataStrings, contains('arrayUnion'));
-      expect(allDataStrings, contains('token-OLD'));
-      expect(allDataStrings, contains('token-NEW'));
+      expect(store.replaceCalls, hasLength(1));
+      final call = store.replaceCalls.first;
+      expect(call.uid, 'uid-1');
+      expect(call.oldToken, 'token-OLD');
+      expect(call.newToken, 'token-NEW');
     });
 
-    test('no-op (no batch commit) when oldToken == newToken', () async {
+    test('no-op (no store call) when oldToken == newToken', () async {
       await service.replaceToken('uid-1', 'token-X', 'token-X');
 
-      expect(store.batchCommitCount, 0);
+      expect(store.replaceCalls, isEmpty);
+    });
+
+    test('updates currentToken to the new value', () async {
+      await service.registerToken('uid-1');
+      await service.replaceToken('uid-1', 'token-A', 'token-B');
+      expect(service.currentToken, 'token-B');
     });
   });
 
   group('FcmTokenService.startTokenRefreshListener', () {
     test('subscribes to onTokenRefresh and invokes replaceToken with the '
         'previously-known token on emit', () async {
-      // Register initial token so the service caches it as the "current"
-      // device token.
       await service.registerToken('uid-1');
-      store.updates.clear(); // Drop initial registration write.
+      store.addCalls.clear(); // Drop the initial-registration call.
 
       service.startTokenRefreshListener('uid-1');
 
       messaging.emitRefresh('token-B');
-      // Let the stream listener microtask drain.
       await Future<void>.delayed(Duration.zero);
 
-      expect(
-        store.batchCommitCount,
-        1,
-        reason:
-            'Expected onTokenRefresh to invoke replaceToken which '
-            'commits a single batch',
-      );
-      final allDataStrings = store.batchUpdates
-          .map((u) => u.data.values.first.toString())
-          .join(' ');
-      expect(allDataStrings, contains('token-A')); // old
-      expect(allDataStrings, contains('token-B')); // new
+      expect(store.replaceCalls, hasLength(1));
+      final call = store.replaceCalls.first;
+      expect(call.oldToken, 'token-A');
+      expect(call.newToken, 'token-B');
+    });
+
+    test('falls back to addToken (no prior cached) when listener fires '
+        'before registerToken', () async {
+      service.startTokenRefreshListener('uid-1');
+      messaging.emitRefresh('token-FIRST');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(store.addCalls, hasLength(1));
+      expect(store.addCalls.first.token, 'token-FIRST');
+      expect(service.currentToken, 'token-FIRST');
     });
 
     test('a second startTokenRefreshListener call cancels the previous '
-        'subscription (defence-in-depth against double-wire)', () async {
+        'subscription (idempotent in the lifecycle sense)', () {
       service.startTokenRefreshListener('uid-1');
       service.startTokenRefreshListener('uid-1');
-      // No test for the actual behaviour beyond not throwing; this
-      // verifies the method is idempotent in the lifecycle sense.
+      // No assertion beyond not throwing; the implementation cancels
+      // the prior _refreshSub before assigning the new one.
       expect(true, isTrue);
     });
 
-    test('stopTokenRefreshListener cancels the subscription so subsequent '
+    test('stopTokenRefreshListener cancels the subscription; subsequent '
         'emissions are ignored', () async {
       await service.registerToken('uid-1');
-      store.updates.clear();
+      store.addCalls.clear();
       service.startTokenRefreshListener('uid-1');
       await service.stopTokenRefreshListener();
 
       messaging.emitRefresh('token-B');
       await Future<void>.delayed(Duration.zero);
 
-      expect(
-        store.batchCommitCount,
-        0,
-        reason: 'Cancelled subscription must not write on emit',
-      );
+      expect(store.replaceCalls, isEmpty);
     });
   });
 
   group('FcmTokenService.currentToken', () {
-    test('is null before registerToken is called', () {
+    test('is null at construction', () {
       expect(service.currentToken, isNull);
-    });
-
-    test('returns the last-registered token', () async {
-      await service.registerToken('uid-1');
-      expect(service.currentToken, 'token-A');
     });
 
     test('updates after a token refresh', () async {

--- a/test/features/notifications/data/fcm_token_service_test.dart
+++ b/test/features/notifications/data/fcm_token_service_test.dart
@@ -263,4 +263,73 @@ void main() {
       expect(service.currentToken, 'token-B');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // computeRefreshedTokens (FR-AC-03 AC-2 — array-mutation contract)
+  // ---------------------------------------------------------------------------
+  //
+  // Locks in the pure array-mutation contract that the previous
+  // batch-based implementation silently violated. The Firestore
+  // transaction inside FirestoreFcmTokenStore.replaceTokenAtomically
+  // calls this helper inside a runTransaction read-modify-write so the
+  // resulting list is committed atomically; this group covers the
+  // mutation semantics independently of any Firestore stub.
+
+  group('computeRefreshedTokens (AC-2 array mutation)', () {
+    test('removes the old token and adds the new token (canonical case)', () {
+      final result = computeRefreshedTokens(
+        current: const ['token-OLD'],
+        oldToken: 'token-OLD',
+        newToken: 'token-NEW',
+      );
+      expect(result, const ['token-NEW']);
+    });
+
+    test('preserves unrelated sibling tokens (multi-device user)', () {
+      final result = computeRefreshedTokens(
+        current: const ['token-PHONE', 'token-OLD', 'token-TABLET'],
+        oldToken: 'token-OLD',
+        newToken: 'token-NEW',
+      );
+      expect(result, const ['token-PHONE', 'token-TABLET', 'token-NEW']);
+    });
+
+    test('adds the new token when the old token is not present (refresh '
+        'without prior cached old)', () {
+      final result = computeRefreshedTokens(
+        current: const ['token-SIBLING'],
+        oldToken: 'token-OLD',
+        newToken: 'token-NEW',
+      );
+      expect(result, const ['token-SIBLING', 'token-NEW']);
+    });
+
+    test('starts from an empty array', () {
+      final result = computeRefreshedTokens(
+        current: const [],
+        oldToken: 'token-OLD',
+        newToken: 'token-NEW',
+      );
+      expect(result, const ['token-NEW']);
+    });
+
+    test('deduplicates: does not add the new token twice if already '
+        'present', () {
+      final result = computeRefreshedTokens(
+        current: const ['token-NEW', 'token-OLD'],
+        oldToken: 'token-OLD',
+        newToken: 'token-NEW',
+      );
+      expect(result, const ['token-NEW']);
+    });
+
+    test('oldToken == newToken is a no-op when present (idempotent)', () {
+      final result = computeRefreshedTokens(
+        current: const ['token-X'],
+        oldToken: 'token-X',
+        newToken: 'token-X',
+      );
+      expect(result, const ['token-X']);
+    });
+  });
 }

--- a/test/features/notifications/data/fcm_token_service_test.dart
+++ b/test/features/notifications/data/fcm_token_service_test.dart
@@ -1,0 +1,352 @@
+// FcmTokenService tests (FR-AC-03).
+//
+// Covers the client-side token-lifecycle helpers:
+//   - registerToken(uid) — calls getToken() then writes via arrayUnion.
+//   - unregisterToken(uid, token) — arrayRemove.
+//   - replaceToken(uid, oldToken, newToken) — single batched write.
+//   - startTokenRefreshListener(uid) — wires onTokenRefresh through
+//     replaceToken.
+//
+// Mocks `FirebaseFirestore` and `FirebaseMessaging` with thin fakes
+// following the existing `FakeFirebaseAuth` / `FakeSettlementStore`
+// pattern in this repo (no `fake_cloud_firestore` dependency).
+//
+// Tests are written BEFORE the implementation exists.
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
+
+// ---------------------------------------------------------------------------
+// Fake messaging
+// ---------------------------------------------------------------------------
+
+/// Minimal fake of FirebaseMessaging exposing only the entry points
+/// FcmTokenService consumes. Implements through composition rather
+/// than `implements FirebaseMessaging` because that class has many
+/// platform-only members; we shim via an adapter interface
+/// (`FcmMessagingAdapter`) injected into the service.
+class FakeMessagingAdapter implements FcmMessagingAdapter {
+  String? returnToken = 'token-A';
+  final StreamController<String> _refreshController =
+      StreamController<String>.broadcast();
+  int getTokenCalls = 0;
+
+  void emitRefresh(String token) => _refreshController.add(token);
+
+  @override
+  Future<String?> getToken() async {
+    getTokenCalls += 1;
+    return returnToken;
+  }
+
+  @override
+  Stream<String> get onTokenRefresh => _refreshController.stream;
+
+  Future<void> dispose() => _refreshController.close();
+}
+
+// ---------------------------------------------------------------------------
+// Fake Firestore plumbing
+//
+// We need just enough to capture the write operations on
+// `users/{uid}` and verify the FieldValue payload. We implement the
+// minimum subset of FirebaseFirestore: `collection().doc().update()`
+// and `batch().update().commit()`.
+// ---------------------------------------------------------------------------
+
+class _UpdateCall {
+  _UpdateCall(this.path, this.data);
+  final String path;
+  final Map<Object, dynamic> data;
+}
+
+class _CapturingDocRef implements DocumentReference<Map<String, dynamic>> {
+  _CapturingDocRef(this.store, this.fullPath);
+  final FakeFirestoreStore store;
+  final String fullPath;
+
+  @override
+  Future<void> update(Map<Object, Object?> data) async {
+    store.updates.add(_UpdateCall(fullPath, Map<Object, dynamic>.from(data)));
+  }
+
+  @override
+  String get id => fullPath.split('/').last;
+
+  @override
+  String get path => fullPath;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _CapturingCollection
+    implements CollectionReference<Map<String, dynamic>> {
+  _CapturingCollection(this.store, this.collectionPath);
+  final FakeFirestoreStore store;
+  final String collectionPath;
+
+  @override
+  DocumentReference<Map<String, dynamic>> doc([String? id]) {
+    return _CapturingDocRef(store, '$collectionPath/${id ?? 'auto-id'}');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Captures every write operation routed through the fake Firestore.
+class FakeFirestoreStore {
+  final List<_UpdateCall> updates = <_UpdateCall>[];
+  final List<_BatchUpdateCall> batchUpdates = <_BatchUpdateCall>[];
+  int batchCommitCount = 0;
+}
+
+class _BatchUpdateCall {
+  _BatchUpdateCall(this.path, this.data);
+  final String path;
+  final Map<Object, dynamic> data;
+}
+
+class _CapturingBatch implements WriteBatch {
+  _CapturingBatch(this.store);
+  final FakeFirestoreStore store;
+  final List<_BatchUpdateCall> _pending = <_BatchUpdateCall>[];
+
+  @override
+  void update(DocumentReference<Object?> document, Map<Object, Object?> data) {
+    _pending.add(
+      _BatchUpdateCall(document.path, Map<Object, dynamic>.from(data)),
+    );
+  }
+
+  @override
+  Future<void> commit() async {
+    store.batchUpdates.addAll(_pending);
+    store.batchCommitCount += 1;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _CapturingFirestore implements FirebaseFirestore {
+  _CapturingFirestore(this.store);
+  final FakeFirestoreStore store;
+
+  @override
+  CollectionReference<Map<String, dynamic>> collection(String path) {
+    return _CapturingCollection(store, path);
+  }
+
+  @override
+  WriteBatch batch() => _CapturingBatch(store);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+bool _isArrayUnion(dynamic value, String expectedToken) {
+  if (value is! FieldValue) return false;
+  // FieldValue's runtime type is FieldValueDelegate from
+  // cloud_firestore_platform_interface; we cannot inspect the wrapped
+  // list directly without reflection. As a pragmatic check, compare
+  // toString() shape that includes the operation name.
+  final s = value.toString();
+  return s.contains('arrayUnion') && s.contains(expectedToken);
+}
+
+bool _isArrayRemove(dynamic value, String expectedToken) {
+  if (value is! FieldValue) return false;
+  final s = value.toString();
+  return s.contains('arrayRemove') && s.contains(expectedToken);
+}
+
+// ---------------------------------------------------------------------------
+// Test body
+// ---------------------------------------------------------------------------
+
+void main() {
+  late FakeFirestoreStore store;
+  late _CapturingFirestore firestore;
+  late FakeMessagingAdapter messaging;
+  late FcmTokenService service;
+
+  setUp(() {
+    store = FakeFirestoreStore();
+    firestore = _CapturingFirestore(store);
+    messaging = FakeMessagingAdapter();
+    service = FcmTokenService(firestore: firestore, messaging: messaging);
+  });
+
+  tearDown(() async {
+    await messaging.dispose();
+  });
+
+  group('FcmTokenService.registerToken', () {
+    test('calls messaging.getToken() once and writes arrayUnion to '
+        'users/{uid}.fcmTokens', () async {
+      final token = await service.registerToken('uid-1');
+
+      expect(token, 'token-A');
+      expect(messaging.getTokenCalls, 1);
+      expect(store.updates, hasLength(1));
+      expect(store.updates.first.path, 'users/uid-1');
+      expect(
+        _isArrayUnion(store.updates.first.data['fcmTokens'], 'token-A'),
+        isTrue,
+        reason:
+            'Expected arrayUnion([token-A]) on fcmTokens; got '
+            '${store.updates.first.data}',
+      );
+    });
+
+    test('returns null and writes nothing when getToken returns null '
+        '(AC-13 — permission denied path)', () async {
+      messaging.returnToken = null;
+
+      final token = await service.registerToken('uid-1');
+
+      expect(token, isNull);
+      expect(store.updates, isEmpty);
+    });
+
+    test('is idempotent — re-registering the same token issues another '
+        'arrayUnion (Firestore deduplicates at the doc level)', () async {
+      await service.registerToken('uid-1');
+      await service.registerToken('uid-1');
+
+      expect(store.updates, hasLength(2));
+      expect(messaging.getTokenCalls, 2);
+    });
+  });
+
+  group('FcmTokenService.unregisterToken', () {
+    test('calls arrayRemove([token]) on users/{uid}.fcmTokens', () async {
+      await service.unregisterToken('uid-1', 'token-A');
+
+      expect(store.updates, hasLength(1));
+      expect(store.updates.first.path, 'users/uid-1');
+      expect(
+        _isArrayRemove(store.updates.first.data['fcmTokens'], 'token-A'),
+        isTrue,
+      );
+    });
+  });
+
+  group('FcmTokenService.replaceToken', () {
+    test('performs arrayRemove + arrayUnion in a SINGLE batched write '
+        '(AC-2 — no window with no valid token)', () async {
+      await service.replaceToken('uid-1', 'token-OLD', 'token-NEW');
+
+      expect(
+        store.batchCommitCount,
+        1,
+        reason: 'Expected exactly one batch.commit() call',
+      );
+      expect(store.batchUpdates, hasLength(2));
+      // Both updates target the same document path.
+      expect(store.batchUpdates[0].path, 'users/uid-1');
+      expect(store.batchUpdates[1].path, 'users/uid-1');
+      // One is arrayRemove(OLD), one is arrayUnion(NEW). Order is
+      // implementation detail but both must be present.
+      final allDataStrings = store.batchUpdates
+          .map((u) => u.data.values.first.toString())
+          .join(' ');
+      expect(allDataStrings, contains('arrayRemove'));
+      expect(allDataStrings, contains('arrayUnion'));
+      expect(allDataStrings, contains('token-OLD'));
+      expect(allDataStrings, contains('token-NEW'));
+    });
+
+    test('no-op (no batch commit) when oldToken == newToken', () async {
+      await service.replaceToken('uid-1', 'token-X', 'token-X');
+
+      expect(store.batchCommitCount, 0);
+    });
+  });
+
+  group('FcmTokenService.startTokenRefreshListener', () {
+    test('subscribes to onTokenRefresh and invokes replaceToken with the '
+        'previously-known token on emit', () async {
+      // Register initial token so the service caches it as the "current"
+      // device token.
+      await service.registerToken('uid-1');
+      store.updates.clear(); // Drop initial registration write.
+
+      service.startTokenRefreshListener('uid-1');
+
+      messaging.emitRefresh('token-B');
+      // Let the stream listener microtask drain.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        store.batchCommitCount,
+        1,
+        reason:
+            'Expected onTokenRefresh to invoke replaceToken which '
+            'commits a single batch',
+      );
+      final allDataStrings = store.batchUpdates
+          .map((u) => u.data.values.first.toString())
+          .join(' ');
+      expect(allDataStrings, contains('token-A')); // old
+      expect(allDataStrings, contains('token-B')); // new
+    });
+
+    test('a second startTokenRefreshListener call cancels the previous '
+        'subscription (defence-in-depth against double-wire)', () async {
+      service.startTokenRefreshListener('uid-1');
+      service.startTokenRefreshListener('uid-1');
+      // No test for the actual behaviour beyond not throwing; this
+      // verifies the method is idempotent in the lifecycle sense.
+      expect(true, isTrue);
+    });
+
+    test('stopTokenRefreshListener cancels the subscription so subsequent '
+        'emissions are ignored', () async {
+      await service.registerToken('uid-1');
+      store.updates.clear();
+      service.startTokenRefreshListener('uid-1');
+      await service.stopTokenRefreshListener();
+
+      messaging.emitRefresh('token-B');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        store.batchCommitCount,
+        0,
+        reason: 'Cancelled subscription must not write on emit',
+      );
+    });
+  });
+
+  group('FcmTokenService.currentToken', () {
+    test('is null before registerToken is called', () {
+      expect(service.currentToken, isNull);
+    });
+
+    test('returns the last-registered token', () async {
+      await service.registerToken('uid-1');
+      expect(service.currentToken, 'token-A');
+    });
+
+    test('updates after a token refresh', () async {
+      await service.registerToken('uid-1');
+      service.startTokenRefreshListener('uid-1');
+      messaging.emitRefresh('token-B');
+      await Future<void>.delayed(Duration.zero);
+      expect(service.currentToken, 'token-B');
+    });
+  });
+}

--- a/test/features/notifications/data/notification_handler_test.dart
+++ b/test/features/notifications/data/notification_handler_test.dart
@@ -1,0 +1,183 @@
+// NotificationHandler tests (FR-AC-03 + FR-AC-05).
+//
+// Verifies the three platform-handler entry points:
+//   - handleForegroundMessage(remoteMessage) — parses + invokes the
+//     banner-overlay callback.
+//   - handleBackgroundTap(remoteMessage) — parses + dispatches via the
+//     deep-link handler callback.
+//   - handleColdStart(remoteMessage) — if unauthenticated, stores in
+//     pendingDeepLinkProvider; if authenticated, dispatches immediately.
+//
+// Tests are written BEFORE the implementation exists.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/notifications/application/pending_deep_link_provider.dart';
+import 'package:onebytwo/features/notifications/data/notification_handler.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+RemoteMessage _validMessage({String type = 'expense_added'}) {
+  return RemoteMessage(
+    data: <String, dynamic>{
+      'type': type,
+      'contextType': 'friendship',
+      'contextId': 'uid-a_uid-b',
+      'itemId': 'expense-1',
+      'title': 'Rahul added an expense',
+      'body': 'Dinner — Rs.600.',
+      'senderName': 'Rahul',
+      'amountPaise': '60000',
+      'createdAt': '2026-06-08T10:00:00.000Z',
+    },
+  );
+}
+
+RemoteMessage _malformedMessage() {
+  return const RemoteMessage(data: <String, dynamic>{'type': 'expense_added'});
+}
+
+void main() {
+  group('NotificationHandler.handleForegroundMessage', () {
+    test('parses the payload and invokes the banner callback', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      NotificationPayload? captured;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (p) async => captured = p,
+        onDeepLink: (_) async {},
+      );
+
+      await handler.handleForegroundMessage(_validMessage());
+
+      expect(captured, isNotNull);
+      expect(captured!.type, NotificationType.expenseAdded);
+      expect(captured!.contextId, 'uid-a_uid-b');
+    });
+
+    test('silently drops malformed payloads without invoking the '
+        'banner callback (defence-in-depth)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var called = false;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (_) async {
+          called = true;
+        },
+        onDeepLink: (_) async {},
+      );
+
+      await handler.handleForegroundMessage(_malformedMessage());
+
+      expect(called, isFalse);
+    });
+  });
+
+  group('NotificationHandler.handleBackgroundTap', () {
+    test('parses the payload and invokes the deep-link callback', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      NotificationPayload? captured;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (_) async {},
+        onDeepLink: (p) async => captured = p,
+      );
+
+      await handler.handleBackgroundTap(
+        _validMessage(type: 'settlement_received'),
+      );
+
+      expect(captured, isNotNull);
+      expect(captured!.type, NotificationType.settlementReceived);
+    });
+
+    test('silently drops malformed payloads', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var called = false;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (_) async {},
+        onDeepLink: (_) async {
+          called = true;
+        },
+      );
+
+      await handler.handleBackgroundTap(_malformedMessage());
+
+      expect(called, isFalse);
+    });
+  });
+
+  group('NotificationHandler.handleColdStart', () {
+    test('stores the payload in pendingDeepLinkProvider when '
+        'unauthenticated (currentUid = null)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var deepLinkCalled = false;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (_) async {},
+        onDeepLink: (_) async => deepLinkCalled = true,
+      );
+
+      await handler.handleColdStart(_validMessage(), currentUid: null);
+
+      expect(deepLinkCalled, isFalse);
+      final pending = container.read(pendingDeepLinkProvider);
+      expect(pending, isNotNull);
+      expect(pending!.type, NotificationType.expenseAdded);
+    });
+
+    test('dispatches via deep-link callback when authenticated (currentUid '
+        'is set)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      NotificationPayload? captured;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (_) async {},
+        onDeepLink: (p) async => captured = p,
+      );
+
+      await handler.handleColdStart(
+        _validMessage(type: 'reminder'),
+        currentUid: 'uid-me',
+      );
+
+      expect(captured, isNotNull);
+      expect(captured!.type, NotificationType.reminder);
+      // The pending provider stays null in the authenticated path.
+      expect(container.read(pendingDeepLinkProvider), isNull);
+    });
+
+    test('does nothing when payload is malformed (no pending intent, no '
+        'deep-link dispatch)', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      var deepLinkCalled = false;
+      final handler = NotificationHandler(
+        ref: container,
+        onBannerShow: (_) async {},
+        onDeepLink: (_) async => deepLinkCalled = true,
+      );
+
+      await handler.handleColdStart(_malformedMessage(), currentUid: 'uid-me');
+
+      expect(deepLinkCalled, isFalse);
+      expect(container.read(pendingDeepLinkProvider), isNull);
+    });
+  });
+}

--- a/test/features/notifications/domain/notification_payload_test.dart
+++ b/test/features/notifications/domain/notification_payload_test.dart
@@ -1,0 +1,240 @@
+// NotificationPayload domain parse tests (FR-AC-03).
+//
+// Verifies the Dart-side parsing of the FCM data envelope defined by
+// `functions/src/notifications/types.ts`. The six `type` values are the
+// discriminator the client routes on.
+//
+// Tests are written BEFORE the implementation exists.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+
+void main() {
+  group('NotificationTypeX.fromWireName', () {
+    test('parses each of the six snake_case wire values', () {
+      expect(
+        NotificationTypeX.fromWireName('expense_added'),
+        NotificationType.expenseAdded,
+      );
+      expect(
+        NotificationTypeX.fromWireName('expense_edited'),
+        NotificationType.expenseEdited,
+      );
+      expect(
+        NotificationTypeX.fromWireName('expense_deleted'),
+        NotificationType.expenseDeleted,
+      );
+      expect(
+        NotificationTypeX.fromWireName('settlement_received'),
+        NotificationType.settlementReceived,
+      );
+      expect(
+        NotificationTypeX.fromWireName('reminder'),
+        NotificationType.reminder,
+      );
+      expect(
+        NotificationTypeX.fromWireName('group_invite'),
+        NotificationType.groupInvite,
+      );
+    });
+
+    test('returns null for unknown wire values (forward-incompat loud)', () {
+      expect(NotificationTypeX.fromWireName('unknown_type'), isNull);
+      expect(NotificationTypeX.fromWireName(''), isNull);
+      expect(NotificationTypeX.fromWireName('expenseAdded'), isNull);
+    });
+  });
+
+  group('NotificationPayload.fromFcmDataMap — happy path', () {
+    test('parses an expense_added payload with all fields populated', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_added',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'itemId': 'expense-1',
+        'title': 'Rahul added an expense',
+        'body': 'Dinner — Rs.600. You owe Rs.300.',
+        'senderName': 'Rahul',
+        'amountPaise': '60000',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.type, NotificationType.expenseAdded);
+      expect(payload.contextType, 'friendship');
+      expect(payload.contextId, 'uid-a_uid-b');
+      expect(payload.itemId, 'expense-1');
+      expect(payload.title, 'Rahul added an expense');
+      expect(payload.body, 'Dinner — Rs.600. You owe Rs.300.');
+      expect(payload.senderName, 'Rahul');
+      expect(payload.amountPaise, 60000);
+      expect(payload.createdAt, DateTime.parse('2026-06-08T10:00:00.000Z'));
+      expect(payload.inviteToken, isNull);
+    });
+
+    test('parses a settlement_received payload', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'settlement_received',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'itemId': 'settlement-9',
+        'title': 'Priya settled up',
+        'body': 'You received Rs.350.',
+        'senderName': 'Priya',
+        'amountPaise': '35000',
+        'createdAt': '2026-06-08T11:30:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.type, NotificationType.settlementReceived);
+      expect(payload.itemId, 'settlement-9');
+      expect(payload.amountPaise, 35000);
+    });
+
+    test('parses a reminder payload', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'reminder',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'title': 'Reminder from Rahul',
+        'body': 'Rahul is nudging you about Rs.500.',
+        'senderName': 'Rahul',
+        'amountPaise': '50000',
+        'createdAt': '2026-06-08T12:00:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.type, NotificationType.reminder);
+      expect(payload.itemId, isNull);
+    });
+
+    test('parses a group_invite payload (no amountPaise, has inviteToken)', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'group_invite',
+        'contextType': 'group',
+        'contextId': 'group-7',
+        'title': 'Rahul invited you to a group',
+        'body': 'Join "Goa Trip" to start splitting.',
+        'senderName': 'Rahul',
+        'inviteToken': 'token-abc-123',
+        'createdAt': '2026-06-08T13:00:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.type, NotificationType.groupInvite);
+      expect(payload.contextType, 'group');
+      expect(payload.amountPaise, isNull);
+      expect(payload.inviteToken, 'token-abc-123');
+    });
+
+    test('parses an expense_deleted payload (no itemId)', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_deleted',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'title': 'Rahul deleted an expense',
+        'body': 'Dinner (Rs.600) was removed.',
+        'senderName': 'Rahul',
+        'amountPaise': '60000',
+        'createdAt': '2026-06-08T14:00:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.type, NotificationType.expenseDeleted);
+      expect(payload.itemId, isNull);
+      expect(payload.amountPaise, 60000);
+    });
+  });
+
+  group('NotificationPayload.fromFcmDataMap — defensive parse', () {
+    test('returns null when `type` field is missing', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNull);
+    });
+
+    test('returns null when `type` is unknown (forward-incompat loud)', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_archived',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNull);
+    });
+
+    test('returns null when `contextType` field is missing', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_added',
+        'contextId': 'uid-a_uid-b',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNull);
+    });
+
+    test('returns null when `contextId` field is missing', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_added',
+        'contextType': 'friendship',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNull);
+    });
+
+    test('returns null when `createdAt` is unparseable', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_added',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'amountPaise': '600',
+        'createdAt': 'not-a-date',
+      });
+      expect(payload, isNull);
+    });
+
+    test('amountPaise is null when missing (group_invite path)', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'group_invite',
+        'contextType': 'group',
+        'contextId': 'group-7',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'inviteToken': 'tok',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.amountPaise, isNull);
+    });
+
+    test('amountPaise is null when unparseable string (defensive)', () {
+      final payload = NotificationPayload.fromFcmDataMap(<String, dynamic>{
+        'type': 'expense_added',
+        'contextType': 'friendship',
+        'contextId': 'uid-a_uid-b',
+        'title': 't',
+        'body': 'b',
+        'senderName': 'n',
+        'amountPaise': 'NaN',
+        'createdAt': '2026-06-08T10:00:00.000Z',
+      });
+      expect(payload, isNotNull);
+      expect(payload!.amountPaise, isNull);
+    });
+  });
+}

--- a/test/features/notifications/notifications_boundary_contract_test.dart
+++ b/test/features/notifications/notifications_boundary_contract_test.dart
@@ -113,16 +113,12 @@ void main() {
         'lib/features/notifications/domain/notification_payload.dart',
         'lib/features/notifications/data/fcm_token_service.dart',
         'lib/features/notifications/data/notification_handler.dart',
-        'lib/features/notifications/application/'
-            'firebase_messaging_provider.dart',
-        'lib/features/notifications/application/'
-            'pending_deep_link_provider.dart',
+        'lib/features/notifications/application/firebase_messaging_provider.dart',
+        'lib/features/notifications/application/pending_deep_link_provider.dart',
         'lib/features/notifications/application/deep_link_handler.dart',
-        'lib/features/notifications/application/'
-            'notification_permission_controller.dart',
+        'lib/features/notifications/application/notification_permission_controller.dart',
         'lib/features/notifications/presentation/pre_permission_dialog.dart',
-        'lib/features/notifications/presentation/widgets/'
-            'in_app_notification_banner.dart',
+        'lib/features/notifications/presentation/widgets/in_app_notification_banner.dart',
         'lib/core/routing/notification_deep_links.dart',
       ];
       final missing = <String>[

--- a/test/features/notifications/notifications_boundary_contract_test.dart
+++ b/test/features/notifications/notifications_boundary_contract_test.dart
@@ -1,0 +1,184 @@
+// Notifications feature boundary-contract tests (FR-AC-03).
+//
+// Mirrors test/features/activity/activity_boundary_contract_test.dart.
+// Greps `lib/features/notifications/**` and
+// `lib/core/routing/notification_deep_links.dart` for forbidden
+// patterns that would violate the load-bearing invariants:
+//
+//   - Invariant 1 (paise integers): no `.toDouble()`, no `/ 100`, no
+//     `double ` declarations. The notification body is server-rendered
+//     to a pre-formatted string; the client just displays it. The
+//     boundary-contract grep is defence-in-depth (AC-15).
+//
+//   - Invariant 2 (simplifiedBalances server-only): no reference to
+//     the string 'simplifiedBalances' (AC-16).
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('notifications boundary contract — no double / no /100 '
+      '(invariant 1, AC-15)', () {
+    test('lib/features/notifications contains no `.toDouble()`, '
+        '`/ 100`, or `double ` declarations', () {
+      final dir = Directory('lib/features/notifications');
+      if (!dir.existsSync()) {
+        fail(
+          'Expected lib/features/notifications to exist; the feature '
+          'must be scaffolded before this contract test can run.',
+        );
+      }
+
+      final violations = _scanForFloatViolations(dir);
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Boundary violations in lib/features/notifications/**:\n'
+            '${violations.join('\n')}',
+      );
+    });
+
+    test('lib/core/routing/notification_deep_links.dart contains no '
+        '`.toDouble()`, `/ 100`, or `double ` declarations', () {
+      final file = File('lib/core/routing/notification_deep_links.dart');
+      if (!file.existsSync()) {
+        fail('Expected notification_deep_links.dart to exist');
+      }
+      final violations = _scanFileForFloatViolations(file);
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+  });
+
+  group('notifications boundary contract — no simplifiedBalances '
+      '(invariant 2, AC-16)', () {
+    test('lib/features/notifications contains no reference to '
+        'simplifiedBalances', () {
+      final dir = Directory('lib/features/notifications');
+      if (!dir.existsSync()) {
+        fail('Expected lib/features/notifications to exist');
+      }
+
+      final violations = <String>[];
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart')) continue;
+
+        final lines = entity.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          if (_isCommentLine(line)) continue;
+          if (line.contains('simplifiedBalances')) {
+            violations.add(
+              '${entity.path}:${i + 1}: forbidden reference to '
+              'simplifiedBalances (server-maintained, client-read-only)',
+            );
+          }
+        }
+      }
+
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+
+    test('lib/core/routing/notification_deep_links.dart contains no '
+        'reference to simplifiedBalances', () {
+      final file = File('lib/core/routing/notification_deep_links.dart');
+      if (!file.existsSync()) {
+        fail('Expected notification_deep_links.dart to exist');
+      }
+      final lines = file.readAsLinesSync();
+      final violations = <String>[];
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        if (_isCommentLine(line)) continue;
+        if (line.contains('simplifiedBalances')) {
+          violations.add(
+            '${file.path}:${i + 1}: forbidden reference to '
+            'simplifiedBalances',
+          );
+        }
+      }
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+  });
+
+  group('notifications boundary contract — FR-AC-03 / FR-AC-05 files '
+      'exist', () {
+    test('the notifications-feature scaffold + shared routing helper are '
+        'present so the recursive walks above have something to walk', () {
+      const expected = <String>[
+        'lib/features/notifications/domain/notification_payload.dart',
+        'lib/features/notifications/data/fcm_token_service.dart',
+        'lib/features/notifications/data/notification_handler.dart',
+        'lib/features/notifications/application/'
+            'firebase_messaging_provider.dart',
+        'lib/features/notifications/application/'
+            'pending_deep_link_provider.dart',
+        'lib/features/notifications/application/deep_link_handler.dart',
+        'lib/features/notifications/application/'
+            'notification_permission_controller.dart',
+        'lib/features/notifications/presentation/pre_permission_dialog.dart',
+        'lib/features/notifications/presentation/widgets/'
+            'in_app_notification_banner.dart',
+        'lib/core/routing/notification_deep_links.dart',
+      ];
+      final missing = <String>[
+        for (final path in expected)
+          if (!File(path).existsSync()) path,
+      ];
+      expect(
+        missing,
+        isEmpty,
+        reason:
+            'FR-AC-03 / FR-AC-05 added these files; if any is missing, '
+            'the contract is broken and the boundary walks above are '
+            'unable to enforce paise / simplifiedBalances guarantees '
+            'against the new code paths.\nMissing: '
+            '${missing.join(', ')}',
+      );
+    });
+  });
+}
+
+List<String> _scanForFloatViolations(Directory dir) {
+  final violations = <String>[];
+  for (final entity in dir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.dart')) continue;
+    violations.addAll(_scanFileForFloatViolations(entity));
+  }
+  return violations;
+}
+
+List<String> _scanFileForFloatViolations(File file) {
+  final violations = <String>[];
+  final lines = file.readAsLinesSync();
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (_isCommentLine(line)) continue;
+
+    if (line.contains('.toDouble()')) {
+      violations.add('${file.path}:${i + 1}: forbidden .toDouble()');
+    }
+    if (line.contains(' double ') || line.contains('(double ')) {
+      violations.add('${file.path}:${i + 1}: forbidden `double` declaration');
+    }
+    if (line.contains(RegExp(r'/\s*100\b')) && !line.contains('~/')) {
+      violations.add(
+        '${file.path}:${i + 1}: forbidden `/ 100` paise division '
+        '(server pre-renders the body string; client does no INR math)',
+      );
+    }
+  }
+  return violations;
+}
+
+bool _isCommentLine(String raw) {
+  final trimmed = raw.trim();
+  return trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*');
+}

--- a/test/features/notifications/notifications_boundary_contract_test.dart
+++ b/test/features/notifications/notifications_boundary_contract_test.dart
@@ -117,7 +117,9 @@ void main() {
         'lib/features/notifications/application/pending_deep_link_provider.dart',
         'lib/features/notifications/application/deep_link_handler.dart',
         'lib/features/notifications/application/notification_permission_controller.dart',
+        'lib/features/notifications/application/sign_out_with_fcm_cleanup.dart',
         'lib/features/notifications/presentation/pre_permission_dialog.dart',
+        'lib/features/notifications/presentation/notifications_lifecycle_host.dart',
         'lib/features/notifications/presentation/widgets/in_app_notification_banner.dart',
         'lib/core/routing/notification_deep_links.dart',
       ];

--- a/test/features/notifications/presentation/in_app_notification_banner_test.dart
+++ b/test/features/notifications/presentation/in_app_notification_banner_test.dart
@@ -1,0 +1,228 @@
+// InAppNotificationBanner widget tests (FR-AC-03).
+//
+// Covers the foreground banner (wireframes §2):
+//   - Renders title + body + category icon per type.
+//   - Auto-dismisses after 4 seconds.
+//   - Tap → calls onTap(payload).
+//   - Swipe up → calls onDismiss.
+//   - Min 64dp height (satisfies 48dp tap target).
+//   - Semantic label includes title + body + tap/swipe hint.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+import 'package:onebytwo/features/notifications/presentation/widgets/in_app_notification_banner.dart';
+
+NotificationPayload _payload({
+  NotificationType type = NotificationType.expenseAdded,
+  String title = 'Rahul added an expense',
+  String body = 'Dinner — Rs.600.',
+}) {
+  return NotificationPayload(
+    type: type,
+    contextType: 'friendship',
+    contextId: 'uid-a_uid-b',
+    itemId: 'expense-1',
+    title: title,
+    body: body,
+    senderName: 'Rahul',
+    amountPaise: 60000,
+    createdAt: DateTime.utc(2026, 6, 8),
+  );
+}
+
+Future<void> _pumpBanner(
+  WidgetTester tester, {
+  required NotificationPayload payload,
+  required void Function(NotificationPayload) onTap,
+  required VoidCallback onDismiss,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: InAppNotificationBanner(
+          payload: payload,
+          onTap: onTap,
+          onDismiss: onDismiss,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('InAppNotificationBanner — content', () {
+    testWidgets('renders title and body text', (tester) async {
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (_) {},
+        onDismiss: () {},
+      );
+      await tester.pump(); // start the entrance animation
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Rahul added an expense'), findsOneWidget);
+      expect(find.text('Dinner — Rs.600.'), findsOneWidget);
+    });
+
+    testWidgets('renders the expense receipt icon for expense_added', (
+      tester,
+    ) async {
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (_) {},
+        onDismiss: () {},
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byIcon(Icons.receipt_long), findsOneWidget);
+    });
+
+    testWidgets('renders the settlement tick-circle icon for '
+        'settlement_received', (tester) async {
+      await _pumpBanner(
+        tester,
+        payload: _payload(type: NotificationType.settlementReceived),
+        onTap: (_) {},
+        onDismiss: () {},
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    });
+
+    testWidgets('renders the reminder bell icon for reminder', (tester) async {
+      await _pumpBanner(
+        tester,
+        payload: _payload(type: NotificationType.reminder),
+        onTap: (_) {},
+        onDismiss: () {},
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byIcon(Icons.notifications_active), findsOneWidget);
+    });
+  });
+
+  group('InAppNotificationBanner — interaction', () {
+    testWidgets('Tap → calls onTap(payload)', (tester) async {
+      NotificationPayload? captured;
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (p) => captured = p,
+        onDismiss: () {},
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      await tester.tap(find.byType(InAppNotificationBanner));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.type, NotificationType.expenseAdded);
+    });
+
+    testWidgets('Swipe up → calls onDismiss', (tester) async {
+      var dismissed = 0;
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (_) {},
+        onDismiss: () => dismissed += 1,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      await tester.fling(
+        find.byType(InAppNotificationBanner),
+        const Offset(0, -300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(dismissed, greaterThanOrEqualTo(1));
+    });
+
+    testWidgets('auto-dismisses after 4 seconds', (tester) async {
+      var dismissed = 0;
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (_) {},
+        onDismiss: () => dismissed += 1,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      // Not yet auto-dismissed.
+      await tester.pump(const Duration(seconds: 3));
+      expect(dismissed, 0);
+
+      // Past the 4-second threshold.
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+      expect(dismissed, 1);
+    });
+  });
+
+  group('InAppNotificationBanner — accessibility', () {
+    testWidgets('container is at least 64dp tall (satisfies 48dp tap target)', (
+      tester,
+    ) async {
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (_) {},
+        onDismiss: () {},
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      final size = tester.getSize(find.byType(InAppNotificationBanner));
+      expect(size.height, greaterThanOrEqualTo(64));
+    });
+
+    testWidgets('exposes a Semantics label with title + body + hint', (
+      tester,
+    ) async {
+      await _pumpBanner(
+        tester,
+        payload: _payload(),
+        onTap: (_) {},
+        onDismiss: () {},
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      // Find any Semantics whose label includes both title and body
+      // text plus the interaction hint per wireframes §2.4.
+      final labels = tester
+          .widgetList<Semantics>(find.byType(Semantics))
+          .map((s) => s.properties.label ?? '')
+          .toList();
+      final hasFullLabel = labels.any(
+        (l) =>
+            l.contains('Rahul added an expense') &&
+            l.contains('Dinner') &&
+            l.contains('Tap to view') &&
+            l.contains('Swipe up'),
+      );
+      expect(
+        hasFullLabel,
+        isTrue,
+        reason:
+            'Expected a Semantics(label: "<title>. <body>. Tap to '
+            'view details. Swipe up to dismiss.") per wireframes §2.4. '
+            'Got labels: $labels',
+      );
+    });
+  });
+}

--- a/test/features/notifications/presentation/notifications_lifecycle_host_test.dart
+++ b/test/features/notifications/presentation/notifications_lifecycle_host_test.dart
@@ -1,0 +1,371 @@
+// NotificationsLifecycleHost widget tests (FR-AC-03 / FR-AC-05).
+//
+// Covers the behaviorally complex app-startup wrapper:
+//   - auth-state transition to AuthenticatedWithProfile replays a
+//     pending deep-link payload exactly once (FR-AC-05 cold-start
+//     unauthenticated-then-sign-in flow);
+//   - the pre-permission dialog telemetry event
+//     fcm_permission_prompt_shown is emitted on first-session
+//     transition (FR-AC-03 AC-14);
+//   - host mounts without crashing when FirebaseMessaging is not
+//     initialised (defensive try/catch in _subscribeFcmStreams).
+//
+// The cold-start `getInitialMessage` path is exercised by seeding
+// `pendingDeepLinkProvider` directly — equivalent to the "OS launched
+// app with payload, user is unauthenticated, payload cached, sign-in
+// completes" flow. The static `FirebaseMessaging.onMessage` and
+// `onMessageOpenedApp` streams are not mocked here because they are
+// static getters that throw without a Firebase platform-channel; the
+// host's try/catch ensures this never crashes the test.
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/routing/notification_deep_links.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/auth/application/auth_state_provider.dart';
+import 'package:onebytwo/features/auth/domain/auth_state.dart';
+import 'package:onebytwo/features/auth/domain/user_model.dart';
+import 'package:onebytwo/features/notifications/application/deep_link_handler.dart';
+import 'package:onebytwo/features/notifications/application/notification_permission_controller.dart';
+import 'package:onebytwo/features/notifications/application/pending_deep_link_provider.dart';
+import 'package:onebytwo/features/notifications/data/fcm_token_service.dart';
+import 'package:onebytwo/features/notifications/domain/notification_payload.dart';
+import 'package:onebytwo/features/notifications/presentation/notifications_lifecycle_host.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeAnalyticsService implements AnalyticsService {
+  final List<String> loggedEvents = <String>[];
+  final List<Map<String, Object>?> loggedParameters = <Map<String, Object>?>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object>? parameters,
+  }) async {
+    loggedEvents.add(name);
+    loggedParameters.add(parameters);
+  }
+}
+
+class FakePermissionMessagingAdapter implements PermissionMessagingAdapter {
+  int requestCalls = 0;
+
+  @override
+  Future<NotificationSettings> requestPermission() async {
+    requestCalls += 1;
+    // The host never actually calls requestPermission in these tests
+    // (it only schedules the dialog; the user has to tap Enable).
+    return const NotificationSettings(
+      alert: AppleNotificationSetting.enabled,
+      announcement: AppleNotificationSetting.disabled,
+      authorizationStatus: AuthorizationStatus.notDetermined,
+      badge: AppleNotificationSetting.enabled,
+      carPlay: AppleNotificationSetting.disabled,
+      lockScreen: AppleNotificationSetting.enabled,
+      notificationCenter: AppleNotificationSetting.enabled,
+      showPreviews: AppleShowPreviewSetting.always,
+      timeSensitive: AppleNotificationSetting.disabled,
+      criticalAlert: AppleNotificationSetting.disabled,
+      sound: AppleNotificationSetting.enabled,
+      providesAppNotificationSettings: AppleNotificationSetting.disabled,
+    );
+  }
+}
+
+class FakeTokenService implements FcmTokenService {
+  @override
+  String? get currentToken => null;
+
+  @override
+  Future<String?> registerToken(String uid) async => null;
+
+  @override
+  void startTokenRefreshListener(String uid) {}
+
+  @override
+  Future<void> unregisterToken(String uid, String token) async {}
+
+  @override
+  Future<void> replaceToken(
+    String uid,
+    String oldToken,
+    String newToken,
+  ) async {}
+
+  @override
+  Future<void> stopTokenRefreshListener() async {}
+}
+
+class FakeDeepLinkHandler implements DeepLinkHandler {
+  int handleCalls = 0;
+  NotificationPayload? lastPayload;
+  String? lastCurrentUid;
+  DeepLinkSource? lastSource;
+
+  // The base DeepLinkHandler holds a private ProviderContainer in
+  // its constructor; the fake does not need one because it overrides
+  // both public methods.
+
+  @override
+  DeepLinkTarget resolveTarget(
+    NotificationPayload payload, {
+    required String currentUid,
+  }) {
+    return const DeepLinkUnavailable();
+  }
+
+  @override
+  Future<void> handleDeepLink({
+    required NotificationPayload payload,
+    required BuildContext context,
+    required String currentUid,
+    required DeepLinkSource source,
+  }) async {
+    handleCalls += 1;
+    lastPayload = payload;
+    lastCurrentUid = currentUid;
+    lastSource = source;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+NotificationPayload _samplePayload() {
+  return NotificationPayload(
+    type: NotificationType.expenseAdded,
+    contextType: 'friendship',
+    contextId: 'uid-me_uid-friend',
+    itemId: 'expense-1',
+    title: 'Test',
+    body: 'Body',
+    senderName: 'Sender',
+    amountPaise: 12300,
+    createdAt: DateTime(2026),
+  );
+}
+
+UserModel _testUser() => UserModel(
+  phoneNumber: '+919999999999',
+  displayName: 'Tester',
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+);
+
+Widget _buildHost({
+  required StreamController<AuthState> authController,
+  required FakeAnalyticsService analytics,
+  required FakeDeepLinkHandler deepLinkHandler,
+  NotificationPayload? seededPending,
+}) {
+  return ProviderScope(
+    overrides: [
+      analyticsServiceProvider.overrideWithValue(analytics),
+      permissionMessagingAdapterProvider.overrideWithValue(
+        FakePermissionMessagingAdapter(),
+      ),
+      fcmTokenServiceProvider.overrideWithValue(FakeTokenService()),
+      deepLinkHandlerProvider.overrideWithValue(deepLinkHandler),
+      authStateNotifierProvider.overrideWith((ref) => authController.stream),
+      if (seededPending != null)
+        pendingDeepLinkProvider.overrideWith((ref) => seededPending),
+    ],
+    child: const MaterialApp(
+      home: NotificationsLifecycleHost(child: Scaffold(body: Text('child'))),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('NotificationsLifecycleHost — host stability', () {
+    testWidgets('mounts and renders the child without crashing even when '
+        'FirebaseMessaging static streams throw (defensive swallow)', (
+      tester,
+    ) async {
+      final analytics = FakeAnalyticsService();
+      final deepLinkHandler = FakeDeepLinkHandler();
+      final authController = StreamController<AuthState>.broadcast();
+      addTearDown(authController.close);
+
+      await tester.pumpWidget(
+        _buildHost(
+          authController: authController,
+          analytics: analytics,
+          deepLinkHandler: deepLinkHandler,
+        ),
+      );
+      authController.add(const AuthUnauthenticated());
+      await tester.pumpAndSettle();
+
+      // The Firebase platform-channel is not initialised in tests —
+      // FirebaseMessaging.onMessage / onMessageOpenedApp throw. The
+      // host's try/catch must swallow these so the app shell renders.
+      expect(find.text('child'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('NotificationsLifecycleHost — pending deep-link replay (FR-AC-05)', () {
+    testWidgets('on first transition to AuthenticatedWithProfile, the '
+        'pending deep-link payload is replayed via DeepLinkHandler and '
+        'cleared from pendingDeepLinkProvider', (tester) async {
+      final analytics = FakeAnalyticsService();
+      final deepLinkHandler = FakeDeepLinkHandler();
+      final authController = StreamController<AuthState>.broadcast();
+      addTearDown(authController.close);
+      final pending = _samplePayload();
+
+      await tester.pumpWidget(
+        _buildHost(
+          authController: authController,
+          analytics: analytics,
+          deepLinkHandler: deepLinkHandler,
+          seededPending: pending,
+        ),
+      );
+      // Start unauthenticated — pending payload stays cached.
+      authController.add(const AuthUnauthenticated());
+      await tester.pumpAndSettle();
+      expect(deepLinkHandler.handleCalls, 0);
+
+      // Transition to AuthenticatedWithProfile — replay fires exactly once.
+      authController.add(
+        AuthenticatedWithProfile(uid: 'uid-me', user: _testUser()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(deepLinkHandler.handleCalls, 1);
+      expect(deepLinkHandler.lastPayload?.itemId, 'expense-1');
+      expect(deepLinkHandler.lastCurrentUid, 'uid-me');
+      expect(deepLinkHandler.lastSource, DeepLinkSource.coldStart);
+    });
+
+    testWidgets('replay does NOT fire a second time on subsequent auth '
+        'emissions of the same AuthenticatedWithProfile state', (tester) async {
+      final analytics = FakeAnalyticsService();
+      final deepLinkHandler = FakeDeepLinkHandler();
+      final authController = StreamController<AuthState>.broadcast();
+      addTearDown(authController.close);
+
+      await tester.pumpWidget(
+        _buildHost(
+          authController: authController,
+          analytics: analytics,
+          deepLinkHandler: deepLinkHandler,
+          seededPending: _samplePayload(),
+        ),
+      );
+      authController.add(const AuthUnauthenticated());
+      await tester.pumpAndSettle();
+
+      final user = _testUser();
+      authController.add(AuthenticatedWithProfile(uid: 'uid-me', user: user));
+      await tester.pumpAndSettle();
+      // Second emission of the SAME logical state (different identity).
+      authController.add(AuthenticatedWithProfile(uid: 'uid-me', user: user));
+      await tester.pumpAndSettle();
+
+      // Replay still fires only once — the second transition is from
+      // AuthenticatedWithProfile -> AuthenticatedWithProfile and is
+      // gated by the `wasAuthenticated` check.
+      expect(deepLinkHandler.handleCalls, 1);
+    });
+
+    testWidgets('with no pending payload, no replay is attempted', (
+      tester,
+    ) async {
+      final analytics = FakeAnalyticsService();
+      final deepLinkHandler = FakeDeepLinkHandler();
+      final authController = StreamController<AuthState>.broadcast();
+      addTearDown(authController.close);
+
+      await tester.pumpWidget(
+        _buildHost(
+          authController: authController,
+          analytics: analytics,
+          deepLinkHandler: deepLinkHandler,
+        ),
+      );
+      authController.add(const AuthUnauthenticated());
+      await tester.pumpAndSettle();
+      authController.add(
+        AuthenticatedWithProfile(uid: 'uid-me', user: _testUser()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(deepLinkHandler.handleCalls, 0);
+    });
+  });
+
+  group('NotificationsLifecycleHost — pre-permission dialog telemetry '
+      '(FR-AC-03 AC-14)', () {
+    testWidgets('emits fcm_permission_prompt_shown with trigger:first_session '
+        'on first transition to AuthenticatedWithProfile', (tester) async {
+      final analytics = FakeAnalyticsService();
+      final deepLinkHandler = FakeDeepLinkHandler();
+      final authController = StreamController<AuthState>.broadcast();
+      addTearDown(authController.close);
+
+      await tester.pumpWidget(
+        _buildHost(
+          authController: authController,
+          analytics: analytics,
+          deepLinkHandler: deepLinkHandler,
+        ),
+      );
+      authController.add(const AuthUnauthenticated());
+      await tester.pumpAndSettle();
+      authController.add(
+        AuthenticatedWithProfile(uid: 'uid-me', user: _testUser()),
+      );
+      await tester.pumpAndSettle();
+
+      final idx = analytics.loggedEvents.indexOf('fcm_permission_prompt_shown');
+      expect(idx, isNonNegative);
+      expect(analytics.loggedParameters[idx], {'trigger': 'first_session'});
+    });
+
+    testWidgets('does NOT emit fcm_permission_prompt_shown a second time '
+        'within the same session', (tester) async {
+      final analytics = FakeAnalyticsService();
+      final deepLinkHandler = FakeDeepLinkHandler();
+      final authController = StreamController<AuthState>.broadcast();
+      addTearDown(authController.close);
+
+      await tester.pumpWidget(
+        _buildHost(
+          authController: authController,
+          analytics: analytics,
+          deepLinkHandler: deepLinkHandler,
+        ),
+      );
+      final user = _testUser();
+      authController.add(const AuthUnauthenticated());
+      await tester.pumpAndSettle();
+      authController.add(AuthenticatedWithProfile(uid: 'uid-me', user: user));
+      await tester.pumpAndSettle();
+      // Same logical state again — guarded by _dialogShownThisSession.
+      authController.add(AuthenticatedWithProfile(uid: 'uid-me', user: user));
+      await tester.pumpAndSettle();
+
+      final count = analytics.loggedEvents
+          .where((e) => e == 'fcm_permission_prompt_shown')
+          .length;
+      expect(count, 1);
+    });
+  });
+}

--- a/test/features/notifications/presentation/pre_permission_dialog_test.dart
+++ b/test/features/notifications/presentation/pre_permission_dialog_test.dart
@@ -1,0 +1,163 @@
+// PrePermissionDialog widget tests (FR-AC-03, AC-20).
+//
+// Covers the "Stay in the loop" dialog (wireframes §1.1):
+//   - Heading announced as a heading (Semantics(header: true)).
+//   - "Enable Notifications" button has min 48dp tap target.
+//   - "Not now" button has min 48dp tap target.
+//   - Tap "Enable" → calls onEnable callback.
+//   - Tap "Not now" → calls onDismiss callback.
+//   - Tap scrim → calls onDismiss callback (≡ "Not now" per wireframes §1.2).
+//   - Back gesture → calls onDismiss.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/notifications/presentation/pre_permission_dialog.dart';
+
+Future<void> _pumpAndShowDialog(
+  WidgetTester tester, {
+  required VoidCallback onEnable,
+  required VoidCallback onDismiss,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            return ElevatedButton(
+              onPressed: () => showPrePermissionDialog(
+                context: context,
+                onEnable: onEnable,
+                onDismiss: onDismiss,
+              ),
+              child: const Text('open'),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('PrePermissionDialog — content', () {
+    testWidgets('renders heading + body + both buttons', (tester) async {
+      await _pumpAndShowDialog(tester, onEnable: () {}, onDismiss: () {});
+
+      expect(find.text('Stay in the loop'), findsOneWidget);
+      expect(
+        find.textContaining('Get notified when friends add expenses'),
+        findsOneWidget,
+      );
+      expect(find.text('Enable Notifications'), findsOneWidget);
+      expect(find.text('Not now'), findsOneWidget);
+    });
+
+    testWidgets('heading is announced as a heading (Semantics header)', (
+      tester,
+    ) async {
+      await _pumpAndShowDialog(tester, onEnable: () {}, onDismiss: () {});
+
+      final headingSemantics = tester
+          .widgetList<Semantics>(find.byType(Semantics))
+          .where((s) => s.properties.header == true)
+          .toList();
+      expect(
+        headingSemantics,
+        isNotEmpty,
+        reason:
+            'Expected at least one Semantics(header: true) widget '
+            'wrapping the heading text per AC-20.',
+      );
+    });
+  });
+
+  group('PrePermissionDialog — interaction', () {
+    testWidgets('Tap "Enable Notifications" invokes onEnable callback', (
+      tester,
+    ) async {
+      var enabledCount = 0;
+      await _pumpAndShowDialog(
+        tester,
+        onEnable: () => enabledCount += 1,
+        onDismiss: () {},
+      );
+
+      await tester.tap(find.text('Enable Notifications'));
+      await tester.pumpAndSettle();
+
+      expect(enabledCount, 1);
+    });
+
+    testWidgets('Tap "Not now" invokes onDismiss callback', (tester) async {
+      var dismissedCount = 0;
+      await _pumpAndShowDialog(
+        tester,
+        onEnable: () {},
+        onDismiss: () => dismissedCount += 1,
+      );
+
+      await tester.tap(find.text('Not now'));
+      await tester.pumpAndSettle();
+
+      expect(dismissedCount, 1);
+    });
+
+    testWidgets('Tap scrim invokes onDismiss (equivalent to Not now '
+        'per wireframes §1.2)', (tester) async {
+      var dismissedCount = 0;
+      await _pumpAndShowDialog(
+        tester,
+        onEnable: () {},
+        onDismiss: () => dismissedCount += 1,
+      );
+
+      // Tap at top-left to hit the barrier scrim outside the dialog
+      // content card.
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      expect(dismissedCount, 1);
+    });
+  });
+
+  group('PrePermissionDialog — accessibility', () {
+    testWidgets('"Enable Notifications" button has min 48dp height tap '
+        'target', (tester) async {
+      await _pumpAndShowDialog(tester, onEnable: () {}, onDismiss: () {});
+
+      final enableButton = find.ancestor(
+        of: find.text('Enable Notifications'),
+        matching: find.byType(FilledButton),
+      );
+      expect(enableButton, findsOneWidget);
+      final size = tester.getSize(enableButton);
+      expect(
+        size.height,
+        greaterThanOrEqualTo(48),
+        reason: 'Enable Notifications button must meet 48dp tap target',
+      );
+    });
+
+    testWidgets('"Not now" button has min 48dp height tap target', (
+      tester,
+    ) async {
+      await _pumpAndShowDialog(tester, onEnable: () {}, onDismiss: () {});
+
+      final notNowButton = find.ancestor(
+        of: find.text('Not now'),
+        matching: find.byType(TextButton),
+      );
+      expect(notNowButton, findsOneWidget);
+      final size = tester.getSize(notNowButton);
+      expect(
+        size.height,
+        greaterThanOrEqualTo(48),
+        reason: 'Not now button must meet 48dp tap target',
+      );
+    });
+  });
+}

--- a/test/features/notifications/presentation/pre_permission_dialog_test.dart
+++ b/test/features/notifications/presentation/pre_permission_dialog_test.dart
@@ -63,7 +63,7 @@ void main() {
 
       final headingSemantics = tester
           .widgetList<Semantics>(find.byType(Semantics))
-          .where((s) => s.properties.header == true)
+          .where((s) => s.properties.header ?? false)
           .toList();
       expect(
         headingSemantics,


### PR DESCRIPTION
## Summary

Ships FR-AC-03 (FCM push notifications) and FR-AC-05 (cold-start deep-link) end-to-end. The Functions notifications module emits FCM data messages from both the expense and settlement triggers respecting `users/{uid}.notificationPrefs`; the Flutter client owns the FCM token lifecycle, renders the pre-permission dialog, the in-app banner, and the system-tap / cold-start deep-link surfaces — all routed through a shared `lib/core/routing/notification_deep_links.dart` helper that is also consumed by the activity feed (`ActivityFeedScreen._onRowTap` refactored to use the same contract).

**Story:** `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` (20 ACs + 10 architect ratifications).
**Story points:** 10. Sprint 2 cumulative: 73 SP / 17 PRs.

## Story / SRS / Design references

- SRS §4.7 (FR-AC-03 push notifications; FR-AC-04 prefs filter — server-side enforced here; FR-AC-05 cold-start deep-link).
- `docs/design/07-technical/notifications.md` (FCM token lifecycle §1, payload schema + per-type templates §2, foreground/background/cold-start §3, deep-link map §4, permission timing §5, security §7).
- `docs/design/04-wireframes/notifications-and-deeplinks.md` (pre-permission dialog §1, in-app banner §2, system notification §3, cold-start splash flow §4).
- `docs/design/07-technical/firestore-schema.md` (`fcmTokens` + `notificationPrefs` already declared; no schema change).
- `lib/features/auth/domain/user_model.dart` (defaults already shipped in FR-AU-06; no backfill needed).

## Cloud Functions surface (new + extended)

- **NEW `functions/src/utils/format-inr.ts`** — Indian-numbering paise → rupee mirror of `lib/core/formatters/inr_formatter.dart`. Sole renderer-side INR formatter; ZERO inline `/100` arithmetic anywhere in `functions/src/notifications/**` (boundary-contract grep clean).
- **NEW `functions/src/notifications/`** — `fcm-send.ts` (admin-SDK helper, parallel `Promise.allSettled`, 410 token cleanup via `arrayRemove`, structured logging with `userIdHash` + `tokenFingerprint`), `payload-renderer.ts` (all six per-type templates), `prefs-filter.ts` (`notificationPrefs` short-circuit; `group_invite` bypasses), `send-expense-notification.ts` (multi-recipient fan-out), `send-settlement-notification.ts` (single recipient = `toUserId`), `types.ts` (shared `NotificationType` / `NotificationPayload` / `NotificationsApi` surface), `index.ts` (public exports).
- **EXTENDED triggers** — both `on-expense-write/function.ts:167` and `on-settlement-write/function.ts:237` close the long-standing `TODO(FR-AC-03)` seams with `emitExpenseFcm` / `emitSettlementFcm` helpers that mirror the FR-AC-01 / FR-EX-07 activity-emission contract (try/catch, never rethrow, placed AFTER the activity emission in the success branch — symmetric with FR-EX-07 AC-5 + FR-AC-01 AC-12).

## Client surface (new + extended)

- **NEW `lib/features/notifications/**`** — feature-first layout (data / domain / application / presentation):
    - `data/fcm_token_service.dart` — `arrayUnion` / `arrayRemove` / `WriteBatch`-based atomic `replaceToken` for AC-2; `onTokenRefresh` listener.
    - `data/notification_handler.dart` — foreground / background / cold-start handlers; top-level `@pragma('vm:entry-point')` background isolate entry point.
    - `domain/notification_payload.dart` — strict-parse `NotificationPayload.fromFcmDataMap`; six `NotificationType` enum values mapped from snake_case wire names.
    - `application/firebase_messaging_provider.dart` — DI override seam for tests.
    - `application/pending_deep_link_provider.dart` — `StateProvider<NotificationPayload?>` per architect §2.4 for the FR-AC-05 unauthenticated-then-sign-in replay flow.
    - `application/notification_permission_controller.dart` — Riverpod `Notifier` driving the "Stay in the loop" dialog flow (AC-1, AC-12, AC-13).
    - `application/deep_link_handler.dart` — payload → route dispatcher; emits `fcm_notification_tapped` telemetry.
    - `application/sign_out_with_fcm_cleanup.dart` — non-blocking FCM token unregister BEFORE `FirebaseAuth.signOut()` (AC-3); consumed by `ProfileScreen` + `ProfilePlaceholderScreen`.
    - `presentation/pre_permission_dialog.dart` — wireframes §1.1.
    - `presentation/widgets/in_app_notification_banner.dart` — wireframes §2.1; auto-dismiss after 4s; pauses for screen readers per §2.4.
    - `presentation/notifications_lifecycle_host.dart` — `MaterialApp.builder` wrapper that owns FCM stream subscriptions, the banner OverlayEntry, the pre-permission dialog trigger via auth-state listener, and the cold-start `getInitialMessage` replay.
- **NEW `lib/core/routing/notification_deep_links.dart`** — sealed `DeepLinkTarget` union + pure `resolve` / `resolveFromFields` + `navigate` helper. Shared by the activity-feed row tap AND the FCM tap surfaces per architect §2.3.
- **EXTENDED `lib/main.dart`** — registers the top-level `firebaseMessagingBackgroundHandler` via `FirebaseMessaging.onBackgroundMessage` BEFORE `runApp` per Flutter Firebase docs (AC-10); wraps the home content with `NotificationsLifecycleHost` via `MaterialApp.builder`.
- **REFACTORED `lib/features/activity/presentation/activity_feed_screen.dart`** — `_onRowTap` now dispatches via `NotificationDeepLinks.navigate`. The `activity_item_tapped` telemetry (with `hashFriendshipId` PII guard per ADR-0013) stays at the call site.

## Test counts

| Layer | Before | After | Delta |
|---|---|---|---|
| Flutter | 973 pass / 30 skipped | **1068 pass / 30 skipped** | +95 |
| Functions | 14 suites / 195 tests | **20 suites / 270 tests** | +6 suites / +75 tests |
| Rules | 9 suites / 188 tests | 9 suites / 188 tests | unchanged (no rules diff) |

`dart format --set-exit-if-changed .` exits 0; `flutter analyze --fatal-infos` reports no issues; `npm run lint && npm run build && npm test` all green.

## Invariants

- ✅ **Invariant 1 (paise integers).** Applicable on the FCM payload-render boundary. New `functions/src/utils/format-inr.ts` is the sole renderer; ZERO inline `/100` in `functions/src/notifications/**`. New affirmative client-side boundary-contract grep at `test/features/notifications/notifications_boundary_contract_test.dart` returns 0 violations across `lib/features/notifications/**` and `lib/core/routing/notification_deep_links.dart`. Existing Functions-side grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new files.
- ✅ **Invariant 2 (`simplifiedBalances` server-only).** ZERO new writes. The FCM module touches `users/{uid}.fcmTokens` (write — server cleanup on 410, client `arrayUnion` on acquire / `arrayRemove` on sign-out) and `users/{uid}.notificationPrefs` (read only).
- N/A **Invariant 3 (system share sheet only).** FCM is a separate surface; the share sheet is for invites.
- ✅ **Invariant 4 (single Firebase project).** `.firebaserc` unchanged. FCM admin SDK uses the same `firebase-admin/app` initialisation.

## Deferred (out of scope — separate PRs)

- **FR-PR-03 / FR-AC-04 notification-preferences UI** — Profile-screen toggle UI; the server-side prefs-filter is already live in this PR.
- **FR-SE-09 Send Reminder** — first downstream consumer of this PR's FCM module; introduces the per-friend 24-hour `_rateLimits` subcollection.
- **`group_invite` producer** — Sprint 3 groups epic. The renderer ships the template for forward-compat; no producer wires it.
- **`OBTBottomNav` shell** — still deferred per the FR-AC-01 architect §2.1 ratification.
- **`shared_preferences` adoption** for cross-launch persistence of `wasPermanentlyDenied` — addendum to architect §2.6 (in-memory only for v1.0 because the lockfile has no `shared_preferences`; a `TODO(flutter-dev)` is recorded in `notification_permission_controller.dart`).
- **Emulator-side FCM integration test infrastructure** — `jest.mock()` does not survive the emulator process boundary; integration round-trips are unit-mocked at the SDK boundary. Tracked as a PR #54 candidate.
- **Issues #47 (rules-hardening), #49 (orphan-cleanup)** — unchanged.
- **Issue #50 (trigger no-op-recompute optimisation)** — EXPLICITLY CONSTRAINED by FR-EX-07 AC-2; unchanged.

## Commit cadence (12 commits)

1. `docs(stories): FR-AC-03 FCM push notifications story`
2. `docs(stories): FR-AC-03 architect notes`
3. `test(functions): FR-AC-03 notifications module tests`
4. `test(functions): FR-AC-03 trigger FCM integration tests`
5. `feat(functions): FCM send module for push notifications (FR-AC-03)`
6. `feat(functions): emit FCM notifications from expense + settlement triggers (FR-AC-03)`
7. `test(notifications): FR-AC-03 FCM client tests`
8. `feat(notifications): FCM client lifecycle + FR-AC-05 cold-start deep-link`
9. (Prompt file commit by maintainer — `Add the prompt file`)
10. `feat(notifications): wire FCM into app startup + share deep-link routing`
11. `test(notifications): extend boundary-contract expected-files list`
12. `docs(plan): PR #53 shipped, prep PR #54`

## QA — manual smoke matrix

To exercise on the canary device post-deploy:

- Sign in as user A on device 1 → verify FCM token is written to `users/A.fcmTokens`.
- Sign in as user A on device 2 (different FCM token) → verify both tokens appear in the array.
- As user B, add an expense to the A↔B friendship → verify A receives the FCM banner on both devices.
- Tap the banner → verify deep-link routing to ExpenseDetailScreen.
- Set `notificationPrefs.newExpense = false` for A → verify subsequent expense adds do NOT trigger FCM (prefs-filter short-circuit).
- Reinstall A's app → verify the stale FCM token is pruned on the next send attempt (410 cleanup).
- Cold-start from a tapped notification (close the app, send a push, tap it) → verify splash → auth-check → target-screen flow per `notifications.md` §3.3.
- Sign out user A → verify the device's FCM token is removed from `users/A.fcmTokens` BEFORE `FirebaseAuth.signOut()` completes.

---

Next PR: PR #54 — TBD per architect's call at kickoff (top candidate: FR-SE-09 Send Reminder).
