### PR TITLE
feat(reminders): FR-SE-09 send reminder + rate limit

### DIFF
--- a/docs/audits/sprint-1/07-bucket-b-burndown.md
+++ b/docs/audits/sprint-1/07-bucket-b-burndown.md
@@ -6,7 +6,7 @@
 > Source: `docs/audits/sprint-1/00-triage-summary.md` (Bucket B section).
 > Detail: `docs/audits/sprint-1/06-deferred-to-sprint-2.md`.
 >
-> Last updated: PR #53.
+> Last updated: PR #54.
 
 ---
 
@@ -627,4 +627,50 @@ any Bucket-B items directly:
   remains open and unrelated to this PR.
 
 Net contribution of PR #53 to Bucket-B totals: **0**. The
+remaining count stays at **27 / 37**.
+
+PR #54 (FR-SE-09 Send Reminder + per-friend 24-hour rate limit) makes
+partial progress on **PY3** and does NOT close any Bucket-B items
+directly:
+
+- **PY3 — Expand integration tests for Sprint 2 flows:** PR #54 adds
+  comprehensive callable-handler tests for the new
+  `sendReminderNotification` function (24 test cases covering auth,
+  input validation, non-member, recipient-doesn't-owe,
+  rate-limit pre-check rejection + post-window pass, prefs-filter,
+  no-tokens, full-failure dispatch FCM_DISPATCH_FAILED non-record,
+  group-context forward-compat error, happy-path rate-limit doc
+  shape, FCM dispatch params, activity emission to recipient, PII
+  hashing in structured logs, and the message-presence-only logging
+  contract). PR #54 also adds 7 helper-level unit tests for the
+  `notifications/send-reminder-notification.ts` FCM dispatch helper
+  mirroring the existing two helper test files, plus 13 activity-
+  validator extension tests for the new `'reminder'` event-type
+  shape. On the Flutter side, PR #54 ships 24 new tests under
+  `test/features/reminders/**` covering the reminder repository,
+  the send controller (success + per-error-code branches +
+  telemetry + concurrent-send short-circuit), the cooldown provider
+  (per-friendship isolation + in-memory reset on container
+  disposal), plus 4 new widget tests for the OBTSettleUpCard
+  receiving-direction variant and 3 new screen tests for the
+  FriendDetailScreen owed-branch wiring (tap → controller, RATE_
+  LIMITED snackbar, RECIPIENT_PREFS_DISABLED snackbar). Partial
+  credit only; PY3 remains open pending the full emulator-side
+  FCM round-trip integration tests across all callable + trigger
+  paths (deferred per PR #53 + PR #54 functions-dev notes — the
+  existing emulator-side integration test infrastructure does not
+  exercise the FCM emission path because `jest.mock()` does not
+  survive the emulator process boundary).
+- **No Bucket-B items closed by PR #54.** The reminder callable +
+  client feature folder are new ground and are not separately
+  tracked Bucket-B items.
+- **No new Bucket-B items filed by PR #54.** The
+  `reminderRepositoryProvider` production wiring gap (it shares the
+  throw-until-overridden pattern with `matchingRepositoryProvider`
+  and `cloud_functions` is not yet in pubspec) is tracked as a
+  candidate in `docs/sprint-zero/next-three-prs.md` for the PR #55
+  slot. The deferred FR-SE-09 message-compose dialog is tracked as
+  a follow-up UX PR candidate.
+
+Net contribution of PR #54 to Bucket-B totals: **0**. The
 remaining count stays at **27 / 37**.

--- a/docs/copilot_prompts/sprint_2/17.md
+++ b/docs/copilot_prompts/sprint_2/17.md
@@ -1,0 +1,381 @@
+1. You are the OneByTwo orchestrator agent. PR #53 (FR-AC-03 — FCM push notifications + FR-AC-05 cold-start deep-link) has merged (squash commit `6cf942e`) and the **FCM push round-trip** is now live in production: the `functions/src/notifications/` module exports `sendExpenseNotification` + `sendSettlementNotification` over a stable `NotificationsApi` surface, the expense and settlement triggers emit FCM data messages to non-author recipients respecting `users/{uid}.notificationPrefs`, the `payload-renderer.ts` ships **all six per-event-type templates including `reminder`** (forward-compat in PR #53; producer ships now), the `prefs-filter.ts` honours `notificationPrefs.reminder` with the `group_invite` bypass, the `fcm-send.ts` helper does parallel `Promise.allSettled` dispatch with 410 token cleanup via `arrayRemove`, the Functions-side `format-inr.ts` is the sole renderer (boundary-contract grep enforces), the client FCM token lifecycle is wired (acquisition → `arrayUnion` on `users/{uid}.fcmTokens`, `onTokenRefresh` via `runTransaction` read-modify-write, `arrayRemove` on sign-out via `signOutWithFcmCleanup`), the pre-permission dialog ("Stay in the loop") triggers on first transition to `AuthenticatedWithProfile` per session, the `NotificationsLifecycleHost` owns FCM stream subscriptions + cold-start replay + in-app banner overlay, and the shared `lib/core/routing/notification_deep_links.dart` helper is consumed by both `ActivityFeedScreen._onRowTap` and the FCM tap surfaces. Sprint 2 velocity through end of PR #53: **73 SP across 17 PRs**. We now implement **PR #54: FR-SE-09 — Send Reminder**. This is the natural P1 follow-on: PR #53 shipped the FCM module surface, ratified the `reminder` template in the renderer + the `notificationPrefs.reminder` short-circuit in the filter, and explicitly deferred FR-SE-09 as the "first downstream consumer" of that module. The new work is the **callable Cloud Function `sendReminderNotification`** (mirror of `lookup-user-by-phone-number` pattern at `functions/src/lookup-user-by-phone-number/`) that (a) authenticates the caller, (b) validates the recipient owes the sender per `simplifiedBalances` on the parent context, (c) enforces the **per-friend 24-hour rate-limit** via a doc at the architect-canonical `_rateLimits/{senderUid}/sends/{recipientUid}` 5-segment path, (d) calls into the FR-AC-03 module's `sendFcmToTokens(...)` with the `renderPayload('reminder', ...)` output, (e) writes an `activity/{recipientUid}/items/{auto-id}` document so the recipient sees the reminder in their activity feed, and (f) returns a typed `SendReminderResponse` with `nextAllowedAt` so the client can optimistically disable the button. Story points: **6** (3 server callable + rate-limit + activity-emission integration + 2 client reminder repository + send-reminder controller + 1 OBTSettleUpCard receiving-direction variant + FriendDetailScreen wiring). Escalate to 8 only if the architect bundles the receiving-direction `OBTSettleUpCard` extraction to `lib/core/widgets/cards/` per PR #43 §2.6 (NOT recommended — extraction lands when the second use site needs it, mirror of the `OBTAmountInput` precedent).
+
+2. The numbering continues from PR #53 — **PR #54 is the next FEATURE PR.** The post-PR-#53 sequence so far: #53 (PR — feat, merged `6cf942e`), no new issues filed during PR #53 review. Issues #47 (rules-hardening — Sprint 3 candidate), #49 (orphan-cleanup — FUTURE), #50 (trigger no-op optimisation — **EXPLICITLY CONSTRAINED** by FR-EX-07 AC-2: cannot close because optimisation would break activity emission on receipt-only updates) remain OPEN and are NOT touched by PR #54. The orchestrator should not assume PR #55 == GitHub issue 55 — issues and PRs share the same sequential namespace, so any new issues filed during PR #54 will consume intermediate numbers. **Pre-merge CI title-lint gotcha (verified PR #45, #46, #48, #51, #52, #53):** the workflow regex `[a-z0-9_-]+` rejects comma-separated scopes — use a single-token scope (e.g. `feat(settlements)` or `feat(reminders)`), and the SUBJECT (everything after `<scope>: `) must be ≤ 72 characters total. Since this PR adds a new server callable + a new client feature folder for reminders, recommend the scope `reminders` (a NEW feature folder is the load-bearing surface). Suggested title (52 chars subject): `feat(reminders): FR-SE-09 send reminder + rate limit`.
+
+3. PR #54 is the **first PR that calls the FR-AC-03 FCM module from a callable Cloud Function path** (the triggers were the only consumers in PR #53) and the **first PR that writes to the `_rateLimits/{uid}/sends/{recipientUid}` 5-segment subcollection extension** of the PR #45-ratified `_rateLimits/{uid}/{category}/{counter-or-key}` container. The seams are already in place:
+   - **Server side — FCM module surface (consumer of PR #53):**
+     - `functions/src/notifications/index.ts` re-exports `sendExpenseNotification` and `sendSettlementNotification` but NOT a `sendReminderNotification`. The new callable does NOT depend on a new `notifications/` helper — it composes the existing `renderPayload('reminder', ...)` + `prefsFilter.isNotificationAllowed('reminder', recipientPrefs)` + `sendFcmToTokens(...)` directly. **Architect's call at §2.x** on whether to ADD a `send-reminder-notification.ts` helper to `functions/src/notifications/` (mirror of the two existing helpers) for consistency, OR to compose inline inside the callable handler. RECOMMENDED: add the helper for consistency — the callable orchestrates auth + rate-limit + balance precondition + activity emission, and the FCM dispatch is the leaf operation, which fits the existing pattern.
+   - **Server side — rate-limit subcollection (extension of PR #45 §2.9 / `_rateLimits/{uid}/lookups/counter` precedent):** the PR #45 chore established the architect-canonical 4-segment path `_rateLimits/{userId}/{category}/counter` for per-user rate limits. FR-SE-09 needs PER-FRIEND (per-recipient) granularity per SRS §4.6: "one reminder per friend per 24 hours". **Architect's call at §2.x** between two paths:
+     1. **5-segment `_rateLimits/{senderUid}/sends/{recipientUid}`** holding `{ lastSentAt: Timestamp, count: number, windowStart: number }`. ONE doc per (sender, recipient) pair. Natural extension of the PR #45 container — `sends` is the new category, and the leaf doc ID is the recipient UID (not the fixed `counter` literal). Permits straightforward per-friend `lastSentAt` lookup with `O(1)` reads.
+     2. **4-segment `_rateLimits/{senderUid}/sends/counter`** holding a MAP keyed by recipient UID: `{ [recipientUid]: { lastSentAt, count } }`. ONE doc per sender; map grows linearly with friend count. Compatible with the literal `counter` doc-ID convention from PR #45 BUT requires reading the whole map on every send (no Firestore field-level read), and map mutation is a full-doc rewrite.
+     RECOMMENDED option 1 (5-segment per-recipient doc). The PR #45 §2.9 ratification of "extends naturally to future rate-limit categories without schema migration" already anticipates additional segments per category, and `cloud-functions-catalogue.md §7` documents `reminders/{senderUid}_{toUserId}` with `lastSentAt: Timestamp` (the conceptual shape per pair). The 5-segment path subsumes the catalogue under the architect-canonical `_rateLimits/` container without losing per-friend granularity. Firestore rules already deny all client access via the existing `match /_rateLimits/{document=**}` block at `firestore.rules:355` — NO rules diff needed.
+   - **Server side — callable mirror of `lookup-user-by-phone-number`:** the new `functions/src/send-reminder-notification/` module follows the established callable pattern:
+     - `index.ts` — `onCall({region: REGION}, ...)` wrapper that injects `db`, `messaging`, `logger` into the handler factory.
+     - `function.ts` — `createSendReminderHandler(deps)` returns the async handler. Validates inputs (`toUserId` non-empty, `contextType ∈ {friendship, group}`, `contextId` non-empty, optional `message` ≤ 500 chars), throws typed `HttpsError` for `UNAUTHENTICATED` / `INVALID_INPUT` / `RATE_LIMITED` (with `nextAllowedAtIso`) / `RECIPIENT_DOESNT_OWE` / `RECIPIENT_PREFS_DISABLED` / `RECIPIENT_NO_TOKENS` / `INTERNAL`.
+     - `algorithm.ts` (OPTIONAL) — extracted pure helpers for testability (rate-limit window math, simplified-balances precondition check). **Architect's call at §2.x.**
+     - The handler's flow:
+       1. Validate `request.auth?.uid` → set as `senderUid`. Throw `UNAUTHENTICATED` if missing.
+       2. Validate request shape.
+       3. Read the parent context doc (`friendships/{contextId}` or `groups/{contextId}` — group-context path is forward-compat; v1.0 producer in this PR is friendship-context only per the scope guardrails). Throw `NOT_A_MEMBER` if `senderUid ∉ memberIds`.
+       4. **Simplified-balances precondition.** Read `context.simplifiedBalances` map and verify `recipientUid` actually owes `senderUid`. The data shape from PR #36 is `simplifiedBalances: { [debtorUid]: { [creditorUid]: paiseAmount } }` (verify by reading `functions/src/simplified-debts/function.ts` — the writer's output shape). The reminder is valid IFF `simplifiedBalances[recipientUid]?.[senderUid] > 0`. If not, throw `RECIPIENT_DOESNT_OWE`. (The sender cannot remind a friend who owes them nothing or who is owed by them — the latter is reverse-direction.)
+       5. **Rate-limit pre-check.** Read `_rateLimits/{senderUid}/sends/{recipientUid}`. If `exists && now - lastSentAt < 24h`, throw `RATE_LIMITED` with `nextAllowedAtIso = lastSentAt + 24h`.
+       6. **Prefs filter + FCM token read.** Read `users/{recipientUid}` doc. If `notificationPrefs.reminder === false`, throw `RECIPIENT_PREFS_DISABLED`. If `fcmTokens` is empty, throw `RECIPIENT_NO_TOKENS` (the recipient has not granted push permission — the reminder cannot be delivered; the rate-limit is NOT recorded so the sender can try again later if the recipient enables push).
+       7. **Render + dispatch.** Call `renderPayload('reminder', { senderName, amountPaise, contextType, contextId, createdAt: now })`. Note `amountPaise` is the OWED amount (per `simplifiedBalances[recipientUid][senderUid]`); `senderName` is resolved via a read of `users/{senderUid}.displayName`. Call `sendFcmToTokens(deps, { userId: recipientUid, tokens, payload })` per the FR-AC-03 module contract.
+       8. **Rate-limit write.** ON SUCCESS only (i.e. at least one FCM `send()` resolved), write `_rateLimits/{senderUid}/sends/{recipientUid}` with `{ lastSentAt: Timestamp.now(), count: FieldValue.increment(1), windowStart: existing or now, recipientUid, senderUid (for queryability), updatedAt: Timestamp.now() }`. **Architect's call at §2.x** on whether rate-limit is recorded if (a) FCM send fully fails (all tokens 410), (b) the optional message is included but unrendered by the platform. RECOMMENDED: record on `succeeded >= 1` (the architect's call is consistent with the SRS phrase "one reminder per friend per 24 hours" — if delivery failed entirely, no reminder was sent).
+       9. **Activity-feed emission.** Mirror the FR-AC-01 / FR-EX-07 contract. Use the existing `writeExpenseActivity(deps, ...)` helper from `functions/src/triggers/on-expense-write/activity-writer.ts` (the misnamed-but-canonical writer per PR #52 architect §2.3) with `eventType: 'reminder'`, `payload: { senderUid, recipientUid, contextType, contextId, amountPaise, message? }`. **Architect's call at §2.x** on whether to (a) emit to BOTH parties (sender sees "you sent a reminder to Friend"; recipient sees "Friend sent you a reminder") OR (b) emit to recipient ONLY (mirror of `settlement_received` template behaviour where only the payee receives the in-app activity). RECOMMENDED: recipient-only (mirror of the FCM target — FCM goes to recipient only, activity goes to recipient only; the sender's UI confirms via the optimistic-disable button state, not via the activity feed). FOLLOW-UP: the architect may flip this if usability research shows senders want a paper-trail of their reminders.
+       10. **Return.** `{ success: true, nextAllowedAtIso: <now + 24h>.toISOString() }`.
+     - The callable MUST be region-pinned to `asia-south1` (mirror of every other Cloud Function per SRS §7.1). The `region: REGION` constant in `functions/src/index.ts` is the existing convention.
+     - **PII posture:** the structured logs (`reminder_send_attempted`, `reminder_send_succeeded`, `reminder_send_rate_limited`, `reminder_send_skipped_by_prefs`, `reminder_send_failed_no_tokens`, `reminder_send_recipient_doesnt_owe`, `reminder_send_failed`) MUST hash `senderUid` + `recipientUid` via `hashId()` from `functions/src/utils/id-hash.ts`. The optional free-text `message` MUST NOT appear in any log; only its presence + length should be logged if at all. FCM tokens use `fingerprintToken()` (mirror of PR #53). `simplifiedBalances` data is NOT logged.
+   - **Activity-writer extension:** the existing `writeExpenseActivity` accepts `eventType: 'expense_added' | 'expense_edited' | 'expense_deleted' | 'settlement'`. The reminder activity adds a new event type `'reminder'`. Verify the validator at `functions/src/triggers/on-expense-write/activity-validator.ts` permits the new event-type discriminator + the new payload shape (architect §2.x will ratify the schema). **Architect's call at §2.x** on whether the validator extension lives in this PR (RECOMMENDED — small extension, ships alongside the producer) or in a parallel chore PR. The schema extension MUST be backward-compatible — existing activity items remain valid.
+   - **Client side — reminders feature folder:** `lib/features/reminders/` does NOT exist today. PR #54 creates the standard feature-first layout:
+     - `data/reminder_repository.dart` — wraps the `sendReminderNotification` callable via `cloud_functions` (already in pubspec; used by lookup at `lib/features/friends/data/`). Returns a typed `Result<ReminderSendSuccess, ReminderSendError>` (mirror of the existing `Result<AuthUser, AuthError>` pattern from FR-AU-03).
+     - `domain/reminder_send_error.dart` — enum mirroring the callable's typed error codes: `unauthenticated`, `rateLimited (nextAllowedAt)`, `recipientDoesntOwe`, `recipientPrefsDisabled`, `recipientNoTokens`, `network`, `unknown`. The `rateLimited` variant carries the `nextAllowedAt` `DateTime` so the client can render "Try again in 5h 32m".
+     - `domain/reminder_send_success.dart` — `{ nextAllowedAt: DateTime }`.
+     - `application/send_reminder_controller.dart` — Riverpod `Notifier<SendReminderState>` that drives the in-progress / success / error states; called from the OBTSettleUpCard's `onSendReminder` callback. Emits the `reminder_send_*` telemetry events.
+     - `application/reminder_cooldown_provider.dart` — `StateProvider.family<DateTime?, String>` keyed by `friendshipId` (or `(senderUid, recipientUid)` pair) holding the optimistic `nextAllowedAt` after a successful send. RESETS on app launch — the server is the authoritative gate per `notifications.md §6.1`. The OBTSettleUpCard watches this provider to disable the button.
+     - `presentation/send_reminder_dialog.dart` — OPTIONAL bottom sheet that prompts for the free-text message (per catalogue spec, max 500 chars). **Architect's call at §2.x** on whether to ship the dialog in v1.0 OR send a default-message reminder on tap and defer the dialog to a later UX PR. RECOMMENDED defer the dialog — the v1.0 SRS row is "send a free-text reminder" but the message-composing UX is a separate UX surface; v1.0 ships with a default message ("This is a friendly reminder!" or similar — architect ratifies the exact copy) and the dialog ships in a follow-up.
+   - **Client side — OBTSettleUpCard extension:** `lib/features/friends/presentation/widgets/obt_settle_up_card.dart` currently has the SETTLING-direction variant (you owe → you settle). PR #54 adds the RECEIVING-direction variant (friend owes you → you send a reminder). Approaches:
+     1. **Add a `bool isReceivingDirection` constructor param** + an optional `onSendReminder` callback + an optional `nextAllowedAt` to disable the button during the cooldown. The CTA label becomes "Send Reminder" instead of "Settle Up"; the avatar arrow direction flips.
+     2. **Create a new `OBTReminderCard` sibling widget** in `lib/features/reminders/presentation/widgets/`. Cleaner separation but duplicates the avatar-pair layout.
+     RECOMMENDED option 1 — the avatar-pair layout is shared and the deferred extraction to `lib/core/widgets/cards/` per PR #43 §2.6 will handle the cosmetic split if needed. The card's existing `onSettleUp` callback stays; the new `onSendReminder` is null on the settling-direction path and required on the receiving-direction path.
+   - **Client side — FriendDetailScreen wiring:** at `lib/features/friends/presentation/friend_detail_screen.dart:100` the existing branch is `if (state.header.balanceState == BalanceState.owes)`. Add a sibling branch `if (state.header.balanceState == BalanceState.owed)` that renders `OBTSettleUpCard(isReceivingDirection: true, onSendReminder: () => _onSendReminderTapped(...))`. The `_onSendReminderTapped` handler calls into the `sendReminderController.send(...)` which invokes the callable, on success updates `reminderCooldownProvider`, on rate-limited shows a snackbar with the `nextAllowedAt` countdown, on prefs-disabled shows a "Your friend has notifications off — try a different way to settle up" snackbar, on no-tokens shows "Your friend hasn't enabled push notifications".
+   - **Rate-limit / prefs UI affordance:** the OBTSettleUpCard's receiving-direction variant MUST visually distinguish three states: (a) **enabled** (default), (b) **cooldown active** (button disabled + caption "Next reminder in 5h 32m" — uses `reminderCooldownProvider` countdown), (c) **disabled-by-prefs** (button enabled with caption "Friend has notifications off — sending will fail" OR button hidden entirely — architect ratifies the exact treatment per the SCR-11 deferred UX research note). RECOMMENDED: the cooldown state is server-truth-driven (sent successfully → set provider → button disabled); the prefs-disabled state is detected only on send-attempt (no per-friend pre-fetch of `notificationPrefs.reminder` — that would be a privacy leak). The error snackbar handles the prefs-disabled case post-hoc.
+   - **Telemetry contract:** **server** events use the `reminder_send_*` prefix (per the existing `fcm_send_*` / `settlement_*` family conventions): `reminder_send_attempted` (every callable invocation), `reminder_send_succeeded` (at least one FCM token delivered + rate-limit doc written), `reminder_send_rate_limited` (pre-check rejection), `reminder_send_recipient_doesnt_owe` (precondition rejection), `reminder_send_skipped_by_prefs`, `reminder_send_failed_no_tokens`, `reminder_send_failed` (catch-all). **Client** events use the `reminder_send_*` prefix mirror: `reminder_send_tapped` (OBTSettleUpCard `onSendReminder` invoked), `reminder_send_succeeded`, `reminder_send_rate_limited` (with `next_allowed_in_seconds` parameter), `reminder_send_recipient_doesnt_owe`, `reminder_send_recipient_prefs_disabled`, `reminder_send_recipient_no_tokens`, `reminder_send_failed`. PII hashing per ADR-0013: any UID-derived parameter on the server side MUST go through `hashId()`; client side MUST go through `hashFriendshipId()` from `lib/core/telemetry/event_id_hash.dart`.
+
+4. PR #54 has **one mandatory cross-PR bundle**: the **OBTSettleUpCard receiving-direction variant + FriendDetailScreen wiring**. Without it, the callable ships orphan (no client caller). Bundle is small (~1 SP). PR #54 must NOT bundle: FR-PR-03 notification-preferences UI (separate P1 story; lives on the Profile screen), the OBTSettleUpCard extraction to `lib/core/widgets/cards/` per PR #43 §2.6 (deferred until a SECOND host needs it — same precedent as `OBTAmountInput`), the deferred message-compose dialog (architect's call at §2.x — RECOMMENDED defer), the optimistic-disable-across-launches persistence (the SRS contract is "server is authoritative" — client-side cooldown is best-effort, in-memory only for v1.0), the OBTBottomNav shell (still deferred per PR #52 architect §2.1), any FR-EX-09 / FR-SR-01 / FR-SR-02 related work (search / filter — deferred), the group-context reminder path (Sprint 3 groups epic — the callable's `contextType: 'group'` branch ships as a forward-compat path but no producer wires it in v1.0).
+
+5. Read before starting:
+   - `.github/copilot-instructions.md`
+   - `.github/shared/invariants.md` — invariant 1 (paise integers — applicable on the `amountPaise` read from `simplifiedBalances`; the value flows unchanged through `renderPayload('reminder', ...)` to the FCM body string; ZERO `/100` arithmetic anywhere in `functions/src/send-reminder-notification/**` or `lib/features/reminders/**`), invariant 2 (`simplifiedBalances` server-only — the callable READS `simplifiedBalances` for the precondition check but never WRITES; client-side reminders module is read-only on this field), invariant 3 (system share sheet — N/A), invariant 4 (single Firebase project — defence-in-depth re-check).
+   - `.github/shared/coding-standards.md` — Dart, Riverpod, widget-test, Cloud Functions, and Conventional Commits rules. Both halves are load-bearing for PR #54; split is roughly 60/40 server/client.
+   - **Memory: PR# references in code/test files are forbidden.** Repository memory: "Do not include PR numbers (e.g. 'PR #36', 'PR #37') in comments or descriptions inside code or test files. PR references belong in docs and commit messages only." Use story IDs (FR-SE-09) in code comments instead.
+   - **Memory: money formatting.** Repository memory: "All paise→INR conversion goes through formatInrFromPaise(int) in lib/core/formatters/inr_formatter.dart. No inline /100 arithmetic anywhere." The `renderPayload('reminder', ...)` already uses the Functions-side `format-inr.ts` helper for the body string; ZERO inline `/100` anywhere on the new code paths.
+   - **Memory: telemetry PII hashing.** Repository memory: "Use hashFriendshipId() in lib/core/telemetry/event_id_hash.dart for any telemetry parameter that would otherwise carry a deterministic friendshipId or other UID-composite identifier." The new `reminder_send_*` client events MUST hash any friendshipId-derived parameter; the new server events MUST hash via `hashId()` from `functions/src/utils/id-hash.ts` (mirror of PR #53).
+   - **Memory: dart format.** Repository memory: "CI runs Flutter 3.44.1 and gates on `dart format --set-exit-if-changed .`. Always run `dart format .` locally before pushing — `flutter analyze` alone does not catch formatter drift."
+   - **Memory: commit message scope.** Repository memory: "PR title lint enforces conventional commit scope `[a-z0-9_-]+` — a single token only. Comma-separated multi-scopes like `chore(functions,docs)` are rejected." AND subject must be ≤ 72 chars. Recommend `feat(reminders): FR-SE-09 send reminder + rate limit` (52 chars).
+   - `.github/shared/decision-log.md` — ADR-0002 (paise integers; applicable on the `amountPaise` carry-through), ADR-0006 (Riverpod state management — `Notifier` for the send-reminder controller; `StateProvider.family<DateTime?, String>` for the per-friendship cooldown), ADR-0007 (feature-first folder layout; `lib/features/reminders/**` follows the standard data / domain / application / presentation split), ADR-0013 (PII / telemetry hashing — see memories above), ADR-0014 (rate-limit subcollection — `_rateLimits/{uid}/{category}/{key-or-counter}` container; PR #54 extends with the 5-segment `_rateLimits/{senderUid}/sends/{recipientUid}` per-recipient variant per architect §2.x ratification).
+   - `docs/patterns/feature-pr-conventions.md` — Feature-First Folder Layout, Boundary-Contract Discipline, Telemetry-Event Discipline (verb-past pattern → `reminder_send_succeeded`, NOT `reminder_send_success`).
+   - `docs/OneByTwo_Requirements_Spec.md` — section 4.6 (FR-SE-09 = P1 send reminder; "rate-limited to one reminder per friend per 24 hours"), section 7.2 (`notificationPrefs.reminder` already on the `users/{userId}` schema — defaults to true), section 7.3 (Invariant 1 — paise integers).
+   - `docs/design/07-technical/notifications.md` — section 6.1 (Reminder Notifications rate-limit enforcement; client-side "may optimistically disable the Send Reminder button" caveat), section 2.2 (the `reminder` template strings — already implemented in `payload-renderer.ts`), section 2.3 (the prefs-filter — `notificationPrefs.reminder` gate; already implemented in `prefs-filter.ts`).
+   - `docs/design/07-technical/cloud-functions-catalogue.md` — section 7 (sendReminderNotification spec — input shape `{ toUserId, contextType, contextId, message? }`, output shape `{ success, nextAllowedAt }`, error codes, idempotency strategy via the rate-limit record). NOTE: the catalogue's storage path `reminders/{senderUid}_{toUserId}` is SUPERSEDED by the architect-canonical `_rateLimits/{senderUid}/sends/{recipientUid}` 5-segment path per the §2.x ratification in this PR.
+   - `docs/design/06-screen-specs/09-12-friends.md` — note the Open Questions at SCR-11 ("Should the screen support a 'Send Reminder' action inline (FR-SE-09 is P1)") — PR #54 closes this by adding the receiving-direction `OBTSettleUpCard` variant on `FriendDetailScreen`. **Architect's call at §2.x** on whether to additionally add the action to the SCR-11 overflow menu (RECOMMENDED defer — the OBTSettleUpCard is the primary surface).
+   - `docs/sprint-zero/stories/CHORE-pr45-lookup-rate-limit-and-pr38-cleanup.md` — architect §2.1 / §2.9 ratifying the `_rateLimits/{userId}/{category}/counter` 4-segment container; PR #54 extends to the 5-segment per-recipient variant for FR-SE-09.
+   - `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` — the immediate predecessor; architect §2.10 item 7 (NotificationsApi injected via Dependencies); the public-surface `notifications/index.ts` exports.
+   - **NEW** `docs/sprint-zero/stories/FR-SE-09-send-reminder.md` — the story to create in Phase 1.
+   - **NEW** `functions/src/send-reminder-notification/function.ts` — callable handler (rate-limit + balance precondition + prefs filter + FCM dispatch + activity emission).
+   - **NEW** `functions/src/send-reminder-notification/index.ts` — `onCall({region: REGION}, ...)` wrapper.
+   - **NEW** `functions/src/send-reminder-notification/algorithm.ts` (OPTIONAL per §2.x) — extracted pure helpers (rate-limit window math + balance precondition function).
+   - **NEW** `functions/src/notifications/send-reminder-notification.ts` (per §2.x) — helper that mirrors `send-expense-notification.ts` / `send-settlement-notification.ts`; the callable composes this helper for the FCM dispatch leaf operation.
+   - `functions/src/notifications/index.ts` — EXTEND with the new public export `sendReminderNotification` from `./send-reminder-notification`.
+   - `functions/src/notifications/types.ts` — EXTEND `NotificationsApi` with `sendReminderNotification(deps, params): Promise<NotificationDispatchResult>` + add `SendReminderNotificationParams` interface mirroring `SendSettlementNotificationParams`.
+   - `functions/src/triggers/on-expense-write/activity-validator.ts` — EXTEND with the new `'reminder'` event type discriminator + the `ReminderPayload` shape validation (per §2.x ratification).
+   - `functions/src/index.ts` — EXTEND with `export {sendReminderNotification} from "./send-reminder-notification/index";`.
+   - **NEW** `functions/test/send-reminder-notification/function.test.ts` — comprehensive callable handler tests (24+ cases: auth required; input validation rejects malformed shape; non-member rejection; recipient doesn't owe rejection; rate-limit pre-check rejection with correct `nextAllowedAt`; rate-limit pre-check passes when window expired; prefs filter rejection; empty fcmTokens rejection; happy path writes rate-limit doc with correct shape; happy path calls `sendFcmToTokens` with correct payload shape; happy path emits activity item; rate-limit doc NOT written if all FCM sends 410'd; PII guard — no raw uids in logs; group-context path is forward-compat and returns the right error today).
+   - **NEW** `functions/test/notifications/send-reminder-notification.test.ts` — unit tests for the FCM-dispatch helper (mirror of the existing two helper test files).
+   - `functions/test/notifications/payload-renderer.test.ts` — already has reminder template assertions from PR #53; verify backwards-compat.
+   - `functions/test/notifications/prefs-filter.test.ts` — already has `notificationPrefs.reminder` short-circuit assertions from PR #53; verify backwards-compat.
+   - `functions/test/triggers/on-expense-write/activity-validator.test.ts` — EXTEND with `'reminder'` event-type validator coverage.
+   - **NEW** `lib/features/reminders/data/reminder_repository.dart`
+   - **NEW** `lib/features/reminders/domain/reminder_send_error.dart`
+   - **NEW** `lib/features/reminders/domain/reminder_send_success.dart`
+   - **NEW** `lib/features/reminders/application/send_reminder_controller.dart`
+   - **NEW** `lib/features/reminders/application/reminder_cooldown_provider.dart`
+   - `lib/features/friends/presentation/widgets/obt_settle_up_card.dart` — EXTEND with the `isReceivingDirection` + `onSendReminder` + `nextAllowedAt` parameters; the existing settling-direction call site (`FriendDetailScreen`) is unaffected.
+   - `lib/features/friends/presentation/friend_detail_screen.dart` — EXTEND the existing `balanceState == BalanceState.owes` branch with a sibling `balanceState == BalanceState.owed` branch that renders the receiving-direction OBTSettleUpCard + wires `_onSendReminderTapped` into the `sendReminderController`.
+   - **NEW** `test/features/reminders/data/reminder_repository_test.dart`
+   - **NEW** `test/features/reminders/application/send_reminder_controller_test.dart`
+   - **NEW** `test/features/reminders/application/reminder_cooldown_provider_test.dart`
+   - `test/features/friends/presentation/widgets/obt_settle_up_card_test.dart` — EXTEND with the receiving-direction variant tests (renders "Send Reminder" CTA when isReceivingDirection==true; disables during cooldown; emits onSendReminder callback).
+   - `test/features/friends/presentation/friend_detail_screen_test.dart` — EXTEND with the receiving-direction branch (when header.balanceState == BalanceState.owed, OBTSettleUpCard renders with Send Reminder; tap fires controller).
+   - **NEW** `test/features/reminders/reminders_boundary_contract_test.dart` — mirror of the FR-AC-03 boundary-contract grep (Inv-1 + Inv-2 guards over `lib/features/reminders/**`).
+   - `docs/sprint-zero/sprint-2-plan.md` — add PR #54 row (6 SP; cumulative 79 SP / 18 PRs).
+   - `docs/sprint-zero/next-three-prs.md` — roll PR #54 to merged; PR #55 / #56 / #57 candidates (top remaining: FR-PR-03 + FR-AC-04 notification preferences UI; OBTBottomNav shell; FR-SE-08 dedicated settlement-history screen).
+   - `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #54 entry; PY3 partial progress.
+   - `firestore.rules` — UNCHANGED. The existing `match /_rateLimits/{document=**}` deny-all block already covers the new 5-segment path.
+   - `firestore.indexes.json` — UNCHANGED.
+   - `storage.rules` — UNCHANGED.
+   - `pubspec.yaml` — UNCHANGED. `cloud_functions` is already in pubspec (used by lookup callable).
+   - `functions/package.json` — UNCHANGED.
+   - **CI hygiene** — `dart format .` MUST be run before push. `flutter analyze --fatal-infos` MUST exit 0. **Functions hygiene** — `npm run lint && npm run build && npm test && npm run test:rules` MUST be green; the rules suite is UNCHANGED at 188 / 9 suites.
+
+6. Honour the four invariants. Invariant 1 (paise integers) is **applicable on the `amountPaise` carry-through path**: the callable reads `simplifiedBalances[recipientUid][senderUid]` as an `int`, passes it unchanged to `renderPayload('reminder', { amountPaise, ... })`, which uses the existing Functions-side `format-inr.ts` helper for the body string; ZERO inline `/100` arithmetic anywhere in `functions/src/send-reminder-notification/**` or `lib/features/reminders/**`. The existing Functions-side boundary-contract grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new server files. The new `test/features/reminders/reminders_boundary_contract_test.dart` covers the new client files. Invariant 2 (`simplifiedBalances` server-only): the callable READS the field for the precondition check; ZERO new writers. Client-side reminders module is read-only on this field via the existing `friendsListProvider` / `friendDetailProvider` consumers (no new read sites). Invariant 3 N/A. Invariant 4: no second Firebase project — the FCM admin SDK uses the same `firebase-admin/app` initialisation; `.firebaserc` unchanged.
+
+────────────────────────────────────────
+PHASE 0 — DEPENDENCY-DAG CHECK
+────────────────────────────────────────
+
+0.1  Confirm PR #53 has merged to main and the post-merge state is clean:
+     - `git log --oneline -1` on `main` shows `6cf942e feat(notifications): FR-AC-03 FCM push + FR-AC-05 cold-start deep-link (#53)`.
+     - `functions/src/notifications/` exists with the full module (fcm-send + payload-renderer + prefs-filter + send-expense-notification + send-settlement-notification + types + index).
+     - `functions/src/utils/format-inr.ts` exists.
+     - `lib/features/notifications/` exists with the full feature folder.
+     - `lib/core/routing/notification_deep_links.dart` exists.
+     - `lib/features/reminders/` does NOT exist.
+     - `functions/src/send-reminder-notification/` does NOT exist.
+     - `flutter analyze --fatal-infos` + `flutter test` exit 0 (1083 pass / 30 skipped post-PR-#53).
+     - `cd functions && npm run lint && npm run build && npm test` exit 0 (20 suites / 270 tests pass).
+     - `cd functions && npm run test:rules` exit 0 against the emulator (9 suites / 188 tests pass).
+     - `dart format --set-exit-if-changed .` exits 0.
+     - `.firebaserc` contains exactly one project (Invariant 4 CI gate green).
+     - The existing `match /_rateLimits/{document=**}` deny-all rule at `firestore.rules:355` is intact.
+     - The existing `notificationPrefs.reminder` flag is in the `UserModel` defaults at `lib/features/auth/domain/user_model.dart`.
+     - Issues #47 (rules-hardening), #49 (orphan-cleanup), #50 (trigger no-op optimisation) are OPEN and unchanged — PR #54 does NOT close any of them.
+
+0.2  Walk the dependency DAG for FR-SE-09:
+     - **FCM module (PR #53 surface):** stable, ratified, consumed via `renderPayload('reminder', ...)` + `sendFcmToTokens(...)` + `prefsFilter.isNotificationAllowed('reminder', ...)`.
+     - **simplifiedBalances data shape:** confirm by reading `functions/src/simplified-debts/function.ts` — the writer's output. Required for the balance-precondition step.
+     - **`_rateLimits/**` rules block:** deny-all already in place; no rules diff needed.
+     - **`notificationPrefs.reminder`:** default true in `UserModel.toCreateMap()` per FR-AU-06; no schema change.
+     - **`writeExpenseActivity` (misnamed-but-canonical writer):** accepts the new `'reminder'` event type once the validator is extended.
+     - **Boundary contracts:** the existing Flutter-side grep template at `test/features/notifications/notifications_boundary_contract_test.dart` does NOT cover `lib/features/reminders/**`. PR #54 ships the parallel grep. The Functions-side grep auto-covers the new server files.
+
+0.3  Confirm DoR for the feature story:
+     - **No story file exists yet** for FR-SE-09 — `docs/sprint-zero/stories/FR-SE-09-send-reminder.md` must be created by the PM in Phase 1.
+     - Story points: **6 SP** (3 server callable + rate-limit + balance precondition + activity-emission integration; 2 client reminder repository + send-reminder controller + cooldown provider; 1 OBTSettleUpCard receiving-direction variant + FriendDetailScreen wiring). Escalate to 8 only if the architect bundles the OBTSettleUpCard extraction to `lib/core/widgets/cards/` (NOT recommended; extraction lands when the SECOND host needs it).
+     - The story must explicitly enumerate: (a) the GitHub issue this PR closes — **none** (FR-SE-09 is a P1 SRS row; no separate GitHub issue exists), (b) the four-invariant applicability assessment, (c) the cross-cutting telemetry contract (7 server events + 7 client events), (d) the explicit decision on rate-limit doc path (architect §2.x ratifies the 5-segment `_rateLimits/{senderUid}/sends/{recipientUid}` per recommendation), (e) the explicit decision on activity-feed emission target (architect §2.x ratifies recipient-only per recommendation), (f) the explicit decision on the message-compose dialog (architect §2.x ratifies defer per recommendation).
+
+0.4  Cross-reference the burndown:
+     - PR #54 closes **no Bucket-B items directly**. The reminder callable is new ground.
+     - PR #54 makes partial progress on **PY3** (Expand integration tests for Sprint 2 flows) — comprehensive callable handler tests + client repository / controller / widget tests for the new feature folder.
+     - Issues #47, #49, #50 remain OPEN and are NOT touched by PR #54.
+     - PR #54 may file an issue to track the deferred message-compose dialog (architect §2.x decision) — the issue title should be "FR-SE-09 follow-up: free-text reminder message-compose dialog" with reference back to FR-SE-09 story.
+
+────────────────────────────────────────
+PHASE 1 — STORY READINESS (PM)
+────────────────────────────────────────
+
+PM agent creates the feature story `docs/sprint-zero/stories/FR-SE-09-send-reminder.md` using the SRS §13.2 feature format. Story points: **6** (per §0.3).
+
+Required Given/When/Then ACs (each MUST be testable):
+
+  **Callable contract — positive ACs**
+
+  - **AC-1 — Authenticated caller sends a reminder; rate-limit doc is written.** Given an authenticated user A who is a member of friendship F with friend B, and B owes A per `simplifiedBalances`, and B has `notificationPrefs.reminder == true` and non-empty `fcmTokens`, when A calls `sendReminderNotification({ toUserId: 'B', contextType: 'friendship', contextId: 'A_B' })`, then the function returns `{ success: true, nextAllowedAtIso: <now+24h>.toISOString() }`, AND a doc at `_rateLimits/A/sends/B` is written with `{ lastSentAt, count: 1, windowStart, recipientUid: 'B', senderUid: 'A', updatedAt }`, AND ONE FCM message per token in `users/B.fcmTokens` is dispatched with the rendered `reminder` payload.
+  - **AC-2 — Activity item is emitted to recipient.** Given the AC-1 success path, then an activity-feed document is written to `activity/B/items/{auto-id}` with `eventType: 'reminder'` and a payload sufficient for SCR-25 to render the row.
+
+  **Callable contract — negative ACs (error codes)**
+
+  - **AC-3 — Unauthenticated caller is rejected.** Given a call without `request.auth`, when the callable runs, then it throws `HttpsError('unauthenticated', ...)` with `errorCode: 'UNAUTHENTICATED'`.
+  - **AC-4 — Malformed input is rejected.** Given a call with missing `toUserId` / missing `contextId` / `contextType ∉ {friendship, group}` / `message` length > 500, when the callable runs, then it throws `HttpsError('invalid-argument', ...)` with `errorCode: 'INVALID_INPUT'`.
+  - **AC-5 — Non-member caller is rejected.** Given a call from user A where `A ∉ memberIds` on the parent context, when the callable runs, then it throws `HttpsError('permission-denied', ...)` with `errorCode: 'NOT_A_MEMBER'`.
+  - **AC-6 — Recipient-doesn't-owe is rejected.** Given a call where `simplifiedBalances[recipientUid]?.[senderUid]` is null or <= 0, when the callable runs, then it throws `HttpsError('failed-precondition', ...)` with `errorCode: 'RECIPIENT_DOESNT_OWE'`. No rate-limit doc is written; no FCM dispatch.
+  - **AC-7 — Rate-limit pre-check rejects within the 24h window.** Given a prior rate-limit doc at `_rateLimits/A/sends/B` with `lastSentAt = now - 12h`, when A calls the callable again, then it throws `HttpsError('resource-exhausted', ...)` with `errorCode: 'RATE_LIMITED'` and `details.nextAllowedAtIso = lastSentAt + 24h`. No FCM dispatch.
+  - **AC-8 — Rate-limit pre-check passes after the 24h window expires.** Given a prior rate-limit doc with `lastSentAt = now - 25h`, when A calls the callable again, then the call succeeds and the rate-limit doc is rewritten with the new `lastSentAt`.
+  - **AC-9 — Prefs filter rejects when recipient has reminder=false.** Given recipient B has `notificationPrefs.reminder == false`, when the callable runs, then it throws `HttpsError('failed-precondition', ...)` with `errorCode: 'RECIPIENT_PREFS_DISABLED'`. No FCM dispatch; no rate-limit doc written.
+  - **AC-10 — Empty fcmTokens rejection.** Given recipient B has `fcmTokens: []`, when the callable runs, then it throws `HttpsError('failed-precondition', ...)` with `errorCode: 'RECIPIENT_NO_TOKENS'`. No rate-limit doc written (the recipient has not enabled push; allowing the rate-limit would silently consume the sender's quota for a no-op send).
+  - **AC-11 — Rate-limit doc NOT written when all FCM sends fail.** Given all of B's fcmTokens 410-pruned by FCM, when the callable runs, then no rate-limit doc is written (per §2.x architect ratification: rate-limit records on `succeeded >= 1` only); the callable still throws or returns success-with-warning per §2.x architect's call (RECOMMENDED throw `HttpsError('unavailable', ...)` with `errorCode: 'FCM_DISPATCH_FAILED'`).
+  - **AC-12 — Group-context path returns a forward-compat error today.** Given a call with `contextType: 'group'`, when the callable runs in v1.0, then it throws `HttpsError('unimplemented', ...)` with `errorCode: 'GROUP_CONTEXT_NOT_SUPPORTED'`. (The Sprint 3 groups epic ratifies the group-context path.)
+
+  **Client UX — positive ACs**
+
+  - **AC-13 — OBTSettleUpCard receiving-direction variant renders on the friend-owes branch.** Given `state.header.balanceState == BalanceState.owed` on `FriendDetailScreen`, when the screen renders, then `OBTSettleUpCard(isReceivingDirection: true, ...)` is rendered with the CTA label "Send Reminder" and the avatar arrow flipped (friend → you).
+  - **AC-14 — Tap fires the controller; success disables button via cooldown provider.** Given the receiving-direction card is rendered, when the user taps "Send Reminder" and the callable returns success, then the `reminderCooldownProvider(friendshipId)` is set to the returned `nextAllowedAt`, the button transitions to disabled state with caption "Next reminder in 23h 59m" (countdown), and `reminder_send_succeeded` telemetry fires.
+  - **AC-15 — Rate-limited returns show inline countdown.** Given the callable returns `RATE_LIMITED` with `nextAllowedAt`, when the controller surfaces the error, then the snackbar reads "You can send another reminder to {name} in 5h 32m." (per `notifications.md §6.1`), and `reminder_send_rate_limited` telemetry fires with `next_allowed_in_seconds` parameter.
+  - **AC-16 — Prefs-disabled returns show a friendly snackbar.** Given the callable returns `RECIPIENT_PREFS_DISABLED`, when the controller surfaces the error, then the snackbar reads "Your friend has notifications turned off." and `reminder_send_recipient_prefs_disabled` telemetry fires.
+  - **AC-17 — No-tokens returns show a friendly snackbar.** Given the callable returns `RECIPIENT_NO_TOKENS`, when the controller surfaces the error, then the snackbar reads "Your friend hasn't enabled push notifications yet." and `reminder_send_recipient_no_tokens` telemetry fires.
+  - **AC-18 — Doesn't-owe returns show an error snackbar.** Given the callable returns `RECIPIENT_DOESNT_OWE` (race condition where simplifiedBalances drifted between render and tap), when the controller surfaces the error, then the snackbar reads "Your friend's balance has changed. Pull to refresh." and `reminder_send_recipient_doesnt_owe` telemetry fires.
+
+  **Cross-cutting and negative ACs**
+
+  - **AC-19 — Telemetry events fire with correct PII guard.** Given any of the new structured-log events on server side OR client side, when the event is emitted, then any UID-derived parameter is hashed via `hashId()` (server) / `hashFriendshipId()` (client); the optional `message` body is NEVER logged (only its presence + length if at all); FCM tokens are NEVER logged in raw form (use `fingerprintToken()` per PR #53).
+  - **AC-20 — Invariant 1 boundary contract (client + server).** Given the PR diff, when scanned for `.toDouble()`, `parseFloat`, `/100`, `.toFixed`, or `double` declarations on monetary fields, then ZERO violations exist anywhere in `lib/features/reminders/**` or `functions/src/send-reminder-notification/**`. The new client-side grep at `test/features/reminders/reminders_boundary_contract_test.dart` is the affirmative client-side test; existing Functions-side grep auto-covers the server side.
+  - **AC-21 — Invariant 2 negative guard.** Given the PR diff, when scanned, then ZERO new writes to `simplifiedBalances` exist. The callable READS the field for the precondition check; the rate-limit and activity writes go to OTHER collections.
+  - **AC-22 — `notificationPrefs.reminder` is read-only on the server side.** Given the prefs-filter consults `notificationPrefs.reminder`, when the callable runs, then NO write to `notificationPrefs` occurs anywhere on the server side. The client-side FR-PR-03 notification-preferences UI (separate PR) is the ONLY write path.
+
+────────────────────────────────────────
+PHASE 2 — ARCHITECT HAND-OFF
+────────────────────────────────────────
+
+Architect agent appends `## Architect Notes` to the feature story ratifying:
+
+2.1  **Rate-limit doc path.** RATIFY: `_rateLimits/{senderUid}/sends/{recipientUid}` 5-segment path. Schema: `{ lastSentAt: Timestamp, count: number, windowStart: number (ms epoch), recipientUid: string, senderUid: string, updatedAt: Timestamp }`. Natural extension of the PR #45 §2.9 container. The existing `firestore.rules:355` deny-all block already covers this path; no rules diff.
+
+2.2  **FCM dispatch helper placement.** RATIFY: add `functions/src/notifications/send-reminder-notification.ts` mirroring the existing two helpers. Extend `notifications/index.ts` + `notifications/types.ts` (`NotificationsApi`, `SendReminderNotificationParams`) accordingly. The callable composes the helper via the `NotificationsApi` surface, consistent with the trigger-side wiring pattern from PR #53.
+
+2.3  **Activity-feed emission target.** RATIFY: recipient-only emission. The reminder is delivered to the recipient via FCM; the in-app activity row is the recipient's record of receipt. The sender's confirmation is the optimistic-disable button state. A future UX-research-driven PR may add sender-side activity emission if needed.
+
+2.4  **Validator extension scope.** RATIFY: the `activity-validator.ts` extension for the `'reminder'` event type ships in this PR (small extension, ships alongside the producer). The reminder payload shape is `{ senderUid: string, recipientUid: string, contextType: 'friendship' | 'group', contextId: string, amountPaise: number, message?: string }`. Validator extension MUST be backward-compatible.
+
+2.5  **Default vs custom message.** RATIFY: ship the callable with `message?: string` (max 500 chars) parameter accepted but the client v1.0 always sends WITHOUT a message (the callable defaults to a hardcoded copy). The message-compose dialog ships in a follow-up UX PR. The default-message copy: `"This is a friendly reminder!"` (architect ratifies the exact copy in `notifications.md §6.1` follow-up).
+
+2.6  **Client cooldown persistence.** RATIFY: in-memory only via Riverpod `StateProvider.family<DateTime?, String>`. Resets on app launch. The server is the authoritative gate per `notifications.md §6.1`. A future PR (paired with the `shared_preferences` adoption deferred from PR #53) may persist across launches.
+
+2.7  **OBTSettleUpCard extension.** RATIFY: extend the existing widget with `isReceivingDirection: bool`, `onSendReminder: VoidCallback?`, `nextAllowedAt: DateTime?` parameters. The settling-direction call site (existing) is unaffected. The extraction to `lib/core/widgets/cards/` per PR #43 §2.6 remains deferred until a SECOND host needs it.
+
+2.8  **Files to touch (exhaustive — anything outside this set is scope creep):** [list per §5 above]
+
+2.9  **Files explicitly NOT to touch (negative scope guardrails):**
+     - `firestore.rules`, `firestore.indexes.json`, `storage.rules` — UNCHANGED.
+     - `pubspec.yaml`, `functions/package.json` — UNCHANGED.
+     - `lib/features/expenses/**`, `lib/features/settlements/**`, `lib/features/activity/**`, `lib/features/notifications/**` (the PR #53 surface stays stable) — UNCHANGED.
+     - `functions/src/triggers/**` (the PR #53 trigger wiring is stable) — UNCHANGED except for `activity-validator.ts` per §2.4.
+     - `functions/src/notifications/{fcm-send,payload-renderer,prefs-filter,send-expense-notification,send-settlement-notification,types,index}.ts` — touched only for the new helper + type extension per §2.2.
+     - `.github/workflows/*.yml` — UNCHANGED.
+     - `docs/design/**` — read-only references; no spec updates in this PR.
+
+2.10 **Anticipated reconciliations:**
+     1. `cloud-functions-catalogue.md §7` storage path (`reminders/{senderUid}_{toUserId}`) is OBSOLETED by the architect-canonical `_rateLimits/{senderUid}/sends/{recipientUid}` path. The catalogue is documentation, not source-of-truth; the architect notes in the FR-SE-09 story are the canonical record. A docs roll-up PR may update the catalogue post-merge.
+     2. The default-message copy is architect-ratifiable; UX may revise in a future PR.
+     3. Group-context support is forward-compat-stub-only in v1.0; Sprint 3 groups epic ratifies the full path.
+     4. The optimistic-disable UI does not survive app restart in v1.0; future `shared_preferences` adoption (deferred from PR #53) may persist.
+     5. The free-text message-compose dialog is deferred to a follow-up UX PR; a tracking issue is filed during PR #54.
+
+────────────────────────────────────────
+PHASE 3 — SCOPE GUARDRAILS
+────────────────────────────────────────
+
+WHAT GOES IN PR #54:
+
+  - All files listed in §2.8.
+  - The `sendReminderNotification` callable (auth + rate-limit + balance precondition + prefs filter + FCM dispatch + activity emission + typed errors).
+  - The `_rateLimits/{senderUid}/sends/{recipientUid}` 5-segment subcollection extension (no rules diff; deny-all already in place).
+  - The activity-validator extension for the `'reminder'` event type.
+  - The `notifications/send-reminder-notification.ts` helper + `NotificationsApi` + `notifications/index.ts` re-export.
+  - The `lib/features/reminders/` feature folder (repository + domain + controller + cooldown provider).
+  - The `OBTSettleUpCard` receiving-direction variant + `FriendDetailScreen` wiring.
+  - 7 server telemetry events + 7 client telemetry events (per §3 telemetry contract).
+  - The boundary-contract grep at `test/features/reminders/reminders_boundary_contract_test.dart`.
+  - The story + Architect Notes.
+  - Plan + burndown roll-ups (Phase 7).
+
+WHAT DOES NOT GO IN PR #54:
+
+  - **FR-PR-03 / FR-AC-04 notification-preferences UI** — separate P1 story.
+  - **Group-context reminder producer** — Sprint 3 groups epic.
+  - **Message-compose dialog** — follow-up UX PR; tracking issue filed during PR #54.
+  - **OBTSettleUpCard extraction to `lib/core/widgets/cards/`** — deferred until a second host needs it (PR #43 §2.6 ratification stands).
+  - **Persistent client cooldown via `shared_preferences`** — pairs with the deferred PR #53 §2.6 addendum.
+  - **OBTBottomNav shell** — still deferred per PR #52 architect §2.1.
+  - **Sender-side activity emission** — RECOMMENDED defer per §2.3.
+  - **Issue #47 rules-hardening** — separate small chore PR.
+  - **Issue #49 orphan-cleanup** — FUTURE.
+  - **Issue #50 trigger no-op-recompute optimisation** — EXPLICITLY CONSTRAINED.
+  - **FR-SE-08 dedicated settlement-history screen** — separate PR.
+  - **Concurrent-edit detection for FR-EX-06** — still deferred.
+  - **Activity-writer rename cleanup** — still deferred per FR-AC-01 architect §2.3.
+
+If an agent suggests any of: "while we're shipping reminders, let's ship the prefs UI too", "let's ship the message-compose dialog now", "let's extract OBTSettleUpCard to core/widgets/cards/", "let's emit a sender-side activity item too", "let's persist the cooldown across launches", "let's add the group-context producer now", "let's also add the reminder to the SCR-11 overflow menu", "let's wire `shared_preferences` for cooldown" — REFUSE. These are scope creep.
+
+────────────────────────────────────────
+PHASE 4 — TEST-FIRST DISCIPLINE
+────────────────────────────────────────
+
+PR #54 follows the standard test-first cadence:
+
+1. Snapshot the pre-fix baseline: 1083 Flutter / 30 skipped; 270 functions / 20 suites; 188 rules / 9 suites.
+2. Write the failing Functions tests first: `send-reminder-notification/function.test.ts` (24+ cases per §AC list); `notifications/send-reminder-notification.test.ts` (helper unit tests mirroring the existing two helper test files); `triggers/on-expense-write/activity-validator.test.ts` extension for `'reminder'`.
+3. Write the failing Flutter tests: `reminder_repository_test.dart`, `send_reminder_controller_test.dart`, `reminder_cooldown_provider_test.dart`, `obt_settle_up_card_test.dart` extension, `friend_detail_screen_test.dart` extension, `reminders_boundary_contract_test.dart`.
+4. Implement Functions source: `notifications/types.ts` extension → `notifications/send-reminder-notification.ts` → `notifications/index.ts` re-export → `triggers/on-expense-write/activity-validator.ts` extension → `send-reminder-notification/function.ts` → `send-reminder-notification/index.ts` → `functions/src/index.ts` export.
+5. Implement Flutter source: `reminders/domain/{reminder_send_error,reminder_send_success}.dart` → `reminders/data/reminder_repository.dart` → `reminders/application/{send_reminder_controller,reminder_cooldown_provider}.dart` → `obt_settle_up_card.dart` extension → `friend_detail_screen.dart` wiring.
+6. Re-run `dart format --set-exit-if-changed .` — 0 changes.
+7. Re-run `flutter analyze --fatal-infos` — "No issues found".
+8. Re-run `flutter test` — expected 1083 + ~30 new = ~1113 tests pass.
+9. Re-run `cd functions && npm run lint && npm run build && npm test` — 270 + ~30 new = ~300 tests pass across ~22 suites.
+10. Re-run `cd functions && npm run test:rules` — 188 unchanged (no rules diff).
+11. Re-run `cd functions && npm run test:integration` — extended with a reminder-callable round-trip (mocked FCM at the SDK boundary).
+
+**Combined CI dry-run:** all jobs must be green.
+
+────────────────────────────────────────
+PHASE 5 — EXECUTION PROTOCOL
+────────────────────────────────────────
+
+Mirror the PR #53 commit cadence:
+
+ 1. PM creates story `docs/sprint-zero/stories/FR-SE-09-send-reminder.md`. Commits as `docs(stories): FR-SE-09 send reminder story`.
+ 2. Architect appends `## Architect Notes` (§2.1–§2.10). Commits as `docs(stories): FR-SE-09 architect notes`.
+ 3. Functions-dev writes failing tests for the new callable + helper + validator extension. Commits as `test(functions): FR-SE-09 send reminder tests`.
+ 4. Functions-dev ships the type extension + `notifications/send-reminder-notification.ts` helper + `notifications/index.ts` re-export + `activity-validator.ts` extension. Commits as `feat(functions): FR-SE-09 reminder notifications helper + activity validator`.
+ 5. Functions-dev ships the callable (`send-reminder-notification/function.ts` + `index.ts`) + `functions/src/index.ts` export. Commits as `feat(functions): FR-SE-09 sendReminderNotification callable`.
+ 6. Flutter-dev writes failing client tests. Commits as `test(reminders): FR-SE-09 reminder client tests`.
+ 7. Flutter-dev ships the reminders feature folder. Commits as `feat(reminders): FR-SE-09 reminder repository + controller + cooldown provider`.
+ 8. Flutter-dev extends `OBTSettleUpCard` with the receiving-direction variant + wires `FriendDetailScreen`. Commits as `feat(reminders): receiving-direction OBTSettleUpCard variant + FriendDetailScreen wiring`.
+ 9. Flutter-dev adds the boundary-contract grep. Commits as `test(reminders): boundary-contract grep against monetary float drift`.
+10. QA runs the manual smoke matrix (emulators + real FCM):
+    - Start emulators; sign in as user A on device 1; verify A and B exist in `users/`.
+    - Add an expense (paid by A, split with B); verify A's friends-list shows "B owes you ₹X".
+    - As A, open Friend Detail screen for B; verify the receiving-direction OBTSettleUpCard renders with "Send Reminder" CTA.
+    - Tap Send Reminder; verify the FCM push lands on B's device with the reminder body string.
+    - Verify the rate-limit doc at `_rateLimits/A/sends/B` was written.
+    - Verify the button is disabled with the cooldown countdown caption.
+    - Tap again; verify the snackbar says "You can send another reminder to B in 23h XXm".
+    - Force-restart the app on A's device; verify the button is enabled again (in-memory cooldown reset per §2.6); tap again; verify the SERVER still rate-limits and the snackbar surfaces.
+    - As B, set `notificationPrefs.reminder = false` in Firestore directly; as A, attempt another reminder; verify the prefs-disabled snackbar.
+    - Settle the debt fully; verify the OBTSettleUpCard is no longer rendered (balance is now zero).
+11. Docs hand updates plan + roll-forward:
+    - `docs/sprint-zero/sprint-2-plan.md` (PR #54 row; 6 SP; cumulative 79 SP / 18 PRs).
+    - `docs/sprint-zero/next-three-prs.md` (PR #55 / #56 / #57 candidates — top is FR-PR-03 + FR-AC-04 notification-preferences UI).
+    - `docs/audits/sprint-1/07-bucket-b-burndown.md` (PR #54 entry; no items closed; partial PY3 progress).
+    - Commits as `docs(plan): PR #54 shipped, prep PR #55`.
+12. PR opened. Title (≤72 chars subject): `feat(reminders): FR-SE-09 send reminder + rate limit`. Body must:
+    - Cite `notifications.md §6.1` + `cloud-functions-catalogue.md §7` + the relevant SRS rows.
+    - Confirm Invariants 1 / 2 / 4 (Inv-3 N/A).
+    - State explicitly the deferred items: message-compose dialog, persistent cooldown, group-context producer, OBTSettleUpCard extraction, sender-side activity item, etc.
+    - End with `Next PR: PR #55 — TBD per architect's call at kickoff (top candidate: FR-PR-03 + FR-AC-04 notification preferences UI).`
+
+────────────────────────────────────────
+PHASE 6 — DEFINITION OF DONE GATE
+────────────────────────────────────────
+
+Walk the DoD checklist. Particular emphasis:
+
+  - DoD §2: every layer green (Flutter / Functions / Rules unchanged / format / analyze).
+  - DoD §3: QA sign-off with evidence for the cross-device reminder send, rate-limit enforcement (both within-window rejection AND post-window pass), prefs-filter short-circuit, no-tokens short-circuit, recipient-doesn't-owe short-circuit.
+  - DoD §7: invariant compliance.
+    * Inv-1: applicable on the `amountPaise` carry-through path. `functions/src/send-reminder-notification/**` + `lib/features/reminders/**` boundary-contract greps return 0 violations.
+    * Inv-2: ZERO new writes to `simplifiedBalances`; reminder module reads the field for the precondition check.
+    * Inv-3: N/A.
+    * Inv-4: `.firebaserc` unchanged.
+  - DoD §8: documentation updated (story + architect notes + sprint-2-plan + next-three-prs + burndown).
+  - DoD §9: deploy verification. The Functions side deploys via `firebase deploy --only functions:sendReminderNotification` on tag. The Flutter client ships in the next mobile build. QA verifies the reminder flow end-to-end in production post-deploy on the canary device.
+
+QA posts the explicit DoD §3 sign-off, including the negative-scope greps from AC-20 (no `/100` in `lib/features/reminders/**` or `functions/src/send-reminder-notification/**`) and AC-21 (no new `simplifiedBalances` writes).
+
+**Pre-push CI hygiene:** run `dart format .` AND all test layers BEFORE `git push`.
+
+────────────────────────────────────────
+PHASE 7 — UPDATE THE ROLLING PLAN AND BURNDOWN
+────────────────────────────────────────
+
+PM agent updates:
+  - `docs/sprint-zero/sprint-2-plan.md` — PR #54 status (merged), velocity #18 (6 SP, total now 79 SP across 18 PRs).
+  - `docs/sprint-zero/next-three-prs.md`:
+      * PR #54 row marked merged; numbering note updated.
+      * PR #55: **TBD** per architect's call at kickoff. Top candidates (in rough priority order):
+          - **FR-PR-03 + FR-AC-04 notification-preferences UI** (P1; lives on Profile screen; the server-side prefs-filter shipped in PR #53 and is also the gate for FR-SE-09 — this PR makes the gate user-controllable).
+          - **OBTBottomNav shell** (UX foundation; needed for Sprint 3 groups epic).
+          - **FR-SE-08 dedicated full-history screen** at `/settlements/history` (P0; in-timeline rows satisfy v1.0 but the dedicated screen is still backlog).
+          - **Bucket-B chore close-out** (single ~3 SP PR closing #20 CV3, #21 R1-R4, #23 PY3 partial with comments).
+          - **Issue #47 rules-hardening** (chore; 2 SP).
+          - **`shared_preferences` adoption** for cross-launch persistence (PR #53 §2.6 addendum + FR-SE-09 §2.6 cooldown).
+          - **FR-SE-09 message-compose dialog follow-up** (the deferred UX PR).
+      * PR #56 / #57: TBD per PR #55 outcome.
+  - `docs/audits/sprint-1/07-bucket-b-burndown.md`:
+      * Header timestamp: PR #53 → PR #54.
+      * Append a PR #54 section: closes NO Bucket-B items directly. Partial PY3 progress: comprehensive callable handler tests + the new client feature-folder tests.
+
+Commits as `docs(plan): PR #54 shipped, prep PR #55`.
+
+────────────────────────────────────────
+GUARDRAILS
+────────────────────────────────────────
+
+If during this PR an agent proposes:
+  - "While we're shipping reminders, let's also ship the notification-preferences UI" → REFUSE. Separate P1 story; lives on the Profile screen with its own SCR.
+  - "Let's ship the message-compose dialog now" → REFUSE per §2.5. Follow-up UX PR; tracking issue filed during PR #54.
+  - "Let's extract OBTSettleUpCard to `lib/core/widgets/cards/` now" → REFUSE per §2.7. Defer until a second host needs it (precedent: `OBTAmountInput`).
+  - "Let's emit a sender-side activity item too" → REFUSE per §2.3. Recipient-only emission for v1.0.
+  - "Let's persist the cooldown across launches via `shared_preferences`" → REFUSE per §2.6. Pairs with the FR-PR-03 / FR-AC-04 PR if needed.
+  - "Let's add the group-context reminder producer now" → REFUSE. Sprint 3 groups epic.
+  - "Let's also add Send Reminder to the SCR-11 overflow menu" → REFUSE. The OBTSettleUpCard is the primary surface; overflow-menu addition is a deferred UX consideration.
+  - "Let's change the rate-limit doc path to be per-user instead of per-friend" → REFUSE. SRS §4.6 is unambiguous: per-friend.
+  - "Let's close issue #47 (rules-hardening) at the same time" → REFUSE. Separate small chore PR.
+  - "Let's close issue #49 (orphan-cleanup) at the same time" → REFUSE. FUTURE.
+  - "Let's close issue #50 (trigger no-op-recompute optimisation)" → **EXPLICITLY REFUSE** — closing it would BREAK FR-EX-07 AC-2.
+  - "Let's do the OBTSettleUpCard extraction at the same time" → REFUSE. Cosmetic; deferred per PR #43 §2.6.
+  - "Let's bundle FR-SE-08 dedicated settlement-history screen since we're touching FriendDetailScreen" → REFUSE. Separate P0 story.
+  - "Let's update the `cloud-functions-catalogue.md` to match the new rate-limit path" → REFUSE in this PR; a docs roll-up PR may follow.
+
+If something genuinely surprises (e.g. the `_rateLimits/**` deny-all rule unexpectedly blocks the admin-SDK write because the rules-test setup uses a non-admin context; or the `simplifiedBalances` data shape from `functions/src/simplified-debts/function.ts` differs from `simplifiedBalances[debtorUid][creditorUid] = paise`; or the `writeExpenseActivity` validator rejects the new `'reminder'` event type even after extension because of a schema-version field on the activity item; or the `cloud_functions` Dart SDK does NOT surface `HttpsError.details` to the client and we need a different error-payload strategy), STOP and surface the friction. PR #54 is the first PR that exercises the FCM module from a callable Cloud Function path AND the first PR that writes to the 5-segment `_rateLimits/{uid}/sends/{recipientUid}` extension — get both contracts right before shipping.
+
+Begin with Phase 0 — verify the dependency DAG (PR #53 merge state at `6cf942e`; baseline test counts; emulators reachable; `notifications/index.ts` + `payload-renderer.ts` reminder template intact; `notificationPrefs.reminder` defaults intact; `match /_rateLimits/{document=**}` deny-all rule intact) and re-read the four reference docs (`docs/design/07-technical/notifications.md` §6.1 + §2.2 + §2.3 in full, `docs/design/07-technical/cloud-functions-catalogue.md` §7 in full, the existing `functions/src/lookup-user-by-phone-number/function.ts` as the architectural blueprint for the symmetric callable, and the existing `functions/src/notifications/send-settlement-notification.ts` as the architectural blueprint for the new `send-reminder-notification.ts` helper) before kickoff.

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -1,11 +1,11 @@
 # Next Three PRs
 
 > Rolling roadmap. Updated at the end of every PR.
-> Last updated: PR #53 merged (FR-AC-03 + FR-AC-05 — FCM push notifications + cold-start deep-link).
+> Last updated: PR #54 merged (FR-SE-09 — Send Reminder + per-friend 24-hour rate limit).
 
 ---
 
-## GitHub issue / PR numbering note (post-PR #53)
+## GitHub issue / PR numbering note (post-PR #54)
 
 The numbering jumped because issues and PRs share the same sequential
 namespace on GitHub. The post-PR #48 sequence so far:
@@ -20,52 +20,49 @@ namespace on GitHub. The post-PR #48 sequence so far:
 | #51 | PR | FR-EX-07 activity feed write-side, friendship expenses (merged 2026-06-07) |
 | #52 | PR | FR-AC-01 activity feed read-side + settlement-trigger activity emission (merged 2026-06-08) |
 | #53 | PR | FR-AC-03 FCM push notifications + FR-AC-05 cold-start deep-link (merged 2026-06-08) |
-| **#54** | **PR** | **Next feature PR — see below** |
+| #54 | PR | FR-SE-09 Send Reminder + per-friend 24-hour rate limit (merged 2026-06-09) |
+| **#55** | **PR** | **Next feature PR — see below** |
 
 The "Next three PRs" below refer to the next three FEATURE/CHORE
-**pull requests** — i.e. PR #54, PR #55, PR #56. Their issue-number
+**pull requests** — i.e. PR #55, PR #56, PR #57. Their issue-number
 counterparts (when filed) will consume intermediate numbers; the
-orchestrator should not assume PR #54 = number 54 on GitHub.
+orchestrator should not assume PR #55 = number 55 on GitHub.
 
 ---
 
-## PR #54 — TBD
+## PR #55 — TBD
 
-**Status:** Next up. Architect picks at PR #54 kickoff per Sprint 2 velocity.
+**Status:** Next up. Architect picks at PR #55 kickoff per Sprint 2 velocity.
 
-PR #53 shipped FR-AC-03 + FR-AC-05 — the FCM module is live (server
-notifications module + per-event-type renderer + 410 token cleanup +
-prefs filter + INR formatter parity), both triggers emit FCM (expense
-to non-author members, settlement to toUserId), the client lifecycle
-is wired (token register / refresh / sign-out cleanup), the
-pre-permission dialog appears on first transition to
-`AuthenticatedWithProfile`, the foreground in-app banner renders via
-an OverlayEntry, the background `onBackgroundMessage` handler is
-registered before runApp, and the cold-start `getInitialMessage`
-payload routes after the auth check. The shared
-`lib/core/routing/notification_deep_links.dart` helper is consumed by
-both the activity feed (`ActivityFeedScreen._onRowTap` refactored)
-and the FCM tap surfaces.
+PR #54 shipped FR-SE-09 — the `sendReminderNotification` callable is
+live (auth + simplifiedBalances precondition + per-friend 24h rate
+limit via the 5-segment `_rateLimits/{senderUid}/sends/{recipientUid}`
+extension + prefs filter + FCM dispatch + recipient-only activity
+emission), the `lib/features/reminders/` feature folder is in place
+(repository + sealed result hierarchy + send controller + in-memory
+cooldown provider + telemetry constants), the `OBTSettleUpCard`
+gained the receiving-direction variant in place, and the
+`FriendDetailScreen.BalanceState.owed` branch wires the card +
+surfaces per-error-code snackbars.
 
 Candidates (in rough priority order):
 
-- **FR-SE-09 — Send Reminder.** Now the **highest unplaced P1** and
-  the **first downstream consumer of the FCM module shipped in
-  PR #53**. Introduces the per-friend 24-hour rate-limit
-  subcollection (`_rateLimits/{uid}/sends/counter` pattern per PR #45
-  Architect Notes §2.9), the Reminder Cloud Function entry point,
-  the `reminder` notification template producer (renderer + filter
-  already shipped in PR #53), and the OBTSettleUpCard "Send Reminder"
-  button on the receiving-direction branch (deferred per PR #43 §2.5
-  default-omit). 4-6 SP. NO new FCM infrastructure work — the
-  `sendFcmToTokens` API is stable.
-- **FR-AC-04 + FR-PR-03 — notification preferences UI.** The Profile
-  screen gains a `/profile/notifications` route with three toggles
-  (`newExpense`, `settlement`, `reminder`) backed by the existing
-  `users/{uid}.notificationPrefs` map. The server-side prefs-filter
-  already shipped in PR #53 — this is purely the client UI + write
-  path. 3-4 SP. Naturally pairs with FR-SE-09 because both touch
-  notification semantics.
+- **FR-AC-04 + FR-PR-03 — notification preferences UI.** Now the
+  **highest unplaced P1** and the natural pair with FR-SE-09. The
+  Profile screen gains a `/profile/notifications` route with three
+  toggles (`newExpense`, `settlement`, `reminder`) backed by the
+  existing `users/{uid}.notificationPrefs` map. The server-side
+  prefs-filter already shipped in PR #53 and is the gate for
+  FR-SE-09 — this PR makes the gate user-controllable. 3-4 SP. A
+  natural place to ALSO add the `shared_preferences` adoption
+  (PR #53 §2.6 + FR-SE-09 §2.6 cross-launch persistence).
+- **`reminderRepositoryProvider` + `matchingRepositoryProvider`
+  production wiring** (chore; ~1 SP). Both providers are
+  throw-until-overridden today; the production override via
+  `cloud_functions` is a known gap. Add `cloud_functions` to pubspec
+  and override both providers in main.dart. Naturally bundleable
+  with FR-AC-04/FR-PR-03 since that PR will also touch profile
+  data wiring.
 - **`OBTBottomNav` shell.** UX foundation deferred from PR #52 per
   architect §2.1. Becomes the canonical entry point for the
   Friends / Groups / Activity / Profile tab cluster — needed before
@@ -73,10 +70,16 @@ Candidates (in rough priority order):
 - **FR-SE-08 dedicated full-history screen** at
   `/settlements/history` (P0 — PR #42's in-timeline rows satisfy
   v1.0 but the dedicated screen is still a backlog item).
+- **Bucket-B chore close-out** (single ~3 SP PR closing #20 CV3,
+  #21 R1-R4, #23 PY3 partial with comments).
 - **Issue #47 rules-hardening for non-creator update/delete gate**
   (operational hardening; small standalone PR ~2 SP). Closes the
   defence-in-depth gap that the FR-EX-06 architect §2.9 item 5
   documented.
+- **FR-SE-09 message-compose dialog follow-up** (the deferred UX
+  PR per architect §2.5). 1-2 SP. Adds a bottom sheet that prompts
+  for the optional 500-char reminder message; updates the callable
+  invocation to pass it. Tracking issue to be filed.
 - **`OBTRupeeText` primitive** (UX foundation; small PR ~1 SP).
   Deferred from PR #52 per architect §2.6. The component catalogue
   declares it; a future PR adds the 5-line wrapper around
@@ -88,15 +91,12 @@ Candidates (in rough priority order):
   `entityIdHash`) was DEFERRED to minimise blast radius. A future
   cleanup PR can do the full rename + Cloud Logging dashboard
   migration as one focused change.
-- **`shared_preferences` adoption for FCM-permission persistence**
-  (architect §2.6 / §2.8 addendum from PR #53). The
-  `wasPermanentlyDenied` flag in
-  `NotificationPermissionController` is in-memory only because the
-  lockfile has no `shared_preferences` entry. Add the dependency +
-  persist the flag across launches so the pre-permission dialog
-  honours the "permanently denied" state across app restarts.
-  1-2 SP. Naturally pairs with the FR-AC-04 / FR-PR-03 prefs UI PR
-  since that also persists user-facing notification preferences.
+- **`cloud-functions-catalogue.md §7` docs roll-up** (cosmetic
+  chore; ~1 SP). The catalogue's `reminders/{senderUid}_{toUserId}`
+  storage path and `RECIPIENT_NO_TOKENS → success: true` shape are
+  SUPERSEDED by the FR-SE-09 architect ratifications (§2.1 + §2.10
+  reconciliation 2). A docs roll-up PR can bring the catalogue in
+  line with the actual implementation.
 - **FCM emulator-side integration test infrastructure** (per PR #53
   functions-dev §1 deviation). The Cloud Functions emulator-side
   integration tests under `functions/test/integration/on-*.integration.test.ts`
@@ -117,7 +117,8 @@ Candidates (in rough priority order):
   this constraint.
 - **Rate-limit transaction race refactor** (operational hardening;
   small standalone PR). Deferred from PR #45 per chore-story
-  Architect Notes §2.2.
+  Architect Notes §2.2. The FR-SE-09 rate-limit doc shape
+  inherits the same read-modify-write race vector.
 - **`emitExpenseActivity` memberIds re-read cleanup** (operational
   cleanup; small standalone PR ~1 SP). Per the PR #51 review
   recommendation #1: the trigger handler currently re-reads the
@@ -128,19 +129,19 @@ Candidates (in rough priority order):
 
 ---
 
-## PR #55 — TBD
-
-**Status:** Slot reserved. Architect picks at PR #54 kickoff.
-
-Candidates: whatever doesn't land in PR #54 from the list above.
-
----
-
 ## PR #56 — TBD
 
 **Status:** Slot reserved. Architect picks at PR #55 kickoff.
 
-Candidates: whatever doesn't land in PR #54 / PR #55 from the lists above.
+Candidates: whatever doesn't land in PR #55 from the list above.
+
+---
+
+## PR #57 — TBD
+
+**Status:** Slot reserved. Architect picks at PR #56 kickoff.
+
+Candidates: whatever doesn't land in PR #55 / PR #56 from the lists above.
 
 ---
 

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #53 (FR-AC-03 + FR-AC-05 — FCM push notifications + cold-start deep-link) — 17th merged PR.
+> Last updated: PR #54 (FR-SE-09 — Send Reminder + per-friend 24-hour rate limit) — 18th merged PR.
 
 ---
 
@@ -164,6 +164,7 @@ If ANY gate is red, file a dedicated DevOps chore PR (estimated
 | #51 | FR-EX-07 | Activity feed write-side (friendship) — activity-writer + payload-builder + activity-validator + activity/{userId}/items rules + trigger emission + 12 new rules tests + 41 new unit tests + 3 integration round-trips | 5 | Merged |
 | #52 | FR-AC-01 / FR-AC-02 | Activity feed read-side — SCR-25 ActivityFeedScreen + OBTActivityRow widget + activity feature folder + 4 telemetry events + settlement-trigger activity-emission extension (closes the on-settlement-write TODO) | 8 | Merged |
 | #53 | FR-AC-03 / FR-AC-05 | FCM push notifications + cold-start deep-link — Functions notifications module (fcm-send + payload-renderer + prefs-filter + Functions-side INR formatter) + expense + settlement trigger FCM emission + client FCM token lifecycle + pre-permission dialog + in-app banner + cold-start handler + shared notification_deep_links routing helper consumed by both the activity feed and notifications | 10 | Merged |
+| #54 | FR-SE-09 | Send Reminder — sendReminderNotification callable (auth + simplifiedBalances precondition + 5-segment `_rateLimits/{senderUid}/sends/{recipientUid}` 24-hour rate-limit + prefs filter + FCM dispatch + recipient-only activity emission) + notifications/send-reminder-notification.ts FCM helper + activity-validator 'reminder' event-type extension + lib/features/reminders/ feature folder (repository + sealed result hierarchy + send controller + cooldown provider + telemetry) + OBTSettleUpCard receiving-direction variant + FriendDetailScreen owed-branch wiring | 6 | Merged |
 
 ---
 
@@ -188,7 +189,8 @@ If ANY gate is red, file a dedicated DevOps chore PR (estimated
 | #51 | 5 | Merged |
 | #52 | 8 | Merged |
 | #53 | 10 | Merged |
-| **Total** | **73** | **17 PRs so far** |
+| #54 | 6 | Merged |
+| **Total** | **79** | **18 PRs so far** |
 
 Sprint 1 reference:
 

--- a/docs/sprint-zero/stories/FR-SE-09-send-reminder.md
+++ b/docs/sprint-zero/stories/FR-SE-09-send-reminder.md
@@ -1,0 +1,485 @@
+# FR-SE-09: Send Reminder
+
+> Implementation-ready user story for the **first callable Cloud
+> Function that composes the FR-AC-03 FCM module surface** with the
+> simplified-balances precondition + per-friend 24-hour rate-limit
+> gate. Ships the `sendReminderNotification` callable
+> (`functions/src/send-reminder-notification/` — mirror of
+> `lookup-user-by-phone-number/`), the new
+> `notifications/send-reminder-notification.ts` helper that mirrors
+> the existing `send-expense-notification.ts` /
+> `send-settlement-notification.ts` helpers and is exposed through
+> the public `NotificationsApi` surface, the
+> `_rateLimits/{senderUid}/sends/{recipientUid}` 5-segment
+> subcollection extension of the architect-canonical `_rateLimits/`
+> container, the `'reminder'` event-type extension to the existing
+> `activity-validator.ts` + `writeExpenseActivity` writer (the
+> misnamed-but-canonical writer), a new `lib/features/reminders/`
+> client feature folder (repository + domain + send controller +
+> in-memory cooldown provider), the receiving-direction variant of
+> `OBTSettleUpCard` (with `isReceivingDirection` /
+> `onSendReminder` / `nextAllowedAt` parameters), and the
+> `FriendDetailScreen` wiring on the `BalanceState.owed` branch.
+
+---
+
+## SRS Requirement ID(s)
+
+FR-SE-09 (SRS section 4.6 — "The app shall allow a user to send a
+free-text reminder push notification to a friend who owes them money,
+rate-limited to one reminder per friend per 24 hours"; P1). The story
+also exercises the read side of FR-AC-04
+(`notificationPrefs.reminder` is consulted as the prefs-filter gate
+for the FCM dispatch leaf; the FR-PR-03 / FR-AC-04 user-facing
+preferences UI ships in a separate PR).
+
+## Relevant SRS Sections
+
+- Section 4.6 — Settlements (FR-SE-09 row: send-reminder action;
+  per-friend 24h rate-limit). The story IS the producer for this row.
+- Section 4.7 — Activity Feed and Notifications (FR-AC-03 FCM
+  consumer surface used by the dispatch leaf; FR-AC-04
+  notification-preferences server-side consumption via the
+  `prefs-filter.ts` reminder short-circuit; a new `'reminder'`
+  activity-feed event-type extension on the existing writer).
+- Section 5.10 — Observability (seven new server structured-log
+  events + seven mirrored client analytics events; PII hashing via
+  `hashId()` server / `hashFriendshipId()` client per ADR-0013).
+- Section 7.3 — Invariant 1 (paise integer carry-through path on
+  `amountPaise` from `simplifiedBalances[recipientUid][senderUid]`
+  → `renderPayload('reminder', ...)` → FCM data envelope; zero
+  inline `/100` on any new code path).
+- Section 7.5 — Security rules (existing
+  `match /_rateLimits/{document=**}` deny-all block at
+  `firestore.rules:355` already covers the new 5-segment per-recipient
+  variant; no rules diff in this story).
+
+## Priority
+
+**P1.** SRS section 4.6 row FR-SE-09 is P1. PR #53 (FR-AC-03) already
+shipped the renderer template + the prefs-filter short-circuit as
+forward-compat for this story; FR-SE-09 is the natural first
+downstream consumer of that module surface.
+
+## Story Points
+
+**6.** Decomposes as:
+
+- 3 SP — server callable
+  (`functions/src/send-reminder-notification/{index,function}.ts`
+  with auth + input validation + membership check +
+  simplifiedBalances precondition + rate-limit pre-check + prefs
+  filter + FCM dispatch + rate-limit write + activity emission +
+  typed `HttpsError` codes), the FCM dispatch helper
+  (`functions/src/notifications/send-reminder-notification.ts`
+  mirror of the existing two helpers; exposed via `NotificationsApi`),
+  the `notifications/index.ts` re-export + `notifications/types.ts`
+  extension (`SendReminderNotificationParams` interface), and the
+  `activity-validator.ts` extension for the new `'reminder'` event
+  type discriminator + `ReminderPayload` shape.
+- 2 SP — client `lib/features/reminders/` feature folder
+  (`data/reminder_repository.dart` callable wrapper,
+  `domain/{reminder_send_error,reminder_send_success}.dart` typed
+  result hierarchy, `application/send_reminder_controller.dart`
+  Riverpod `Notifier<SendReminderState>` driving the in-progress /
+  success / error states with telemetry, and
+  `application/reminder_cooldown_provider.dart`
+  `StateProvider.family<DateTime?, String>` for the optimistic
+  in-memory cooldown).
+- 1 SP — `OBTSettleUpCard` receiving-direction variant
+  (`isReceivingDirection: bool`, `onSendReminder: VoidCallback?`,
+  `nextAllowedAt: DateTime?` parameters; existing settling-direction
+  call site unaffected) and `FriendDetailScreen.BalanceState.owed`
+  branch wiring (renders the receiving-direction card, wires
+  `_onSendReminderTapped` into the controller, surfaces error
+  snackbars per typed error variant).
+
+Patterns reused without re-derivation:
+
+- `functions/src/lookup-user-by-phone-number/` is the symmetric
+  callable blueprint (handler factory with injected `db` + `logger`;
+  `HttpsError` with `errorCode` in `details`; rate-limit document
+  read-modify-write; `region: REGION` pinning).
+- `functions/src/notifications/send-settlement-notification.ts` is
+  the FCM-helper blueprint (single recipient; prefs-filter +
+  token-read + `sendFcmToTokens` composition; structured-log
+  contract).
+- `functions/src/triggers/on-expense-write/activity-writer.ts` +
+  `activity-validator.ts` are the activity-emission blueprint (per-
+  member fan-out; the new `'reminder'` event-type extends both).
+- `lib/features/friends/data/matching_repository.dart` is the
+  callable-wrapper blueprint (`CloudFunctionException` →
+  discriminated result hierarchy).
+- `lib/features/settlements/application/settle_up_telemetry.dart`
+  is the client telemetry-constants blueprint (one final-class
+  abstract with `static const` event names + parameter keys).
+- `lib/features/friends/presentation/widgets/obt_settle_up_card.dart`
+  is the host widget that gains the receiving-direction variant in
+  place (no extraction to `lib/core/widgets/cards/` — the cosmetic
+  split is deferred until a second host needs it, per the
+  `OBTAmountInput` precedent).
+
+## User Story
+
+As a **signed-in user with a friend who owes me money**,
+I want **a "Send Reminder" call-to-action on the Friend Detail screen
+that sends a push notification to my friend asking them to settle up,
+rate-limited to one reminder per friend per 24 hours**,
+so that **I can nudge them to settle without leaving the app or
+sending a manual WhatsApp/SMS message**.
+
+## Acceptance Criteria
+
+> 22 ACs. Mirrors the FR-AC-03 cadence (positive callable contract +
+> per-error-code negative branches + client UX branches + cross-
+> cutting invariant guards).
+
+### Callable contract — positive
+
+**AC-1 — Authenticated caller sends a reminder; rate-limit doc is
+written.** Given an authenticated user A who is a member of friendship
+F (`memberIds = [A, B]`) with friend B, and B owes A per
+`simplifiedBalances[B][A] > 0`, and B has
+`notificationPrefs.reminder == true` and non-empty
+`users/B.fcmTokens`, when A calls
+`sendReminderNotification({ toUserId: 'B', contextType: 'friendship',
+contextId: F })`, then the function returns
+`{ success: true, nextAllowedAtIso: <now+24h>.toISOString() }`, AND a
+document at `_rateLimits/A/sends/B` is written with
+`{ lastSentAt: Timestamp, count: 1, windowStart: number,
+recipientUid: 'B', senderUid: 'A', updatedAt: Timestamp }`, AND ONE
+FCM message per token in `users/B.fcmTokens` is dispatched with the
+rendered `reminder` payload (`type: 'reminder'`, `title: 'Reminder
+from {A.displayName}'`, body `{A.displayName} is nudging you about
+₹{amount}.`).
+
+**AC-2 — Activity item is emitted to recipient.** Given the AC-1
+success path, then an activity-feed document is written to
+`activity/B/items/{auto-id}` with `type: 'reminder'` and a payload
+containing `{ senderUid, recipientUid, contextType, contextId,
+amountPaise }` sufficient for the SCR-25 row renderer to identify
+the reminder and deep-link to the friendship. (Recipient-only
+emission per architect §2.3 — the sender's confirmation is the
+optimistic-disable button state, not an activity row.)
+
+### Callable contract — negative (error codes)
+
+**AC-3 — Unauthenticated caller is rejected.** Given a call without
+`request.auth`, when the callable runs, then it throws
+`HttpsError('unauthenticated', ...)` with
+`details.errorCode === 'UNAUTHENTICATED'`. No rate-limit doc written;
+no FCM dispatch; no activity emission.
+
+**AC-4 — Malformed input is rejected.** Given a call with any of:
+missing `toUserId`, empty-string `toUserId`, missing `contextId`,
+empty-string `contextId`, `contextType ∉ {friendship, group}`, or
+`message` length > 500 characters, when the callable runs, then it
+throws `HttpsError('invalid-argument', ...)` with
+`details.errorCode === 'INVALID_INPUT'`. No rate-limit doc written;
+no FCM dispatch; no activity emission.
+
+**AC-5 — Non-member caller is rejected.** Given a call from user A
+where `A ∉ memberIds` on the parent context, when the callable runs,
+then it throws `HttpsError('permission-denied', ...)` with
+`details.errorCode === 'NOT_A_MEMBER'`. No rate-limit doc written;
+no FCM dispatch; no activity emission.
+
+**AC-6 — Recipient-doesn't-owe is rejected.** Given a call where
+`simplifiedBalances[recipientUid]?.[senderUid]` is `undefined`, `0`,
+or negative (the recipient doesn't owe the sender — sender is owed
+by no-one in that direction or is themselves the debtor), when the
+callable runs, then it throws `HttpsError('failed-precondition',
+...)` with `details.errorCode === 'RECIPIENT_DOESNT_OWE'`. No
+rate-limit doc written; no FCM dispatch; no activity emission.
+
+**AC-7 — Rate-limit pre-check rejects within the 24h window.** Given
+a prior rate-limit doc at `_rateLimits/A/sends/B` with `lastSentAt =
+now - 12h`, when A calls the callable again with the same
+`recipientUid`, then it throws `HttpsError('resource-exhausted',
+...)` with `details.errorCode === 'RATE_LIMITED'` AND
+`details.nextAllowedAtIso === (lastSentAt + 24h).toISOString()`. No
+FCM dispatch; no new rate-limit write.
+
+**AC-8 — Rate-limit pre-check passes after the 24h window expires.**
+Given a prior rate-limit doc at `_rateLimits/A/sends/B` with
+`lastSentAt = now - 25h`, when A calls the callable again with the
+same `recipientUid`, then the call succeeds (per AC-1 contract) and
+the rate-limit doc is rewritten with the new `lastSentAt` (the
+`count` field is incremented).
+
+**AC-9 — Prefs filter rejects when recipient has reminder=false.**
+Given recipient B's `notificationPrefs.reminder === false`, when the
+callable runs, then it throws `HttpsError('failed-precondition',
+...)` with `details.errorCode === 'RECIPIENT_PREFS_DISABLED'`. No
+FCM dispatch; no rate-limit doc written; no activity emission.
+
+**AC-10 — Empty fcmTokens rejection.** Given recipient B's
+`users/B.fcmTokens` is missing or empty, when the callable runs,
+then it throws `HttpsError('failed-precondition', ...)` with
+`details.errorCode === 'RECIPIENT_NO_TOKENS'`. No rate-limit doc
+written (the recipient has not granted push permission — allowing
+the rate-limit would silently consume the sender's quota for a no-op
+send); no activity emission.
+
+**AC-11 — Rate-limit doc NOT written when all FCM sends fail.**
+Given all of B's `fcmTokens` are pruned by the FCM admin SDK with
+HTTP 410 (`messaging/registration-token-not-registered`), when the
+callable runs, then the callable throws
+`HttpsError('unavailable', ...)` with
+`details.errorCode === 'FCM_DISPATCH_FAILED'` AND no rate-limit doc
+is written (per architect §2.5: rate-limit records on
+`succeeded >= 1` only — full-failure dispatch is not a "send"). The
+410-pruned tokens are still removed from the recipient's `fcmTokens`
+array by the existing FR-AC-03 helper (defence-in-depth).
+
+**AC-12 — Group-context path returns a forward-compat error today.**
+Given a call with `contextType: 'group'` and any `contextId`, when
+the callable runs in v1.0, then it throws
+`HttpsError('unimplemented', ...)` with
+`details.errorCode === 'GROUP_CONTEXT_NOT_SUPPORTED'`. (The Sprint 3
+groups epic ratifies the full group-context path; FR-SE-09 v1.0
+ships friendship-context only.)
+
+### Client UX — positive
+
+**AC-13 — OBTSettleUpCard receiving-direction variant renders on the
+friend-owes branch.** Given `state.header.balanceState ==
+BalanceState.owed` on `FriendDetailScreen` (i.e. the friend owes the
+authenticated user), when the screen renders, then
+`OBTSettleUpCard(isReceivingDirection: true, ...)` is rendered with
+the CTA label "Send Reminder", the avatar arrow flipped (friend →
+you), the friend's avatar on the left as the payer position, and
+the suggested amount displaying the absolute net balance via
+`formatInrFromPaise()`.
+
+**AC-14 — Tap fires the controller; success disables button via
+cooldown provider.** Given the receiving-direction card is rendered,
+when the user taps "Send Reminder" and the callable returns
+`{ success: true, nextAllowedAtIso }`, then the
+`reminderCooldownProvider(friendshipId)` is set to the returned
+`nextAllowedAt`, the button transitions to a disabled state with a
+caption like "Next reminder in 23h 59m" (live countdown), and a
+`reminder_send_succeeded` client telemetry event fires with
+`friendship_id_hash` parameter.
+
+**AC-15 — Rate-limited returns show inline countdown.** Given the
+callable returns `RATE_LIMITED` with `nextAllowedAtIso`, when the
+controller surfaces the error, then a snackbar reads "You can send
+another reminder to {friend.displayName} in {h}h {m}m." (per
+`notifications.md §6.1`), AND a `reminder_send_rate_limited` client
+telemetry event fires with `friendship_id_hash` +
+`next_allowed_in_seconds` parameters, AND the cooldown provider is
+updated to the server-returned `nextAllowedAt` (so the button stays
+disabled).
+
+**AC-16 — Prefs-disabled returns show a friendly snackbar.** Given
+the callable returns `RECIPIENT_PREFS_DISABLED`, when the controller
+surfaces the error, then a snackbar reads "{friend.displayName} has
+notifications turned off." AND a
+`reminder_send_recipient_prefs_disabled` client telemetry event
+fires with `friendship_id_hash` parameter.
+
+**AC-17 — No-tokens returns show a friendly snackbar.** Given the
+callable returns `RECIPIENT_NO_TOKENS`, when the controller surfaces
+the error, then a snackbar reads "{friend.displayName} hasn't
+enabled push notifications yet." AND a
+`reminder_send_recipient_no_tokens` client telemetry event fires
+with `friendship_id_hash` parameter.
+
+**AC-18 — Doesn't-owe returns show an error snackbar.** Given the
+callable returns `RECIPIENT_DOESNT_OWE` (race condition where
+`simplifiedBalances` drifted between render and tap — e.g. the friend
+just settled), when the controller surfaces the error, then a
+snackbar reads "{friend.displayName}'s balance has changed. Pull to
+refresh." AND a `reminder_send_recipient_doesnt_owe` client
+telemetry event fires with `friendship_id_hash` parameter.
+
+### Cross-cutting and negative guards
+
+**AC-19 — Telemetry events fire with correct PII guard.** Given any
+of the new server structured-log events (`reminder_send_attempted`,
+`reminder_send_succeeded`, `reminder_send_rate_limited`,
+`reminder_send_skipped_by_prefs`, `reminder_send_failed_no_tokens`,
+`reminder_send_recipient_doesnt_owe`, `reminder_send_failed`) OR
+any of the new client events (`reminder_send_tapped`,
+`reminder_send_succeeded`, `reminder_send_rate_limited`,
+`reminder_send_recipient_prefs_disabled`,
+`reminder_send_recipient_no_tokens`,
+`reminder_send_recipient_doesnt_owe`, `reminder_send_failed`), when
+the event is emitted, then any UID-derived parameter (sender, recipient,
+or friendship id) is hashed through `hashId()` (server) /
+`hashFriendshipId()` (client); the optional `message` body is NEVER
+logged in raw form (only its presence + length if at all); FCM
+tokens are NEVER logged in raw form (use `fingerprintToken()` per
+FR-AC-03).
+
+**AC-20 — Invariant 1 boundary contract (client + server).** Given
+the PR diff, when scanned for `.toDouble()`, `parseFloat`, `/100`,
+`.toFixed`, or `double` declarations on monetary fields, then ZERO
+violations exist anywhere in `lib/features/reminders/**` or
+`functions/src/send-reminder-notification/**`. The new client-side
+grep at `test/features/reminders/reminders_boundary_contract_test.dart`
+is the affirmative client-side gate; the existing Functions-side
+grep at `functions/test/boundary-contracts/no-double-on-money-fields.test.ts`
+auto-covers the new server files.
+
+**AC-21 — Invariant 2 negative guard.** Given the PR diff, when
+scanned, then ZERO new writes to `simplifiedBalances` exist
+anywhere. The callable READS the field for the precondition check
+(via `db.collection('friendships').doc(contextId).get()`); the
+rate-limit write goes to `_rateLimits/{senderUid}/sends/{recipientUid}`
+and the activity write goes to `activity/{recipientUid}/items/{auto}`
+— neither touches `simplifiedBalances`.
+
+**AC-22 — `notificationPrefs.reminder` is read-only on the server
+side.** Given the prefs-filter consults `notificationPrefs.reminder`,
+when the callable runs, then NO write to `notificationPrefs`
+occurs anywhere on the server side. The client-side FR-PR-03
+notification-preferences UI (separate PR) is the ONLY write path
+for the field.
+
+## Out of Scope
+
+These are explicitly EXCLUDED to keep PR #54 surgical:
+
+- **FR-PR-03 / FR-AC-04 notification-preferences UI** — separate P1
+  story; lives on the Profile screen. The server-side prefs-filter
+  shipped in PR #53; FR-SE-09 just CONSUMES it.
+- **Group-context reminder producer** — Sprint 3 groups epic. The
+  callable accepts `contextType: 'group'` as a forward-compat input
+  but throws `GROUP_CONTEXT_NOT_SUPPORTED` today (AC-12).
+- **Free-text message-compose dialog** — follow-up UX PR. The
+  callable accepts an optional `message?: string` (max 500 chars)
+  but the client v1.0 always omits it; the server defaults to a
+  hardcoded copy ("This is a friendly reminder!" — architect
+  ratifies the exact copy in `notifications.md §6.1` follow-up).
+- **OBTSettleUpCard extraction to `lib/core/widgets/cards/`** —
+  deferred until a second host needs it (PR #43 §2.6 precedent
+  stands; mirror of `OBTAmountInput`).
+- **Persistent client cooldown via `shared_preferences`** — pairs
+  with the deferred PR #53 §2.6 `shared_preferences` adoption. v1.0
+  cooldown is in-memory only; the server is the authoritative gate.
+- **Sender-side activity emission** — recipient-only per architect
+  §2.3. A future UX-research-driven PR may add sender-side activity
+  if needed.
+- **SCR-11 overflow-menu reminder action** — the OBTSettleUpCard is
+  the primary surface; overflow-menu placement is a deferred UX
+  consideration.
+
+## Test Strategy
+
+- **Functions unit tests** (Jest, no emulator):
+  - `functions/test/send-reminder-notification/function.test.ts` —
+    24+ cases covering ACs 1-12 + 19 + 21 + 22 (auth, input
+    validation, non-member, recipient-doesn't-owe, rate-limit
+    pre-check rejection + post-window pass, prefs-filter,
+    no-tokens, full-failure non-record, group-context forward-compat
+    error, happy-path rate-limit doc shape, happy-path FCM call
+    shape, happy-path activity emission, PII-hashing of structured
+    logs, no `simplifiedBalances` writes, no `notificationPrefs`
+    writes).
+  - `functions/test/notifications/send-reminder-notification.test.ts`
+    — helper-level unit tests mirroring the existing two helper test
+    files (prefs short-circuit; empty-tokens short-circuit;
+    missing-user log; happy-path FCM dispatch call shape).
+  - `functions/test/triggers/on-expense-write/activity-validator.test.ts`
+    — extended with `'reminder'` event-type validator coverage
+    (positive shape; per-field negative branches for `senderUid`,
+    `recipientUid`, `contextType`, `contextId`, `amountPaise`,
+    `message`).
+- **Flutter unit tests** (no emulator):
+  - `test/features/reminders/data/reminder_repository_test.dart` —
+    callable wrapper success / per-error-code branches.
+  - `test/features/reminders/application/send_reminder_controller_test.dart`
+    — controller drives success → cooldown set; per-error-code →
+    snackbar message + telemetry event.
+  - `test/features/reminders/application/reminder_cooldown_provider_test.dart`
+    — provider holds per-friendship `DateTime?`; resets on app
+    launch (provider container disposal).
+- **Flutter widget tests:**
+  - `test/features/friends/presentation/widgets/obt_settle_up_card_test.dart`
+    (NEW) — settling-direction renders "Settle Up"; receiving-
+    direction renders "Send Reminder"; receiving-direction disabled
+    during cooldown with caption; tap fires `onSendReminder`.
+  - `test/features/friends/friend_detail_screen_widget_test.dart`
+    (EXTEND) — `BalanceState.owed` branch renders receiving-direction
+    OBTSettleUpCard; tap routes through the controller.
+- **Boundary-contract grep:**
+  - `test/features/reminders/reminders_boundary_contract_test.dart`
+    — Inv-1 (no float arithmetic) + Inv-2 (no `simplifiedBalances`
+    write) guards over `lib/features/reminders/**`. Plus a
+    file-existence guard so the recursive walks have something to
+    walk.
+- **Integration tests:** extended with a reminder-callable round-trip
+  (mocked FCM at the SDK boundary; rate-limit doc verified to be
+  written; activity-feed doc verified to be written).
+- **Manual smoke:** the QA matrix in §5 below covers cross-device
+  send + rate-limit enforcement + prefs-filter + no-tokens + race-
+  condition coverage.
+
+## Telemetry Contract (FR-SE-09 v1.0)
+
+**Server (structured logs, via `functions/logger`):**
+
+| Event | Trigger | Parameters |
+|---|---|---|
+| `reminder_send_attempted` | Every callable invocation, before validation | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash` |
+| `reminder_send_succeeded` | After successful FCM dispatch + rate-limit + activity writes | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash`, `succeeded`, `failed`, `pruned` (count only) |
+| `reminder_send_rate_limited` | Pre-check rejection within 24h window | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash`, `nextAllowedAtIso` |
+| `reminder_send_skipped_by_prefs` | Prefs-filter rejection | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash` |
+| `reminder_send_failed_no_tokens` | Empty `fcmTokens` rejection | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash` |
+| `reminder_send_recipient_doesnt_owe` | `simplifiedBalances` precondition rejection | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash` |
+| `reminder_send_failed` | Any other catch-all error | `senderUidHash`, `recipientUidHash`, `contextType`, `contextIdHash`, `errorCode` |
+
+**Client (Firebase Analytics, via `analyticsServiceProvider`):**
+
+| Event | Trigger | Parameters |
+|---|---|---|
+| `reminder_send_tapped` | OBTSettleUpCard `onSendReminder` fired | `friendship_id_hash` |
+| `reminder_send_succeeded` | Callable returned success | `friendship_id_hash` |
+| `reminder_send_rate_limited` | Callable returned RATE_LIMITED | `friendship_id_hash`, `next_allowed_in_seconds` |
+| `reminder_send_recipient_prefs_disabled` | Callable returned RECIPIENT_PREFS_DISABLED | `friendship_id_hash` |
+| `reminder_send_recipient_no_tokens` | Callable returned RECIPIENT_NO_TOKENS | `friendship_id_hash` |
+| `reminder_send_recipient_doesnt_owe` | Callable returned RECIPIENT_DOESNT_OWE | `friendship_id_hash` |
+| `reminder_send_failed` | Network / unknown / FCM_DISPATCH_FAILED | `friendship_id_hash`, `error_code` |
+
+PII guard (ADR-0013): every UID-derived parameter on the server side
+goes through `hashId()`; every friendship-id-derived parameter on
+the client side goes through `hashFriendshipId()`; FCM tokens use
+`fingerprintToken()` (FR-AC-03 precedent); the optional reminder
+`message` body is NEVER logged.
+
+## Invariant Compliance
+
+| Invariant | Applicability | How enforced |
+|---|---|---|
+| 1 — paise integers | Applicable on the `amountPaise` carry-through path | The callable reads `simplifiedBalances[recipientUid][senderUid]` as `int`, passes it unchanged to `renderPayload('reminder', { amountPaise, ... })`, which uses the Functions-side `format-inr.ts` helper for the body string. ZERO inline `/100` arithmetic anywhere in `functions/src/send-reminder-notification/**` or `lib/features/reminders/**`. Existing Functions-side grep + new client-side grep enforce. |
+| 2 — `simplifiedBalances` server-only | Applicable as a NEGATIVE guard | The callable READS `simplifiedBalances` for the precondition check; ZERO new writers. Client-side reminders module never references the field (boundary-contract grep enforces). |
+| 3 — system share sheet | N/A | Reminders use FCM push, not the share sheet. |
+| 4 — single Firebase project | Defence-in-depth re-check | `.firebaserc` unchanged; FCM admin SDK uses the same `firebase-admin/app` initialisation. |
+
+## Definition of Done
+
+- All 22 ACs satisfied with passing tests.
+- Story (this file) + Architect Notes appended.
+- `dart format --set-exit-if-changed .` exits 0.
+- `flutter analyze --fatal-infos` exits 0; `flutter test` 1083 + ~30
+  new = ~1113 tests pass.
+- `cd functions && npm run lint && npm run build && npm test` exits
+  0; ~270 + ~30 new = ~300 tests pass across ~22 suites.
+- `cd functions && npm run test:rules` exits 0 (188 / 9 suites
+  unchanged).
+- `cd functions && npm run test:integration` extended with the new
+  reminder round-trip; passes.
+- `docs/sprint-zero/sprint-2-plan.md` rolled forward with the PR
+  #54 row (6 SP; cumulative 79 SP / 18 PRs).
+- `docs/sprint-zero/next-three-prs.md` rolled forward (PR #55 TBD;
+  top candidate FR-PR-03 + FR-AC-04 notification-preferences UI).
+- `docs/audits/sprint-1/07-bucket-b-burndown.md` PR #54 entry
+  appended (no items closed; partial PY3 progress).
+- DoD checklist §7 invariant compliance verified in PR body.
+
+## GitHub Issue This Story Closes
+
+**None.** FR-SE-09 is a P1 SRS row; no separate GitHub issue exists.
+The story is the source of truth.

--- a/docs/sprint-zero/stories/FR-SE-09-send-reminder.md
+++ b/docs/sprint-zero/stories/FR-SE-09-send-reminder.md
@@ -483,3 +483,351 @@ the client side goes through `hashFriendshipId()`; FCM tokens use
 
 **None.** FR-SE-09 is a P1 SRS row; no separate GitHub issue exists.
 The story is the source of truth.
+
+---
+
+## Architect Notes
+
+> Appended by the architect agent at Phase 2 of the PR #54 protocol.
+> These notes RATIFY the design calls flagged in the orchestrator's
+> brief and pin the surface area for the Functions-dev + Flutter-dev
+> implementations that follow.
+
+### 2.1 Rate-limit doc path
+
+**RATIFY:** `_rateLimits/{senderUid}/sends/{recipientUid}` (5-segment
+path). Schema:
+
+```typescript
+interface RateLimitSendDoc {
+  lastSentAt: Timestamp;       // serverTimestamp on write
+  count: number;               // monotonic counter (FieldValue.increment(1))
+  windowStart: number;         // ms epoch of the first send in the
+                               // current rolling window
+  recipientUid: string;        // denormalised for queryability
+  senderUid: string;           // denormalised for queryability
+  updatedAt: Timestamp;        // serverTimestamp on write
+}
+```
+
+The path extends the architect-canonical
+`_rateLimits/{userId}/{category}/{key-or-counter}` container ratified
+in the PR #45 chore (§2.1 / §2.9 of
+`CHORE-pr45-lookup-rate-limit-and-pr38-cleanup.md`). The recipient
+UID replaces the literal `counter` doc-ID in the 4-segment lookup
+variant because reminders are per-pair, not per-sender. The existing
+`firestore.rules:355` deny-all block (`match
+/_rateLimits/{document=**}`) already covers the new path — no rules
+diff is required.
+
+The legacy `reminders/{senderUid}_{toUserId}` shape documented in
+`cloud-functions-catalogue.md §7` is SUPERSEDED by this 5-segment
+path. The catalogue is documentation, not source-of-truth; a
+docs-roll-up PR may update the catalogue post-merge (not in scope
+here per §2.10 below).
+
+### 2.2 FCM dispatch helper placement
+
+**RATIFY:** Add `functions/src/notifications/send-reminder-notification.ts`
+mirroring `send-expense-notification.ts` /
+`send-settlement-notification.ts`. The helper composes:
+
+1. `db.collection('users').doc(toUserId).get()` for prefs + tokens.
+2. `isNotificationAllowed('reminder', prefs)` short-circuit (returns
+   suppressed-by-prefs branch).
+3. `tokens.length === 0` short-circuit (returns empty-tokens branch).
+4. `renderPayload('reminder', { senderName, amountPaise, contextType,
+   contextId, createdAt })`.
+5. `sendFcmToTokens(deps, { userId: toUserId, notificationType:
+   'reminder', tokens, payload })`.
+
+The helper returns the standard `NotificationDispatchResult`. It
+does NOT throw — the callable wraps each branch decision and maps to
+its typed `HttpsError` codes itself. (Unlike the trigger-side
+callers, the callable WANTS to distinguish "prefs disabled" from
+"no tokens" from "delivery failed" — so the callable consumes the
+result's tally fields directly and the helper is a pure dispatch
+leaf, not a decision-maker.)
+
+Extend `notifications/index.ts` with `export
+{sendReminderNotification} from "./send-reminder-notification"` and
+`notifications/types.ts` with `SendReminderNotificationParams`
+interface mirroring `SendSettlementNotificationParams`:
+
+```typescript
+export interface SendReminderNotificationParams {
+  fromUserId: string;          // sender — for log correlation; NOT a recipient
+  toUserId: string;            // recipient
+  contextType: 'friendship' | 'group';
+  contextId: string;
+  senderName: string;          // resolved displayName of the sender
+  amountPaise: number;         // OWED amount per simplifiedBalances
+  eventTimestamp: Date;        // server-side now()
+}
+```
+
+Extend `NotificationsApi` with:
+
+```typescript
+sendReminderNotification(
+  deps: NotificationsDependencies,
+  params: SendReminderNotificationParams,
+): Promise<NotificationDispatchResult>;
+```
+
+### 2.3 Activity-feed emission target
+
+**RATIFY:** Recipient-only emission. The reminder is delivered to
+the recipient via FCM; the in-app activity row at
+`activity/{recipientUid}/items/{auto-id}` is the recipient's record
+of receipt. The sender's confirmation is the optimistic-disable
+button state on the OBTSettleUpCard receiving-direction variant
+(via `reminderCooldownProvider`).
+
+A future UX-research-driven PR may add sender-side activity emission
+("you sent a reminder to {friend}") if user research shows senders
+want a paper-trail. v1.0 keeps the surface minimal.
+
+### 2.4 Validator extension scope
+
+**RATIFY:** The `activity-validator.ts` extension for the
+`'reminder'` event-type ships in this PR — it's a small,
+backward-compatible extension and ships alongside the only producer
+that needs it. The reminder activity payload shape:
+
+```typescript
+export interface ReminderPayload {
+  senderUid: string;
+  recipientUid: string;
+  contextType: 'friendship' | 'group';
+  contextId: string;
+  amountPaise: number;         // positive integer paise
+  message?: string;            // optional free-text (max 500 chars)
+}
+```
+
+Add to `payload-builder.ts`:
+
+- Extend `ActivityItemType` discriminated union with `'reminder'`.
+- Export `ReminderPayload` interface.
+- Add `'reminder'` to `ActivityPayload` discriminated union.
+
+Add to `activity-validator.ts`:
+
+- Add `case 'reminder':` branch to the `validateActivityPayload`
+  switch.
+- New `validateReminderPayload(payload)` function asserting:
+  - `senderUid`, `recipientUid`, `contextType`, `contextId` are
+    non-empty strings.
+  - `contextType ∈ {'friendship', 'group'}`.
+  - `amountPaise` is a positive integer.
+  - `message`, when present, is a string of length ≤ 500.
+
+Existing activity items remain valid (no breaking change).
+
+The `writeExpenseActivity` writer name is misleading post-PR #52 (it
+now writes settlement and reminder activities too) but the rename
+remains DEFERRED per FR-AC-01 architect §2.3 — outside the scope of
+this PR.
+
+### 2.5 Default vs custom message + rate-limit-on-failure
+
+**RATIFY default message:** The callable accepts an optional
+`message?: string` (max 500 chars) but the client v1.0 always omits
+it; the server defaults to `"This is a friendly reminder!"` when
+`message` is absent. The message-compose dialog is deferred to a
+follow-up UX PR.
+
+The default message is currently NOT embedded in the FCM body
+string (the body string is templated from the renderer:
+`{senderName} is nudging you about ₹{amount}.`); the `message`
+field is propagated through to the activity-feed payload only.
+That keeps the FCM body deterministic and the user-customisation
+surface contained to the in-app row.
+
+**RATIFY rate-limit-on-failure:** Record the rate-limit document on
+`succeeded >= 1` (i.e. at least one FCM `send()` resolved). If
+every token 410-pruned, the dispatch is a "no-op send" and the
+sender's quota is NOT consumed — they can retry later if the
+recipient enables push. The callable throws
+`HttpsError('unavailable', ...)` with
+`details.errorCode === 'FCM_DISPATCH_FAILED'` in this case (AC-11).
+
+### 2.6 Client cooldown persistence
+
+**RATIFY in-memory only.** The cooldown is a Riverpod
+`StateProvider.family<DateTime?, String>` keyed by `friendshipId`.
+It RESETS on app launch (provider container disposal). The server
+is the authoritative gate per `notifications.md §6.1`; the client
+provider is a best-effort UX optimisation.
+
+A future PR (paired with the `shared_preferences` adoption deferred
+from PR #53 §2.6) may persist the cooldown across launches. Out of
+scope here.
+
+### 2.7 OBTSettleUpCard extension
+
+**RATIFY in-place extension.** Add three new parameters:
+
+```dart
+const OBTSettleUpCard({
+  required this.payerDisplayName,
+  required this.payerPhotoUrl,
+  required this.payeeDisplayName,
+  required this.payeePhotoUrl,
+  required this.suggestedAmountPaise,
+  required this.onSettleUp,
+  this.isReceivingDirection = false,
+  this.onSendReminder,
+  this.nextAllowedAt,
+  super.key,
+});
+```
+
+Semantics:
+
+- `isReceivingDirection: false` (default) — settling-direction
+  (existing). CTA reads "Settle Up"; tapping fires `onSettleUp`.
+- `isReceivingDirection: true` — receiving-direction. CTA reads
+  "Send Reminder"; tapping fires `onSendReminder` (which MUST be
+  provided when `isReceivingDirection: true`). The avatar arrow
+  semantic label flips from "pays" to "owes". When `nextAllowedAt`
+  is in the future, the button is disabled with a caption like
+  "Next reminder in {h}h {m}m" (live countdown).
+
+The existing settling-direction call site
+(`FriendDetailScreen` `BalanceState.owes` branch) is unaffected — it
+omits the new parameters and gets the existing behaviour.
+
+Extraction of the widget to `lib/core/widgets/cards/` remains
+DEFERRED until a second host needs it (PR #43 §2.6 ratification
+stands; precedent: `OBTAmountInput` extraction landed in PR #38 only
+when the FR-SE-05 settle-up sheet became the second host).
+
+### 2.8 Files to touch (exhaustive)
+
+Anything outside this set is scope creep. New files marked NEW;
+extended files marked EXTEND.
+
+**Functions side (server):**
+
+- NEW `functions/src/send-reminder-notification/index.ts` — `onCall`
+  wrapper, region-pinned to `asia-south1`.
+- NEW `functions/src/send-reminder-notification/function.ts` — handler
+  factory `createSendReminderHandler(deps)` returning the async
+  handler. Validates inputs, throws typed `HttpsError` codes,
+  orchestrates the flow per §1 of the orchestrator's brief.
+- NEW `functions/src/notifications/send-reminder-notification.ts` —
+  FCM dispatch helper per §2.2.
+- EXTEND `functions/src/notifications/index.ts` — re-export
+  `sendReminderNotification`.
+- EXTEND `functions/src/notifications/types.ts` —
+  `SendReminderNotificationParams` interface;
+  `NotificationsApi.sendReminderNotification` method signature.
+- EXTEND `functions/src/triggers/on-expense-write/payload-builder.ts`
+  — extend `ActivityItemType` with `'reminder'`; export
+  `ReminderPayload` interface; extend `ActivityPayload` union.
+- EXTEND `functions/src/triggers/on-expense-write/activity-validator.ts`
+  — `case 'reminder':` branch + `validateReminderPayload`.
+- EXTEND `functions/src/index.ts` — re-export
+  `sendReminderNotification`.
+
+**Functions side (tests):**
+
+- NEW `functions/test/send-reminder-notification/function.test.ts` —
+  24+ cases per the AC matrix.
+- NEW `functions/test/notifications/send-reminder-notification.test.ts`
+  — helper-level unit tests mirroring the existing two helper test
+  files.
+- EXTEND `functions/test/triggers/on-expense-write/activity-validator.test.ts`
+  — `'reminder'` event-type coverage.
+
+**Flutter side (client):**
+
+- NEW `lib/features/reminders/data/reminder_repository.dart` —
+  callable wrapper; `CloudFunctionException` → typed result.
+- NEW `lib/features/reminders/domain/reminder_send_error.dart` — sealed
+  hierarchy mirroring the server typed-error codes.
+- NEW `lib/features/reminders/domain/reminder_send_success.dart` —
+  `{ nextAllowedAt: DateTime }`.
+- NEW `lib/features/reminders/application/send_reminder_controller.dart`
+  — Riverpod `Notifier<SendReminderState>` driving in-progress /
+  success / error states; emits the client telemetry events per §3.
+- NEW `lib/features/reminders/application/reminder_cooldown_provider.dart`
+  — `StateProvider.family<DateTime?, String>` per §2.6.
+- NEW `lib/features/reminders/application/reminder_telemetry.dart` —
+  event-name + parameter-key constants (mirror of
+  `settle_up_telemetry.dart`).
+- EXTEND `lib/features/friends/presentation/widgets/obt_settle_up_card.dart`
+  — three new parameters per §2.7.
+- EXTEND `lib/features/friends/presentation/friend_detail_screen.dart`
+  — `BalanceState.owed` branch wires the receiving-direction card.
+
+**Flutter side (tests):**
+
+- NEW `test/features/reminders/data/reminder_repository_test.dart`
+- NEW `test/features/reminders/application/send_reminder_controller_test.dart`
+- NEW `test/features/reminders/application/reminder_cooldown_provider_test.dart`
+- NEW `test/features/friends/presentation/widgets/obt_settle_up_card_test.dart`
+  (the file does not exist today — the FR-FR-04 widget was shipped
+  without its own dedicated test file; both directional variants
+  ship together here).
+- EXTEND `test/features/friends/friend_detail_screen_widget_test.dart`
+  — `BalanceState.owed` branch coverage.
+- NEW `test/features/reminders/reminders_boundary_contract_test.dart`
+  — mirror of `test/features/notifications/notifications_boundary_contract_test.dart`.
+
+**Docs:**
+
+- NEW `docs/sprint-zero/stories/FR-SE-09-send-reminder.md` (this file).
+- EXTEND `docs/sprint-zero/sprint-2-plan.md` — PR #54 row.
+- EXTEND `docs/sprint-zero/next-three-prs.md` — PR #54 merged; PR
+  #55 candidates.
+- EXTEND `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #54
+  entry.
+
+### 2.9 Files explicitly NOT to touch
+
+- `firestore.rules` — UNCHANGED (existing `_rateLimits/{document=**}`
+  deny-all already covers the new path).
+- `firestore.indexes.json` — UNCHANGED.
+- `storage.rules` — UNCHANGED.
+- `pubspec.yaml`, `functions/package.json` — UNCHANGED.
+- `lib/features/expenses/**`, `lib/features/settlements/**`,
+  `lib/features/activity/**`, `lib/features/notifications/**` (the
+  FR-AC-03 surface stays stable) — UNCHANGED.
+- `functions/src/triggers/**` (the PR #51/52/53 trigger wiring is
+  stable) — UNCHANGED except for `payload-builder.ts` +
+  `activity-validator.ts` per §2.4.
+- `functions/src/notifications/{fcm-send,payload-renderer,prefs-filter,send-expense-notification,send-settlement-notification}.ts`
+  — UNCHANGED. `index.ts` + `types.ts` touched only for the new
+  exports per §2.2.
+- `.github/workflows/*.yml` — UNCHANGED.
+- `docs/design/**` — read-only references; no spec updates in this
+  PR (a docs roll-up PR may follow per §2.10).
+
+### 2.10 Anticipated reconciliations
+
+1. `cloud-functions-catalogue.md §7` storage path
+   `reminders/{senderUid}_{toUserId}` is OBSOLETED by the
+   architect-canonical `_rateLimits/{senderUid}/sends/{recipientUid}`
+   path. The catalogue is documentation, not source-of-truth; the
+   architect notes here are the canonical record. A docs roll-up PR
+   may update the catalogue post-merge.
+2. `cloud-functions-catalogue.md §7` says the `RECIPIENT_NO_TOKENS`
+   case "returns `success: true`"; the architect-ratified contract
+   here throws `HttpsError('failed-precondition')` with
+   `RECIPIENT_NO_TOKENS` so the client can show a friendly snackbar
+   (AC-17). Same docs-roll-up PR addresses this.
+3. The default-message copy `"This is a friendly reminder!"` is
+   architect-ratifiable; UX may revise in a future PR.
+4. Group-context support is forward-compat-stub-only in v1.0; Sprint
+   3 groups epic ratifies the full path.
+5. The optimistic-disable UI does not survive app restart in v1.0;
+   future `shared_preferences` adoption (deferred from PR #53) may
+   persist.
+6. The free-text message-compose dialog is deferred to a follow-up
+   UX PR.
+7. `writeExpenseActivity` is the misnamed-but-canonical writer
+   (handles expense + settlement + reminder activities now); the
+   rename remains DEFERRED per FR-AC-01 architect §2.3.

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/src", "<rootDir>/test/simplified-debts", "<rootDir>/test/lookup-user-by-phone-number", "<rootDir>/test/triggers", "<rootDir>/test/utils", "<rootDir>/test/boundary-contracts", "<rootDir>/test/notifications"],
+  roots: ["<rootDir>/src", "<rootDir>/test/simplified-debts", "<rootDir>/test/lookup-user-by-phone-number", "<rootDir>/test/send-reminder-notification", "<rootDir>/test/triggers", "<rootDir>/test/utils", "<rootDir>/test/boundary-contracts", "<rootDir>/test/notifications"],
   testMatch: ["**/*.test.ts"],
   testPathIgnorePatterns: ["\\.integration\\.test\\.ts$"],
   moduleFileExtensions: ["ts", "js", "json"],

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,6 +34,14 @@ export {recomputeSimplifiedBalances} from "./simplified-debts/index";
 // Lookup user by phone number callable
 export {lookupUserByPhoneNumber} from "./lookup-user-by-phone-number/index";
 
+// FR-SE-09 send-reminder callable. First downstream consumer of the
+// FR-AC-03 FCM module via a callable Cloud Function path. Reads
+// simplifiedBalances for the precondition check (Invariant 2: read-
+// only); writes to `_rateLimits/{senderUid}/sends/{recipientUid}` for
+// the per-friend 24-hour rate limit and to `activity/{recipientUid}/
+// items/{auto}` for the in-app activity row.
+export {sendReminderNotification} from "./send-reminder-notification/index";
+
 // Firestore trigger: recompute simplifiedBalances when an expense is
 // created, updated, or deleted under a friendship (FR-SE-03/04).
 // First non-callable producer of simplifiedBalances (Invariant 2).

--- a/functions/src/notifications/index.ts
+++ b/functions/src/notifications/index.ts
@@ -15,6 +15,7 @@
 
 export {sendExpenseNotification} from "./send-expense-notification";
 export {sendSettlementNotification} from "./send-settlement-notification";
+export {sendReminderNotification} from "./send-reminder-notification";
 export type {
   NotificationsApi,
   NotificationsDependencies,
@@ -24,4 +25,5 @@ export type {
   RecipientPrefs,
   SendExpenseNotificationParams,
   SendSettlementNotificationParams,
+  SendReminderNotificationParams,
 } from "./types";

--- a/functions/src/notifications/send-reminder-notification.ts
+++ b/functions/src/notifications/send-reminder-notification.ts
@@ -1,0 +1,139 @@
+/**
+ * Callable-facing dispatcher for FR-SE-09 reminder FCM notifications.
+ *
+ * Mirrors `send-settlement-notification.ts` with a SINGLE recipient
+ * (`toUserId` — the friend who owes the sender). The sender
+ * (`fromUserId`) is the actor and is NOT notified.
+ *
+ * The helper composes:
+ *
+ *   1. Reads `users/{toUserId}` once.
+ *   2. Runs the prefs-filter (gated by the `reminder` flag).
+ *   3. Empty-tokens short-circuit.
+ *   4. Renders the `reminder` payload.
+ *   5. Calls `sendFcmToTokens` if the token list is non-empty.
+ *
+ * Unlike the trigger-side callers, the FR-SE-09 callable WANTS to
+ * distinguish "prefs disabled" from "no tokens" from "delivery
+ * failed" — so this helper returns the `NotificationDispatchResult`
+ * tally unchanged and the caller maps it to its typed `HttpsError`
+ * codes itself (see `functions/src/send-reminder-notification/function.ts`).
+ *
+ * The helper does NOT throw on dispatch failure; the caller decides
+ * the policy.
+ *
+ * @module notifications/send-reminder-notification
+ */
+
+import {hashId} from "../utils/id-hash";
+import {renderPayload} from "./payload-renderer";
+import {isNotificationAllowed} from "./prefs-filter";
+import {sendFcmToTokens} from "./fcm-send";
+import type {
+  NotificationDispatchResult,
+  NotificationsDependencies,
+  RecipientPrefs,
+  SendReminderNotificationParams,
+} from "./types";
+
+/**
+ * Dispatches a reminder notification to the recipient (toUserId).
+ *
+ * @param deps - DI dependencies (db, messaging, logger).
+ * @param params - Reminder parameters; only `toUserId` is used as
+ *   recipient (the sender `fromUserId` is NOT notified).
+ * @returns Dispatch result with counts ≤ token-count.
+ */
+export async function sendReminderNotification(
+  deps: NotificationsDependencies,
+  params: SendReminderNotificationParams,
+): Promise<NotificationDispatchResult> {
+  const {db, logger} = deps;
+  const {
+    toUserId,
+    contextType,
+    contextId,
+    senderName,
+    amountPaise,
+    eventTimestamp,
+  } = params;
+
+  const notificationType = "reminder" as const;
+  const userIdHash = hashId(toUserId);
+
+  const totals: NotificationDispatchResult = {
+    succeeded: 0,
+    failed: 0,
+    pruned: [],
+    suppressedByPrefs: 0,
+    skippedEmptyTokens: 0,
+    skippedMissingUser: 0,
+  };
+
+  let userSnap: FirebaseFirestore.DocumentSnapshot;
+  try {
+    userSnap = await db.collection("users").doc(toUserId).get();
+  } catch (err) {
+    logger.warn("fcm_send_user_read_failed", {
+      event: "fcm_send_user_read_failed",
+      userIdHash,
+      notificationType,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
+    return totals;
+  }
+
+  if (!userSnap.exists) {
+    logger.info("fcm_send_skipped_missing_user", {
+      event: "fcm_send_skipped_missing_user",
+      userIdHash,
+      notificationType,
+    });
+    totals.skippedMissingUser += 1;
+    return totals;
+  }
+
+  const userData = userSnap.data() as Record<string, unknown> | undefined;
+  const prefs = userData?.notificationPrefs as RecipientPrefs | undefined;
+  const tokens = (userData?.fcmTokens as string[] | undefined) ?? [];
+
+  if (!isNotificationAllowed(notificationType, prefs)) {
+    logger.info("fcm_send_suppressed_by_prefs", {
+      event: "fcm_send_suppressed_by_prefs",
+      userIdHash,
+      notificationType,
+    });
+    totals.suppressedByPrefs += 1;
+    return totals;
+  }
+
+  if (tokens.length === 0) {
+    logger.info("fcm_send_skipped_empty_tokens", {
+      event: "fcm_send_skipped_empty_tokens",
+      userIdHash,
+      notificationType,
+    });
+    totals.skippedEmptyTokens += 1;
+    return totals;
+  }
+
+  const payload = renderPayload(notificationType, {
+    senderName,
+    amountPaise,
+    contextType,
+    contextId,
+    createdAt: eventTimestamp,
+  });
+
+  const sendResult = await sendFcmToTokens(deps, {
+    userId: toUserId,
+    notificationType,
+    tokens,
+    payload,
+  });
+
+  totals.succeeded += sendResult.succeeded;
+  totals.failed += sendResult.failed;
+  totals.pruned = totals.pruned.concat(sendResult.pruned);
+  return totals;
+}

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -169,6 +169,28 @@ export interface SendSettlementNotificationParams {
 }
 
 /**
+ * Parameters for `sendReminderNotification` (FR-SE-09). Only one
+ * recipient (`toUserId`); the sender (`fromUserId`) is the actor and
+ * is NOT notified. The `amountPaise` is the OWED amount per
+ * `simplifiedBalances[toUserId][fromUserId]` (resolved by the
+ * callable's precondition check before invoking this helper).
+ */
+export interface SendReminderNotificationParams {
+  /** Sender UID — for log correlation. NOT a recipient. */
+  fromUserId: string;
+  /** Recipient UID — the friend who owes the sender. */
+  toUserId: string;
+  contextType: "friendship" | "group";
+  contextId: string;
+  /** Resolved displayName of the sender (fromUserId). */
+  senderName: string;
+  /** Integer paise the recipient owes the sender. */
+  amountPaise: number;
+  /** Server-side `now()` at the time the callable fires. */
+  eventTimestamp: Date;
+}
+
+/**
  * Aggregated result of an FCM dispatch. Per-recipient counts are
  * tallied across the multi-recipient expense case; the settlement
  * helper produces a result with counts ≤ 1.
@@ -202,5 +224,9 @@ export interface NotificationsApi {
   sendSettlementNotification(
     deps: NotificationsDependencies,
     params: SendSettlementNotificationParams,
+  ): Promise<NotificationDispatchResult>;
+  sendReminderNotification(
+    deps: NotificationsDependencies,
+    params: SendReminderNotificationParams,
   ): Promise<NotificationDispatchResult>;
 }

--- a/functions/src/send-reminder-notification/function.ts
+++ b/functions/src/send-reminder-notification/function.ts
@@ -1,0 +1,527 @@
+/**
+ * FR-SE-09 Send Reminder — Callable Handler Boundary.
+ *
+ * HTTPS Callable that allows an authenticated user to send a reminder
+ * push notification to a friend who owes them money, rate-limited to
+ * one reminder per friend per 24 hours (SRS §4.6).
+ *
+ * Handler flow:
+ *
+ *   1. Auth check (UNAUTHENTICATED).
+ *   2. Input validation (INVALID_INPUT).
+ *   3. Group-context forward-compat short-circuit
+ *      (GROUP_CONTEXT_NOT_SUPPORTED).
+ *   4. Friendship doc read + membership check (NOT_A_MEMBER).
+ *   5. simplifiedBalances precondition: recipient must owe sender
+ *      (RECIPIENT_DOESNT_OWE). Invariant 1: amountPaise carried as
+ *      int; no inline /100 anywhere.
+ *   6. Rate-limit pre-check against
+ *      _rateLimits/{senderUid}/sends/{recipientUid}
+ *      (RATE_LIMITED with nextAllowedAtIso).
+ *   7. Recipient user-doc read for displayName + prefs gate
+ *      (RECIPIENT_PREFS_DISABLED) + token presence check
+ *      (RECIPIENT_NO_TOKENS).
+ *   8. Sender displayName read (for FCM body string).
+ *   9. FCM dispatch via the injected sendReminderFcm helper.
+ *  10. Full-failure check (FCM_DISPATCH_FAILED — rate-limit NOT
+ *      recorded per architect §2.5).
+ *  11. Rate-limit document write (on succeeded >= 1).
+ *  12. Activity-feed emission to recipient ONLY (architect §2.3).
+ *  13. Return { success: true, nextAllowedAtIso }.
+ *
+ * Invariant compliance:
+ *   - Inv-1 (paise integer): amountPaise read as int from
+ *     simplifiedBalances[recipientUid][senderUid], passed unchanged
+ *     through the FCM helper to renderPayload('reminder', ...). Zero
+ *     /100 arithmetic.
+ *   - Inv-2 (simplifiedBalances server-only): the callable READS the
+ *     field for the precondition check; ZERO new writers. Rate-limit
+ *     and activity writes go to _rateLimits/* and activity/*.
+ *
+ * Structured-log events (PII-hashed via hashId per ADR-0013):
+ *   - reminder_send_attempted
+ *   - reminder_send_succeeded
+ *   - reminder_send_rate_limited
+ *   - reminder_send_skipped_by_prefs
+ *   - reminder_send_failed_no_tokens
+ *   - reminder_send_recipient_doesnt_owe
+ *   - reminder_send_failed
+ *
+ * Error codes follow docs/design/07-technical/cloud-functions-error-codes.md.
+ *
+ * @module send-reminder-notification/function
+ */
+
+import {HttpsError} from "firebase-functions/v2/https";
+import {FieldValue, Timestamp} from "firebase-admin/firestore";
+import {hashId} from "../utils/id-hash";
+import {validateActivityPayload} from
+  "../triggers/on-expense-write/activity-validator";
+import type {ReminderPayload} from
+  "../triggers/on-expense-write/payload-builder";
+import type {
+  NotificationsDependencies,
+  NotificationDispatchResult,
+  SendReminderNotificationParams,
+} from "../notifications/types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Per-friend 24-hour rate-limit window in milliseconds. */
+const REMINDER_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Maximum length of the optional free-text reminder message. */
+const REMINDER_MESSAGE_MAX_LENGTH = 500;
+
+/**
+ * Default reminder body text (architect §2.5). v1.0 clients always
+ * omit the optional `message` field; the server stores this default
+ * on the activity-feed item so the recipient sees a friendly note.
+ */
+const REMINDER_DEFAULT_MESSAGE = "This is a friendly reminder!";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Shape of the input data for the callable. */
+export interface SendReminderInput {
+  toUserId: string;
+  contextType: "friendship" | "group";
+  contextId: string;
+  message?: string;
+}
+
+/** Shape of the successful callable response. */
+export interface SendReminderResponse {
+  success: true;
+  nextAllowedAtIso: string;
+}
+
+/**
+ * FCM dispatch leaf injected for testability. Production wires to
+ * `sendReminderNotification` from `../notifications`; tests inject a
+ * jest.fn() that returns a scripted NotificationDispatchResult.
+ */
+export type SendReminderFcm = (
+  deps: NotificationsDependencies,
+  params: SendReminderNotificationParams,
+) => Promise<NotificationDispatchResult>;
+
+/** Dependencies injected into the handler for testability. */
+export interface SendReminderFunctionDeps {
+  db: FirebaseFirestore.Firestore;
+  logger: {
+    info: (message: string, data?: Record<string, unknown>) => void;
+    warn: (message: string, data?: Record<string, unknown>) => void;
+    error: (message: string, data?: Record<string, unknown>) => void;
+  };
+  /** FCM dispatch helper from `../notifications`. */
+  sendReminderFcm: SendReminderFcm;
+  /** Optional Messaging instance — wired in production via the onCall index. */
+  messaging?: import("firebase-admin/messaging").Messaging;
+  /** Clock injection for deterministic tests. */
+  now: () => Date;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface RateLimitDocData {
+  lastSentAt: Timestamp | {toMillis(): number};
+  count?: number;
+  windowStart?: number;
+  recipientUid?: string;
+  senderUid?: string;
+}
+
+function readLastSentMs(data: unknown): number {
+  if (data === null || typeof data !== "object") return 0;
+  const lastSentAt = (data as RateLimitDocData).lastSentAt as
+    | {toMillis?: () => number}
+    | undefined;
+  if (
+    lastSentAt &&
+    typeof lastSentAt === "object" &&
+    typeof lastSentAt.toMillis === "function"
+  ) {
+    return lastSentAt.toMillis();
+  }
+  return 0;
+}
+
+function throwInvalidInput(message: string): never {
+  throw new HttpsError("invalid-argument", message, {
+    errorCode: "INVALID_INPUT",
+  });
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the HTTPS Callable handler with injected dependencies.
+ */
+export function createSendReminderHandler(
+  deps: SendReminderFunctionDeps,
+): (
+  data: unknown,
+  context: {auth?: {uid: string}},
+) => Promise<SendReminderResponse> {
+  const {db, logger, sendReminderFcm, messaging, now} = deps;
+
+  return async (
+    data: unknown,
+    context: {auth?: {uid: string}},
+  ): Promise<SendReminderResponse> => {
+    // 1. Auth check
+    const senderUid = context.auth?.uid;
+    if (!senderUid) {
+      throw new HttpsError("unauthenticated", "Authentication required.", {
+        errorCode: "UNAUTHENTICATED",
+      });
+    }
+
+    // 2. Input validation
+    const obj = (data ?? {}) as Record<string, unknown>;
+    const toUserId = obj.toUserId;
+    const contextType = obj.contextType;
+    const contextId = obj.contextId;
+    const messageRaw = obj.message;
+
+    if (!isNonEmptyString(toUserId)) {
+      throwInvalidInput("toUserId must be a non-empty string.");
+    }
+    if (contextType !== "friendship" && contextType !== "group") {
+      throwInvalidInput("contextType must be 'friendship' or 'group'.");
+    }
+    if (!isNonEmptyString(contextId)) {
+      throwInvalidInput("contextId must be a non-empty string.");
+    }
+    let message: string | undefined;
+    if (messageRaw !== undefined) {
+      if (typeof messageRaw !== "string") {
+        throwInvalidInput("message, when present, must be a string.");
+      }
+      if ((messageRaw as string).length > REMINDER_MESSAGE_MAX_LENGTH) {
+        throwInvalidInput(
+          `message length must be \u2264 ${REMINDER_MESSAGE_MAX_LENGTH} chars.`,
+        );
+      }
+      message = messageRaw as string;
+    }
+
+    const senderUidHash = hashId(senderUid);
+    const recipientUidHash = hashId(toUserId as string);
+    const contextIdHash = hashId(contextId as string);
+
+    logger.info("reminder_send_attempted", {
+      event: "reminder_send_attempted",
+      senderUidHash,
+      recipientUidHash,
+      contextType,
+      contextIdHash,
+    });
+
+    // 3. Group-context forward-compat short-circuit
+    if (contextType === "group") {
+      logger.warn("reminder_send_failed", {
+        event: "reminder_send_failed",
+        senderUidHash,
+        recipientUidHash,
+        contextType,
+        contextIdHash,
+        errorCode: "GROUP_CONTEXT_NOT_SUPPORTED",
+      });
+      throw new HttpsError(
+        "unimplemented",
+        "Reminders for group contexts are not supported in v1.0.",
+        {errorCode: "GROUP_CONTEXT_NOT_SUPPORTED"},
+      );
+    }
+
+    try {
+      // 4. Friendship doc read + membership check
+      const friendshipSnap = await db
+        .collection("friendships")
+        .doc(contextId as string)
+        .get();
+
+      if (!friendshipSnap.exists) {
+        logger.warn("reminder_send_failed", {
+          event: "reminder_send_failed",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+          errorCode: "NOT_A_MEMBER",
+        });
+        throw new HttpsError(
+          "permission-denied",
+          "Caller is not a member of the requested context.",
+          {errorCode: "NOT_A_MEMBER"},
+        );
+      }
+
+      const friendshipData = friendshipSnap.data() as
+        | Record<string, unknown>
+        | undefined;
+      const memberIds = (friendshipData?.memberIds as string[] | undefined) ??
+        [];
+      if (!memberIds.includes(senderUid)) {
+        logger.warn("reminder_send_failed", {
+          event: "reminder_send_failed",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+          errorCode: "NOT_A_MEMBER",
+        });
+        throw new HttpsError(
+          "permission-denied",
+          "Caller is not a member of the requested context.",
+          {errorCode: "NOT_A_MEMBER"},
+        );
+      }
+
+      // 5. simplifiedBalances precondition
+      // Shape: { [debtorUid]: { [creditorUid]: paiseAmount } }.
+      // Valid IFF simplifiedBalances[recipientUid][senderUid] > 0.
+      const simplifiedBalances = (friendshipData?.simplifiedBalances as
+        | Record<string, Record<string, number> | undefined>
+        | undefined) ?? {};
+      const owedRow = simplifiedBalances[toUserId as string];
+      const owedPaise = owedRow ? owedRow[senderUid] : undefined;
+
+      if (
+        typeof owedPaise !== "number" ||
+        !Number.isInteger(owedPaise) ||
+        owedPaise <= 0
+      ) {
+        logger.info("reminder_send_recipient_doesnt_owe", {
+          event: "reminder_send_recipient_doesnt_owe",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+        });
+        throw new HttpsError(
+          "failed-precondition",
+          "The recipient does not owe you in this context.",
+          {errorCode: "RECIPIENT_DOESNT_OWE"},
+        );
+      }
+
+      // 6. Rate-limit pre-check
+      const rateLimitPath =
+        `_rateLimits/${senderUid}/sends/${toUserId as string}`;
+      const rateLimitRef = db.doc(rateLimitPath);
+      const rateLimitSnap = await rateLimitRef.get();
+      const nowDate = now();
+      const nowMs = nowDate.getTime();
+
+      if (rateLimitSnap.exists) {
+        const rlData = rateLimitSnap.data();
+        const lastSentMs = readLastSentMs(rlData);
+        if (lastSentMs > 0 && nowMs - lastSentMs < REMINDER_WINDOW_MS) {
+          const nextAllowedAtIso = new Date(
+            lastSentMs + REMINDER_WINDOW_MS,
+          ).toISOString();
+          logger.info("reminder_send_rate_limited", {
+            event: "reminder_send_rate_limited",
+            senderUidHash,
+            recipientUidHash,
+            contextType,
+            contextIdHash,
+            nextAllowedAtIso,
+          });
+          throw new HttpsError(
+            "resource-exhausted",
+            "You can send another reminder after the cooldown.",
+            {errorCode: "RATE_LIMITED", nextAllowedAtIso},
+          );
+        }
+      }
+
+      // 7. Recipient user-doc read
+      const recipientSnap = await db
+        .collection("users")
+        .doc(toUserId as string)
+        .get();
+
+      if (!recipientSnap.exists) {
+        logger.warn("reminder_send_failed_no_tokens", {
+          event: "reminder_send_failed_no_tokens",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+        });
+        throw new HttpsError(
+          "failed-precondition",
+          "Recipient has not enabled push notifications.",
+          {errorCode: "RECIPIENT_NO_TOKENS"},
+        );
+      }
+
+      const recipientData = recipientSnap.data() as
+        | Record<string, unknown>
+        | undefined;
+      const prefs = (recipientData?.notificationPrefs as
+        | Record<string, boolean | undefined>
+        | undefined);
+      const reminderAllowed = prefs?.reminder !== false;
+      if (!reminderAllowed) {
+        logger.info("reminder_send_skipped_by_prefs", {
+          event: "reminder_send_skipped_by_prefs",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+        });
+        throw new HttpsError(
+          "failed-precondition",
+          "Recipient has notifications turned off.",
+          {errorCode: "RECIPIENT_PREFS_DISABLED"},
+        );
+      }
+
+      const tokens =
+        (recipientData?.fcmTokens as string[] | undefined) ?? [];
+      if (tokens.length === 0) {
+        logger.info("reminder_send_failed_no_tokens", {
+          event: "reminder_send_failed_no_tokens",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+        });
+        throw new HttpsError(
+          "failed-precondition",
+          "Recipient has not enabled push notifications.",
+          {errorCode: "RECIPIENT_NO_TOKENS"},
+        );
+      }
+
+      // 8. Sender displayName read (for FCM body string)
+      const senderSnap = await db.collection("users").doc(senderUid).get();
+      const senderData = senderSnap.exists ?
+        (senderSnap.data() as Record<string, unknown> | undefined) :
+        undefined;
+      const senderName =
+        (senderData?.displayName as string | undefined) ?? "A friend";
+
+      // 9. FCM dispatch — Invariant 1: amountPaise carried as int
+      const dispatchResult = await sendReminderFcm(
+        {db, logger, messaging: messaging as never},
+        {
+          fromUserId: senderUid,
+          toUserId: toUserId as string,
+          contextType: "friendship",
+          contextId: contextId as string,
+          senderName,
+          amountPaise: owedPaise,
+          eventTimestamp: nowDate,
+        },
+      );
+
+      // 10. Full-failure check (architect §2.5)
+      if (dispatchResult.succeeded < 1) {
+        logger.error("reminder_send_failed", {
+          event: "reminder_send_failed",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+          errorCode: "FCM_DISPATCH_FAILED",
+          failed: dispatchResult.failed,
+          pruned: dispatchResult.pruned.length,
+        });
+        throw new HttpsError(
+          "unavailable",
+          "Reminder could not be delivered to the recipient's device(s).",
+          {errorCode: "FCM_DISPATCH_FAILED"},
+        );
+      }
+
+      // 11. Rate-limit document write
+      const windowStart =
+        (rateLimitSnap.exists &&
+          typeof rateLimitSnap.data()?.windowStart === "number") ?
+          (rateLimitSnap.data()!.windowStart as number) :
+          nowMs;
+
+      await rateLimitRef.set({
+        lastSentAt: Timestamp.fromDate(nowDate),
+        count: rateLimitSnap.exists ? FieldValue.increment(1) : 1,
+        windowStart,
+        recipientUid: toUserId as string,
+        senderUid,
+        updatedAt: Timestamp.fromDate(nowDate),
+      });
+
+      // 12. Activity-feed emission (recipient-only)
+      const reminderPayload: ReminderPayload = {
+        senderUid,
+        recipientUid: toUserId as string,
+        contextType: "friendship",
+        contextId: contextId as string,
+        amountPaise: owedPaise,
+        message: message ?? REMINDER_DEFAULT_MESSAGE,
+      };
+      validateActivityPayload("reminder", reminderPayload);
+
+      await db
+        .collection("activity")
+        .doc(toUserId as string)
+        .collection("items")
+        .add({
+          type: "reminder",
+          payload: reminderPayload,
+          createdAt: FieldValue.serverTimestamp(),
+        });
+
+      const nextAllowedAtIso = new Date(
+        nowMs + REMINDER_WINDOW_MS,
+      ).toISOString();
+
+      logger.info("reminder_send_succeeded", {
+        event: "reminder_send_succeeded",
+        senderUidHash,
+        recipientUidHash,
+        contextType,
+        contextIdHash,
+        succeeded: dispatchResult.succeeded,
+        failed: dispatchResult.failed,
+        pruned: dispatchResult.pruned.length,
+        ...(message !== undefined ? {messageLength: message.length} : {}),
+      });
+
+      return {success: true, nextAllowedAtIso};
+    } catch (err: unknown) {
+      if (err instanceof HttpsError) {
+        throw err;
+      }
+      logger.error("reminder_send_failed", {
+        event: "reminder_send_failed",
+        senderUidHash,
+        recipientUidHash,
+        contextType,
+        contextIdHash,
+        errorCode: "INTERNAL",
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+      throw new HttpsError("internal", "Internal error.", {
+        errorCode: "INTERNAL",
+      });
+    }
+  };
+}

--- a/functions/src/send-reminder-notification/function.ts
+++ b/functions/src/send-reminder-notification/function.ts
@@ -54,16 +54,19 @@
 
 import {HttpsError} from "firebase-functions/v2/https";
 import {FieldValue, Timestamp} from "firebase-admin/firestore";
+import type {Messaging} from "firebase-admin/messaging";
 import {hashId} from "../utils/id-hash";
 import {validateActivityPayload} from
   "../triggers/on-expense-write/activity-validator";
 import type {ReminderPayload} from
   "../triggers/on-expense-write/payload-builder";
-import type {
-  NotificationsDependencies,
-  NotificationDispatchResult,
-  SendReminderNotificationParams,
-} from "../notifications/types";
+import {renderPayload} from "../notifications/payload-renderer";
+import {
+  sendFcmToTokens,
+  type SendFcmParams,
+  type SendFcmResult,
+} from "../notifications/fcm-send";
+import type {NotificationsDependencies} from "../notifications/types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -101,14 +104,21 @@ export interface SendReminderResponse {
 }
 
 /**
- * FCM dispatch leaf injected for testability. Production wires to
- * `sendReminderNotification` from `../notifications`; tests inject a
- * jest.fn() that returns a scripted NotificationDispatchResult.
+ * Low-level FCM dispatch leaf injected for testability. Production
+ * defaults to `sendFcmToTokens` from `../notifications/fcm-send`;
+ * tests inject a jest.fn() that returns a scripted [SendFcmResult].
+ *
+ * The callable performs its own user-doc read for the typed
+ * RECIPIENT_PREFS_DISABLED / RECIPIENT_NO_TOKENS branches, so the
+ * high-level `notifications/send-reminder-notification.ts` helper
+ * (which re-reads the same doc) is intentionally NOT used here.
+ * Direct use of [sendFcmToTokens] eliminates the duplicate
+ * `users/{toUserId}` read on the happy path.
  */
-export type SendReminderFcm = (
+export type SendFcm = (
   deps: NotificationsDependencies,
-  params: SendReminderNotificationParams,
-) => Promise<NotificationDispatchResult>;
+  params: SendFcmParams,
+) => Promise<SendFcmResult>;
 
 /** Dependencies injected into the handler for testability. */
 export interface SendReminderFunctionDeps {
@@ -118,10 +128,19 @@ export interface SendReminderFunctionDeps {
     warn: (message: string, data?: Record<string, unknown>) => void;
     error: (message: string, data?: Record<string, unknown>) => void;
   };
-  /** FCM dispatch helper from `../notifications`. */
-  sendReminderFcm: SendReminderFcm;
-  /** Optional Messaging instance — wired in production via the onCall index. */
-  messaging?: import("firebase-admin/messaging").Messaging;
+  /**
+   * Admin SDK [Messaging] instance, required by [sendFcmToTokens]
+   * for the per-token `messaging.send(...)` calls. Wired in
+   * production via `getMessaging()` in the onCall index; tests
+   * pass a stub.
+   */
+  messaging: Messaging;
+  /**
+   * FCM dispatch leaf. Defaults to [sendFcmToTokens] when omitted —
+   * specify only in tests that need to assert dispatch call shape
+   * or simulate dispatch failures.
+   */
+  sendFcm?: SendFcm;
   /** Clock injection for deterministic tests. */
   now: () => Date;
 }
@@ -176,7 +195,8 @@ export function createSendReminderHandler(
   data: unknown,
   context: {auth?: {uid: string}},
 ) => Promise<SendReminderResponse> {
-  const {db, logger, sendReminderFcm, messaging, now} = deps;
+  const {db, logger, messaging, now} = deps;
+  const dispatch: SendFcm = deps.sendFcm ?? sendFcmToTokens;
 
   return async (
     data: unknown,
@@ -419,17 +439,31 @@ export function createSendReminderHandler(
       const senderName =
         (senderData?.displayName as string | undefined) ?? "A friend";
 
-      // 9. FCM dispatch — Invariant 1: amountPaise carried as int
-      const dispatchResult = await sendReminderFcm(
-        {db, logger, messaging: messaging as never},
+      // 9. Render + dispatch.
+      //
+      // Invariant 1: amountPaise carried as int through renderPayload
+      // (which formats via the Functions-side format-inr.ts helper).
+      //
+      // Calls the low-level FCM leaf directly rather than the
+      // high-level `notifications/send-reminder-notification.ts`
+      // helper — the helper would re-read `users/{toUserId}` to do
+      // its own prefs + tokens checks, but we already did both above
+      // (with typed HttpsError branches). Direct dispatch eliminates
+      // the duplicate read.
+      const payload = renderPayload("reminder", {
+        senderName,
+        amountPaise: owedPaise,
+        contextType: "friendship",
+        contextId: contextId as string,
+        createdAt: nowDate,
+      });
+      const dispatchResult = await dispatch(
+        {db, logger, messaging},
         {
-          fromUserId: senderUid,
-          toUserId: toUserId as string,
-          contextType: "friendship",
-          contextId: contextId as string,
-          senderName,
-          amountPaise: owedPaise,
-          eventTimestamp: nowDate,
+          userId: toUserId as string,
+          notificationType: "reminder",
+          tokens,
+          payload,
         },
       );
 
@@ -452,11 +486,21 @@ export function createSendReminderHandler(
         );
       }
 
-      // 11. Rate-limit document write
+      // 11. Rate-limit document write.
+      //
+      // The `windowStart` field marks the start of the CURRENT 24h
+      // rolling window. v1.0 enforces one send per window, so on a
+      // successful send the window always restarts — but if the
+      // existing windowStart is still within the current window
+      // (forward-compat: a future multi-send-per-window policy),
+      // preserve it; otherwise reset to nowMs.
+      const existingWindowStart = rateLimitSnap.exists ?
+        (rateLimitSnap.data()?.windowStart as number | undefined) :
+        undefined;
       const windowStart =
-        (rateLimitSnap.exists &&
-          typeof rateLimitSnap.data()?.windowStart === "number") ?
-          (rateLimitSnap.data()!.windowStart as number) :
+        typeof existingWindowStart === "number" &&
+        nowMs - existingWindowStart < REMINDER_WINDOW_MS ?
+          existingWindowStart :
           nowMs;
 
       await rateLimitRef.set({
@@ -468,7 +512,13 @@ export function createSendReminderHandler(
         updatedAt: Timestamp.fromDate(nowDate),
       });
 
-      // 12. Activity-feed emission (recipient-only)
+      // 12. Activity-feed emission (recipient-only).
+      //
+      // Fire-and-forget: the FCM push has already landed and the
+      // rate-limit doc is recorded — if the activity write fails
+      // (e.g. transient Firestore unavailability), the sender's
+      // success path should NOT be flipped to INTERNAL because the
+      // recipient already received the reminder. Log + swallow.
       const reminderPayload: ReminderPayload = {
         senderUid,
         recipientUid: toUserId as string,
@@ -479,15 +529,28 @@ export function createSendReminderHandler(
       };
       validateActivityPayload("reminder", reminderPayload);
 
-      await db
-        .collection("activity")
-        .doc(toUserId as string)
-        .collection("items")
-        .add({
-          type: "reminder",
-          payload: reminderPayload,
-          createdAt: FieldValue.serverTimestamp(),
+      try {
+        await db
+          .collection("activity")
+          .doc(toUserId as string)
+          .collection("items")
+          .add({
+            type: "reminder",
+            payload: reminderPayload,
+            createdAt: FieldValue.serverTimestamp(),
+          });
+      } catch (activityErr) {
+        logger.warn("reminder_activity_write_failed", {
+          event: "reminder_activity_write_failed",
+          senderUidHash,
+          recipientUidHash,
+          contextType,
+          contextIdHash,
+          errorMessage: activityErr instanceof Error ?
+            activityErr.message :
+            String(activityErr),
         });
+      }
 
       const nextAllowedAtIso = new Date(
         nowMs + REMINDER_WINDOW_MS,

--- a/functions/src/send-reminder-notification/index.ts
+++ b/functions/src/send-reminder-notification/index.ts
@@ -1,0 +1,48 @@
+/**
+ * FR-SE-09 Send Reminder — Module Index
+ *
+ * Exports the `sendReminderNotification` HTTPS Callable Cloud
+ * Function. Region-pinned to asia-south1 (Mumbai) per SRS section
+ * 7.1.
+ *
+ * @module send-reminder-notification
+ */
+
+import {onCall} from "firebase-functions/v2/https";
+import {getFirestore} from "firebase-admin/firestore";
+import {getMessaging} from "firebase-admin/messaging";
+import * as logger from "firebase-functions/logger";
+import {sendReminderNotification as sendReminderFcm} from "../notifications";
+import {createSendReminderHandler} from "./function";
+
+const REGION = "asia-south1";
+
+/**
+ * HTTPS Callable Cloud Function that sends a reminder push
+ * notification to a friend who owes the caller money.
+ *
+ * Input: `SendReminderInput` — `{ toUserId, contextType, contextId,
+ *   message? }`.
+ *
+ * Output: `SendReminderResponse` — `{ success: true, nextAllowedAtIso }`.
+ *
+ * Error codes: UNAUTHENTICATED, INVALID_INPUT, NOT_A_MEMBER,
+ *   RECIPIENT_DOESNT_OWE, RATE_LIMITED, RECIPIENT_PREFS_DISABLED,
+ *   RECIPIENT_NO_TOKENS, FCM_DISPATCH_FAILED,
+ *   GROUP_CONTEXT_NOT_SUPPORTED, INTERNAL.
+ */
+export const sendReminderNotification = onCall(
+  {region: REGION},
+  async (request) => {
+    const handler = createSendReminderHandler({
+      db: getFirestore(),
+      logger,
+      sendReminderFcm,
+      messaging: getMessaging(),
+      now: () => new Date(),
+    });
+    return handler(request.data, {
+      auth: request.auth ? {uid: request.auth.uid} : undefined,
+    });
+  },
+);

--- a/functions/src/send-reminder-notification/index.ts
+++ b/functions/src/send-reminder-notification/index.ts
@@ -12,7 +12,6 @@ import {onCall} from "firebase-functions/v2/https";
 import {getFirestore} from "firebase-admin/firestore";
 import {getMessaging} from "firebase-admin/messaging";
 import * as logger from "firebase-functions/logger";
-import {sendReminderNotification as sendReminderFcm} from "../notifications";
 import {createSendReminderHandler} from "./function";
 
 const REGION = "asia-south1";
@@ -37,8 +36,8 @@ export const sendReminderNotification = onCall(
     const handler = createSendReminderHandler({
       db: getFirestore(),
       logger,
-      sendReminderFcm,
       messaging: getMessaging(),
+      // sendFcm defaults to sendFcmToTokens from ../notifications/fcm-send
       now: () => new Date(),
     });
     return handler(request.data, {

--- a/functions/src/triggers/on-expense-write/activity-validator.ts
+++ b/functions/src/triggers/on-expense-write/activity-validator.ts
@@ -20,6 +20,7 @@ import type {
   ExpenseAddedPayload,
   ExpenseDeletedPayload,
   ExpenseEditedPayload,
+  ReminderPayload,
   SettlementPayload,
 } from "./payload-builder";
 
@@ -55,6 +56,9 @@ export function validateActivityPayload(
       return;
     case "settlement":
       validateSettlementPayload(payload as SettlementPayload);
+      return;
+    case "reminder":
+      validateReminderPayload(payload as ReminderPayload);
       return;
     default: {
       const _exhaustive: never = eventType;
@@ -217,6 +221,73 @@ function validateSettlementPayload(payload: SettlementPayload): void {
       "validateActivityPayload: settlement.note, when present, must be " +
         "a string.",
     );
+  }
+}
+
+/**
+ * Validates a `reminder` payload (FR-SE-09 architect §2.4). Required
+ * fields: senderUid, recipientUid, contextType, contextId, amountPaise.
+ * The `message` field is optional (max 500 chars).
+ */
+function validateReminderPayload(payload: ReminderPayload): void {
+  assertHasFields("reminder", payload, [
+    "senderUid",
+    "recipientUid",
+    "contextType",
+    "contextId",
+    "amountPaise",
+  ] as const);
+
+  if (typeof payload.senderUid !== "string" || payload.senderUid.length === 0) {
+    throw new Error(
+      "validateActivityPayload: reminder.senderUid must be a " +
+        "non-empty string.",
+    );
+  }
+  if (
+    typeof payload.recipientUid !== "string" ||
+    payload.recipientUid.length === 0
+  ) {
+    throw new Error(
+      "validateActivityPayload: reminder.recipientUid must be a " +
+        "non-empty string.",
+    );
+  }
+  if (payload.contextType !== "friendship" && payload.contextType !== "group") {
+    throw new Error(
+      "validateActivityPayload: reminder.contextType must be 'friendship' " +
+        "or 'group'.",
+    );
+  }
+  if (typeof payload.contextId !== "string" || payload.contextId.length === 0) {
+    throw new Error(
+      "validateActivityPayload: reminder.contextId must be a " +
+        "non-empty string.",
+    );
+  }
+  if (
+    typeof payload.amountPaise !== "number" ||
+    !Number.isInteger(payload.amountPaise) ||
+    payload.amountPaise <= 0
+  ) {
+    throw new Error(
+      "validateActivityPayload: reminder.amountPaise must be a positive " +
+        "integer.",
+    );
+  }
+  if (payload.message !== undefined) {
+    if (typeof payload.message !== "string") {
+      throw new Error(
+        "validateActivityPayload: reminder.message, when present, must be " +
+          "a string.",
+      );
+    }
+    if (payload.message.length > 500) {
+      throw new Error(
+        "validateActivityPayload: reminder.message length must be ≤ 500 " +
+          "characters.",
+      );
+    }
   }
 }
 

--- a/functions/src/triggers/on-expense-write/index.ts
+++ b/functions/src/triggers/on-expense-write/index.ts
@@ -30,6 +30,7 @@ import {createTriggerHandler} from "./function";
 import {
   sendExpenseNotification,
   sendSettlementNotification,
+  sendReminderNotification,
 } from "../../notifications";
 
 const REGION = "asia-south1";
@@ -74,6 +75,7 @@ export const onExpenseWriteFriendship = onDocumentWritten(
       notificationsApi: {
         sendExpenseNotification,
         sendSettlementNotification,
+        sendReminderNotification,
       },
       messaging: getMessaging(),
     });

--- a/functions/src/triggers/on-expense-write/payload-builder.ts
+++ b/functions/src/triggers/on-expense-write/payload-builder.ts
@@ -32,7 +32,8 @@ export type ActivityItemType =
   | "expense_added"
   | "expense_edited"
   | "expense_deleted"
-  | "settlement";
+  | "settlement"
+  | "reminder";
 
 /** Trigger change discriminator (mirrors `function.ts` `ChangeType`). */
 export type ChangeType = "create" | "update" | "delete";
@@ -105,12 +106,29 @@ export interface SettlementPayload {
   authorUid: string;
 }
 
+/**
+ * `reminder` payload — emitted by the FR-SE-09 sendReminderNotification
+ * callable (architect §2.4). The `message` field is the optional
+ * free-text composed by the sender (max 500 chars); v1.0 always
+ * omits it on the client side and the callable defaults to a
+ * hardcoded copy.
+ */
+export interface ReminderPayload {
+  senderUid: string;
+  recipientUid: string;
+  contextType: "friendship" | "group";
+  contextId: string;
+  amountPaise: number;
+  message?: string;
+}
+
 /** Discriminated union of every payload shape this builder emits. */
 export type ActivityPayload =
   | ExpenseAddedPayload
   | ExpenseEditedPayload
   | ExpenseDeletedPayload
-  | SettlementPayload;
+  | SettlementPayload
+  | ReminderPayload;
 
 /** Result tuple of `buildExpenseActivityPayload`. */
 export interface BuiltActivityPayload {

--- a/functions/src/triggers/on-settlement-write/index.ts
+++ b/functions/src/triggers/on-settlement-write/index.ts
@@ -35,6 +35,7 @@ import {createTriggerHandler} from "./function";
 import {
   sendExpenseNotification,
   sendSettlementNotification,
+  sendReminderNotification,
 } from "../../notifications";
 
 const REGION = "asia-south1";
@@ -81,6 +82,7 @@ export const onSettlementWrite = onDocumentWritten(
       notificationsApi: {
         sendExpenseNotification,
         sendSettlementNotification,
+        sendReminderNotification,
       },
       messaging: getMessaging(),
     });

--- a/functions/test/notifications/send-reminder-notification.test.ts
+++ b/functions/test/notifications/send-reminder-notification.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for the FCM-dispatch helper used by the FR-SE-09 send-
+ * reminder callable.
+ *
+ * Mirrors `send-settlement-notification.test.ts` (single-recipient
+ * shape). The helper composes user-doc read → prefs-filter →
+ * empty-tokens short-circuit → `renderPayload('reminder', ...)` →
+ * `sendFcmToTokens`. Like the other two helpers, it does NOT throw —
+ * the callable consumes the typed `NotificationDispatchResult` tally
+ * and maps to its own `HttpsError` codes.
+ *
+ * @module test/notifications/send-reminder-notification.test.ts
+ */
+
+import {sendReminderNotification} from
+  "../../src/notifications/send-reminder-notification";
+import {sendFcmToTokens} from "../../src/notifications/fcm-send";
+
+jest.mock("../../src/notifications/fcm-send", () => {
+  const actual = jest.requireActual("../../src/notifications/fcm-send");
+  return {
+    ...actual,
+    sendFcmToTokens: jest.fn().mockResolvedValue({
+      succeeded: 1,
+      failed: 0,
+      pruned: [],
+    }),
+  };
+});
+
+const mockedSendFcmToTokens = sendFcmToTokens as jest.MockedFunction<
+  typeof sendFcmToTokens
+>;
+
+beforeEach(() => {
+  mockedSendFcmToTokens.mockClear();
+  mockedSendFcmToTokens.mockResolvedValue({
+    succeeded: 1,
+    failed: 0,
+    pruned: [],
+  });
+});
+
+interface LoggerCall {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "warn", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+function createMockDb(
+  users: Record<string, Record<string, unknown> | null>,
+): FirebaseFirestore.Firestore {
+  const docFn = jest.fn((userId: string) => ({
+    get: jest.fn().mockResolvedValue({
+      exists: users[userId] !== undefined && users[userId] !== null,
+      data: () => users[userId] ?? undefined,
+      id: userId,
+    }),
+  }));
+  return {
+    collection: jest.fn().mockReturnValue({doc: docFn}),
+  } as unknown as FirebaseFirestore.Firestore;
+}
+
+function createMockMessaging() {
+  return {} as unknown as import("firebase-admin/messaging").Messaging;
+}
+
+const baseParams = {
+  fromUserId: "uid-sender",
+  toUserId: "uid-recipient",
+  contextType: "friendship" as const,
+  contextId: "uid-sender_uid-recipient",
+  senderName: "Avtansh",
+  amountPaise: 50000,
+  eventTimestamp: new Date("2026-06-08T10:00:00Z"),
+};
+
+describe("sendReminderNotification — FR-SE-09 FCM helper", () => {
+  it("dispatches reminder to recipient when prefs allow and tokens non-empty",
+    async () => {
+      const db = createMockDb({
+        "uid-recipient": {
+          fcmTokens: ["tokRec1", "tokRec2"],
+          notificationPrefs: {
+            newExpense: true,
+            settlement: true,
+            reminder: true,
+          },
+        },
+      });
+      const logger = createMockLogger();
+
+      const result = await sendReminderNotification(
+        {db, logger, messaging: createMockMessaging()},
+        baseParams,
+      );
+
+      expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+      const callArgs = mockedSendFcmToTokens.mock.calls[0][1];
+      expect(callArgs.userId).toBe("uid-recipient");
+      expect(callArgs.tokens).toEqual(["tokRec1", "tokRec2"]);
+      expect(callArgs.notificationType).toBe("reminder");
+      expect(callArgs.payload.title).toBe("Reminder from Avtansh");
+      expect(callArgs.payload.body).toBe(
+        "Avtansh is nudging you about \u20B9500.",
+      );
+      expect(result.succeeded).toBe(1);
+    });
+
+  it("does NOT read or send to the sender (fromUserId — the actor)", async () => {
+    const db = createMockDb({
+      "uid-sender": {
+        fcmTokens: ["tokSender"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+      "uid-recipient": {
+        fcmTokens: ["tokRec"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    await sendReminderNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    expect(mockedSendFcmToTokens.mock.calls[0][1].userId).toBe("uid-recipient");
+  });
+
+  it("suppresses send when reminder=false (logs fcm_send_suppressed_by_prefs)",
+    async () => {
+      const db = createMockDb({
+        "uid-recipient": {
+          fcmTokens: ["tokRec"],
+          notificationPrefs: {
+            newExpense: true,
+            settlement: true,
+            reminder: false,
+          },
+        },
+      });
+      const logger = createMockLogger();
+
+      const result = await sendReminderNotification(
+        {db, logger, messaging: createMockMessaging()},
+        baseParams,
+      );
+
+      expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+      expect(result.suppressedByPrefs).toBe(1);
+      const suppressedLog = logger.calls.find(
+        (c) => c.data?.event === "fcm_send_suppressed_by_prefs",
+      );
+      expect(suppressedLog).toBeDefined();
+      expect(suppressedLog!.data!.notificationType).toBe("reminder");
+    });
+
+  it("logs fcm_send_skipped_empty_tokens when recipient has no tokens",
+    async () => {
+      const db = createMockDb({
+        "uid-recipient": {
+          fcmTokens: [],
+          notificationPrefs: {
+            newExpense: true,
+            settlement: true,
+            reminder: true,
+          },
+        },
+      });
+      const logger = createMockLogger();
+
+      const result = await sendReminderNotification(
+        {db, logger, messaging: createMockMessaging()},
+        baseParams,
+      );
+
+      expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+      expect(result.skippedEmptyTokens).toBe(1);
+      const skipLog = logger.calls.find(
+        (c) => c.data?.event === "fcm_send_skipped_empty_tokens",
+      );
+      expect(skipLog).toBeDefined();
+    });
+
+  it("logs fcm_send_skipped_missing_user when recipient doc does not exist",
+    async () => {
+      const db = createMockDb({});
+      const logger = createMockLogger();
+
+      const result = await sendReminderNotification(
+        {db, logger, messaging: createMockMessaging()},
+        baseParams,
+      );
+
+      expect(mockedSendFcmToTokens).not.toHaveBeenCalled();
+      expect(result.skippedMissingUser).toBe(1);
+      const skipLog = logger.calls.find(
+        (c) => c.data?.event === "fcm_send_skipped_missing_user",
+      );
+      expect(skipLog).toBeDefined();
+    });
+
+  it("defaults to reminder=true when notificationPrefs map is absent",
+    async () => {
+      const db = createMockDb({
+        "uid-recipient": {
+          fcmTokens: ["tokRec"],
+        },
+      });
+      const logger = createMockLogger();
+
+      await sendReminderNotification(
+        {db, logger, messaging: createMockMessaging()},
+        baseParams,
+      );
+
+      expect(mockedSendFcmToTokens).toHaveBeenCalledTimes(1);
+    });
+
+  it("propagates the dispatch result counts unchanged", async () => {
+    mockedSendFcmToTokens.mockResolvedValueOnce({
+      succeeded: 2,
+      failed: 1,
+      pruned: ["tokDead"],
+    });
+    const db = createMockDb({
+      "uid-recipient": {
+        fcmTokens: ["tokA", "tokB", "tokDead"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    });
+    const logger = createMockLogger();
+
+    const result = await sendReminderNotification(
+      {db, logger, messaging: createMockMessaging()},
+      baseParams,
+    );
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.pruned).toEqual(["tokDead"]);
+  });
+
+  it("hashes the recipient userId in suppressed-by-prefs log (PII guard)",
+    async () => {
+      const db = createMockDb({
+        "uid-recipient": {
+          fcmTokens: ["tokRec"],
+          notificationPrefs: {reminder: false},
+        },
+      });
+      const logger = createMockLogger();
+
+      await sendReminderNotification(
+        {db, logger, messaging: createMockMessaging()},
+        baseParams,
+      );
+
+      const suppressed = logger.calls.find(
+        (c) => c.data?.event === "fcm_send_suppressed_by_prefs",
+      );
+      expect(suppressed).toBeDefined();
+      // Hashed userId is 16-hex-char SHA-256 prefix; raw uid must not appear.
+      const raw = JSON.stringify(suppressed!.data);
+      expect(raw).not.toContain("uid-recipient");
+      expect(suppressed!.data!.userIdHash).toMatch(/^[0-9a-f]{16}$/);
+    });
+});

--- a/functions/test/send-reminder-notification/function.test.ts
+++ b/functions/test/send-reminder-notification/function.test.ts
@@ -226,14 +226,14 @@ function createDeps(state: Partial<MockDbState> = {}): {
     succeeded: 2,
     failed: 0,
     pruned: [],
-    suppressedByPrefs: 0,
-    skippedEmptyTokens: 0,
-    skippedMissingUser: 0,
   });
+  const messaging =
+    {} as unknown as import("firebase-admin/messaging").Messaging;
   const deps: SendReminderFunctionDeps = {
     db,
     logger,
-    sendReminderFcm: fcmDispatch,
+    messaging,
+    sendFcm: fcmDispatch,
     now: () => new Date("2026-06-08T12:00:00Z"),
   };
   return {deps, logger, writes, fcmDispatch};
@@ -282,7 +282,7 @@ describe("sendReminderNotification handler — FR-SE-09", () => {
       expect(written.count).toBeDefined();
     });
 
-  it("AC-1: happy path calls sendReminderFcm with correct params", async () => {
+  it("AC-1: happy path calls dispatch with the rendered FCM payload", async () => {
     const {deps, fcmDispatch} = createDeps();
     const handler = createSendReminderHandler(deps);
 
@@ -290,13 +290,111 @@ describe("sendReminderNotification handler — FR-SE-09", () => {
 
     expect(fcmDispatch).toHaveBeenCalledTimes(1);
     const params = fcmDispatch.mock.calls[0][1];
-    expect(params.fromUserId).toBe("uid-sender");
-    expect(params.toUserId).toBe("uid-recipient");
-    expect(params.senderName).toBe("Avtansh");
-    expect(params.amountPaise).toBe(50000);
-    expect(params.contextType).toBe("friendship");
-    expect(params.contextId).toBe("uid-sender_uid-recipient");
+    // Low-level SendFcmParams: userId + notificationType + tokens + payload.
+    expect(params.userId).toBe("uid-recipient");
+    expect(params.notificationType).toBe("reminder");
+    expect(params.tokens).toEqual(["tokRec1", "tokRec2"]);
+    expect(params.payload.type).toBe("reminder");
+    expect(params.payload.title).toBe("Reminder from Avtansh");
+    expect(params.payload.body).toBe(
+      "Avtansh is nudging you about \u20B9500.",
+    );
+    expect(params.payload.contextType).toBe("friendship");
+    expect(params.payload.contextId).toBe("uid-sender_uid-recipient");
+    // amountPaise is string-encoded in the FCM data envelope.
+    expect(params.payload.amountPaise).toBe("50000");
   });
+
+  it("AC-1: dispatch reads users/{toUserId} only ONCE (no double-read)",
+    async () => {
+      // The callable does its own prefs/tokens validation; the FCM
+      // helper would have re-read the same doc when called through
+      // the high-level helper. The low-level injection point sidesteps
+      // that — assert the recipient doc is fetched at most once.
+      let recipientGets = 0;
+      const baseState: MockDbState = {
+        friendship: {
+          exists: true,
+          data: {
+            memberIds: ["uid-sender", "uid-recipient"],
+            simplifiedBalances: {"uid-recipient": {"uid-sender": 50000}},
+          },
+        },
+        sender: {exists: true, data: {displayName: "Avtansh"}},
+        recipient: {
+          exists: true,
+          data: {
+            displayName: "Priya",
+            fcmTokens: ["tokRec1"],
+            notificationPrefs: {reminder: true},
+          },
+        },
+        rateLimit: {exists: false, data: null},
+      };
+      const collectionFn = jest.fn((c: string) => {
+        if (c === "friendships") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue({
+                exists: true,
+                data: () => baseState.friendship.data,
+              }),
+            })),
+          };
+        }
+        if (c === "users") {
+          return {
+            doc: jest.fn((u: string) => ({
+              get: jest.fn().mockImplementation(() => {
+                if (u === "uid-recipient") recipientGets += 1;
+                return Promise.resolve({
+                  exists: true,
+                  data: () => u === "uid-sender" ?
+                    baseState.sender.data :
+                    baseState.recipient.data,
+                });
+              }),
+            })),
+          };
+        }
+        if (c === "activity") {
+          return {
+            doc: jest.fn(() => ({
+              collection: jest.fn(() => ({
+                add: jest.fn().mockResolvedValue({id: "a"}),
+              })),
+            })),
+          };
+        }
+        throw new Error("unexpected");
+      });
+      const docFn = jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({exists: false, data: () => undefined}),
+        set: jest.fn().mockResolvedValue(undefined),
+      }));
+      const db = {
+        collection: collectionFn,
+        doc: docFn,
+      } as unknown as FirebaseFirestore.Firestore;
+      const messaging =
+        {} as unknown as import("firebase-admin/messaging").Messaging;
+      const fcmDispatch = jest.fn().mockResolvedValue({
+        succeeded: 1,
+        failed: 0,
+        pruned: [],
+      });
+      const handler = createSendReminderHandler({
+        db,
+        logger: createMockLogger(),
+        messaging,
+        sendFcm: fcmDispatch,
+        now: () => new Date("2026-06-08T12:00:00Z"),
+      });
+
+      await handler(validInput, authContext("uid-sender"));
+
+      expect(recipientGets).toBe(1);
+    });
 
   it("AC-2: happy path emits activity item to recipient ONLY", async () => {
     const {deps, writes} = createDeps();
@@ -682,9 +780,6 @@ describe("sendReminderNotification handler — FR-SE-09", () => {
         succeeded: 0,
         failed: 2,
         pruned: ["tokRec1", "tokRec2"],
-        suppressedByPrefs: 0,
-        skippedEmptyTokens: 0,
-        skippedMissingUser: 0,
       });
       const handler = createSendReminderHandler(deps);
 
@@ -795,5 +890,138 @@ describe("sendReminderNotification handler — FR-SE-09", () => {
       );
       expect(succeeded).toBeDefined();
       expect(succeeded!.data!.messageLength).toBe(21);
+    });
+
+  // -----------------------------------------------------------------------
+  // Recommendation #3 — windowStart reset on fresh window
+  // -----------------------------------------------------------------------
+  it("resets windowStart to nowMs when the existing windowStart is > 24h old",
+    async () => {
+      const twentyFiveHoursAgoMs = new Date("2026-06-07T11:00:00Z").getTime();
+      const {deps, writes} = createDeps({
+        rateLimit: {
+          exists: true,
+          data: {
+            lastSentAt: {toMillis: () => twentyFiveHoursAgoMs},
+            count: 1,
+            windowStart: twentyFiveHoursAgoMs,
+            recipientUid: "uid-recipient",
+            senderUid: "uid-sender",
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await handler(validInput, authContext("uid-sender"));
+
+      expect(writes.rateLimitSets).toHaveLength(1);
+      const written = writes.rateLimitSets[0];
+      // Fresh window — windowStart resets to nowMs (2026-06-08T12:00:00Z).
+      expect(written.windowStart).toBe(
+        new Date("2026-06-08T12:00:00Z").getTime(),
+      );
+    });
+
+  // -----------------------------------------------------------------------
+  // Recommendation #4 — activity write failure is non-fatal
+  // -----------------------------------------------------------------------
+  it("returns success even if the activity write throws (fire-and-forget)",
+    async () => {
+      // Build a mock db where the activity .add() rejects.
+      const writes = {
+        rateLimitSets: [] as Array<Record<string, unknown>>,
+        activityAdds: [] as Array<{
+          recipient: string;
+          payload: Record<string, unknown>;
+        }>,
+      };
+      const collectionFn = jest.fn((c: string) => {
+        if (c === "friendships") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue({
+                exists: true,
+                data: () => ({
+                  memberIds: ["uid-sender", "uid-recipient"],
+                  simplifiedBalances: {
+                    "uid-recipient": {"uid-sender": 50000},
+                  },
+                }),
+              }),
+            })),
+          };
+        }
+        if (c === "users") {
+          return {
+            doc: jest.fn((u: string) => ({
+              get: jest.fn().mockResolvedValue({
+                exists: true,
+                data: () => u === "uid-sender" ?
+                  {displayName: "Avtansh"} :
+                  {
+                    displayName: "Priya",
+                    fcmTokens: ["tok1"],
+                    notificationPrefs: {reminder: true},
+                  },
+              }),
+            })),
+          };
+        }
+        if (c === "activity") {
+          return {
+            doc: jest.fn(() => ({
+              collection: jest.fn(() => ({
+                add: jest.fn().mockRejectedValue(new Error("firestore down")),
+              })),
+            })),
+          };
+        }
+        throw new Error("unexpected collection " + c);
+      });
+      const docFn = jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({
+          exists: false,
+          data: () => undefined,
+        }),
+        set: jest.fn((p: Record<string, unknown>) => {
+          writes.rateLimitSets.push(p);
+          return Promise.resolve();
+        }),
+      }));
+      const db = {
+        collection: collectionFn,
+        doc: docFn,
+      } as unknown as FirebaseFirestore.Firestore;
+      const logger = createMockLogger();
+      const messaging =
+        {} as unknown as import("firebase-admin/messaging").Messaging;
+      const fcmDispatch = jest.fn().mockResolvedValue({
+        succeeded: 1,
+        failed: 0,
+        pruned: [],
+      });
+      const handler = createSendReminderHandler({
+        db,
+        logger,
+        messaging,
+        sendFcm: fcmDispatch,
+        now: () => new Date("2026-06-08T12:00:00Z"),
+      });
+
+      const result = await handler(validInput, authContext("uid-sender"));
+
+      // Success bubbles through despite the activity-write failure.
+      expect(result.success).toBe(true);
+      expect(result.nextAllowedAtIso).toBe("2026-06-09T12:00:00.000Z");
+      // Rate-limit was still recorded.
+      expect(writes.rateLimitSets).toHaveLength(1);
+      // FCM was still dispatched.
+      expect(fcmDispatch).toHaveBeenCalledTimes(1);
+      // A warn log surfaced the activity-write failure for ops visibility.
+      const warn = logger.calls.find(
+        (c) => c.data?.event === "reminder_activity_write_failed",
+      );
+      expect(warn).toBeDefined();
+      expect(warn!.level).toBe("warn");
     });
 });

--- a/functions/test/send-reminder-notification/function.test.ts
+++ b/functions/test/send-reminder-notification/function.test.ts
@@ -1,0 +1,799 @@
+/**
+ * Function-boundary tests for the FR-SE-09 sendReminderNotification
+ * callable.
+ *
+ * Mirrors `functions/test/lookup-user-by-phone-number/function.test.ts`
+ * (DI-mocked Firestore + logger; no emulator). Exercises every AC
+ * in the FR-SE-09 contract:
+ *
+ *   - AC-1   happy path → success + rate-limit doc + FCM dispatch +
+ *            activity emission.
+ *   - AC-3   unauth → UNAUTHENTICATED.
+ *   - AC-4   malformed input → INVALID_INPUT (multiple shapes).
+ *   - AC-5   non-member → NOT_A_MEMBER.
+ *   - AC-6   recipient doesn't owe → RECIPIENT_DOESNT_OWE.
+ *   - AC-7   rate-limit within 24h window → RATE_LIMITED + nextAllowedAtIso.
+ *   - AC-8   rate-limit post-window → pass + rewrite.
+ *   - AC-9   prefs disabled → RECIPIENT_PREFS_DISABLED.
+ *   - AC-10  no tokens → RECIPIENT_NO_TOKENS.
+ *   - AC-11  full-failure dispatch → FCM_DISPATCH_FAILED + no rate-
+ *            limit write.
+ *   - AC-12  group-context → GROUP_CONTEXT_NOT_SUPPORTED.
+ *   - AC-19  structured-log PII guard.
+ *   - AC-21  no simplifiedBalances writes.
+ *   - AC-22  no notificationPrefs writes.
+ *
+ * @module test/send-reminder-notification/function.test.ts
+ */
+
+import {HttpsError} from "firebase-functions/v2/https";
+import {
+  createSendReminderHandler,
+  SendReminderFunctionDeps,
+} from "../../src/send-reminder-notification/function";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+interface LoggerCall {
+  level: "info" | "warn" | "error";
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function createMockLogger() {
+  const calls: LoggerCall[] = [];
+  return {
+    info: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "info", message, data});
+    },
+    warn: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "warn", message, data});
+    },
+    error: (message: string, data?: Record<string, unknown>) => {
+      calls.push({level: "error", message, data});
+    },
+    calls,
+  };
+}
+
+interface FriendshipDocSnapshot {
+  exists: boolean;
+  data: Record<string, unknown> | null;
+}
+
+interface UserDocSnapshot {
+  exists: boolean;
+  data: Record<string, unknown> | null;
+}
+
+interface RateLimitDocSnapshot {
+  exists: boolean;
+  data: Record<string, unknown> | null;
+}
+
+interface MockDbState {
+  friendship: FriendshipDocSnapshot;
+  sender: UserDocSnapshot;
+  recipient: UserDocSnapshot;
+  rateLimit: RateLimitDocSnapshot;
+  /** When true, the rate-limit doc write throws to simulate transient. */
+  rateLimitWriteThrows?: boolean;
+}
+
+/**
+ * Captures every Firestore write for assertions. Each entry records
+ * the doc-path string and the payload passed to set / update.
+ */
+interface CapturedWrites {
+  rateLimitSets: Array<Record<string, unknown>>;
+  activityAdds: Array<{recipient: string; payload: Record<string, unknown>}>;
+}
+
+/**
+ * Builds a mock Firestore that returns scripted snapshots for
+ *   - `friendships/{contextId}` reads,
+ *   - `users/{senderUid}` and `users/{recipientUid}` reads,
+ *   - `_rateLimits/{senderUid}/sends/{recipientUid}` reads + writes,
+ *   - `activity/{recipientUid}/items` add.
+ *
+ * The callable's exact read order and doc-paths are asserted by the
+ * tests by exercising the public callable handler and observing the
+ * resulting writes + log events; the mock supports both `.doc()` and
+ * `.collection().doc()` access patterns used by the handler.
+ */
+function createMockDb(state: MockDbState): {
+  db: FirebaseFirestore.Firestore;
+  writes: CapturedWrites;
+} {
+  const writes: CapturedWrites = {
+    rateLimitSets: [],
+    activityAdds: [],
+  };
+
+  const collectionFn = jest.fn((collectionId: string) => {
+    if (collectionId === "friendships") {
+      return {
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue({
+            exists: state.friendship.exists,
+            data: () => state.friendship.data ?? undefined,
+          }),
+        })),
+      };
+    }
+    if (collectionId === "users") {
+      return {
+        doc: jest.fn((userId: string) => {
+          const snap = userId === "uid-sender" ? state.sender :
+            state.recipient;
+          return {
+            get: jest.fn().mockResolvedValue({
+              exists: snap.exists,
+              data: () => snap.data ?? undefined,
+            }),
+          };
+        }),
+      };
+    }
+    if (collectionId === "activity") {
+      return {
+        doc: jest.fn((recipientUid: string) => ({
+          collection: jest.fn(() => ({
+            add: jest.fn((payload: Record<string, unknown>) => {
+              writes.activityAdds.push({recipient: recipientUid, payload});
+              return Promise.resolve({id: `act-${writes.activityAdds.length}`});
+            }),
+          })),
+        })),
+      };
+    }
+    throw new Error(`Mock db: unexpected collection '${collectionId}'`);
+  });
+
+  const docFn = jest.fn((docPath: string) => {
+    if (
+      docPath.startsWith("_rateLimits/") &&
+      docPath.includes("/sends/")
+    ) {
+      return {
+        get: jest.fn().mockResolvedValue({
+          exists: state.rateLimit.exists,
+          data: () => state.rateLimit.data ?? undefined,
+        }),
+        set: jest.fn((payload: Record<string, unknown>) => {
+          if (state.rateLimitWriteThrows) {
+            return Promise.reject(new Error("rate-limit write failed"));
+          }
+          writes.rateLimitSets.push(payload);
+          return Promise.resolve();
+        }),
+      };
+    }
+    throw new Error(`Mock db: unexpected doc path '${docPath}'`);
+  });
+
+  return {
+    db: {
+      collection: collectionFn,
+      doc: docFn,
+    } as unknown as FirebaseFirestore.Firestore,
+    writes,
+  };
+}
+
+function createDeps(state: Partial<MockDbState> = {}): {
+  deps: SendReminderFunctionDeps;
+  logger: ReturnType<typeof createMockLogger>;
+  writes: CapturedWrites;
+  fcmDispatch: jest.Mock;
+} {
+  const defaults: MockDbState = {
+    friendship: {
+      exists: true,
+      data: {
+        memberIds: ["uid-sender", "uid-recipient"],
+        simplifiedBalances: {
+          "uid-recipient": {"uid-sender": 50000},
+        },
+      },
+    },
+    sender: {
+      exists: true,
+      data: {
+        displayName: "Avtansh",
+      },
+    },
+    recipient: {
+      exists: true,
+      data: {
+        displayName: "Priya",
+        fcmTokens: ["tokRec1", "tokRec2"],
+        notificationPrefs: {
+          newExpense: true,
+          settlement: true,
+          reminder: true,
+        },
+      },
+    },
+    rateLimit: {exists: false, data: null},
+  };
+  const merged: MockDbState = {...defaults, ...state};
+  const {db, writes} = createMockDb(merged);
+  const logger = createMockLogger();
+  const fcmDispatch = jest.fn().mockResolvedValue({
+    succeeded: 2,
+    failed: 0,
+    pruned: [],
+    suppressedByPrefs: 0,
+    skippedEmptyTokens: 0,
+    skippedMissingUser: 0,
+  });
+  const deps: SendReminderFunctionDeps = {
+    db,
+    logger,
+    sendReminderFcm: fcmDispatch,
+    now: () => new Date("2026-06-08T12:00:00Z"),
+  };
+  return {deps, logger, writes, fcmDispatch};
+}
+
+function authContext(uid: string) {
+  return {auth: {uid}};
+}
+
+function noAuthContext() {
+  return {};
+}
+
+const validInput = {
+  toUserId: "uid-recipient",
+  contextType: "friendship" as const,
+  contextId: "uid-sender_uid-recipient",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sendReminderNotification handler — FR-SE-09", () => {
+  // -----------------------------------------------------------------------
+  // AC-1 / AC-2 — happy path
+  // -----------------------------------------------------------------------
+  it("AC-1: happy path returns nextAllowedAtIso and writes rate-limit doc",
+    async () => {
+      const {deps, writes} = createDeps();
+      const handler = createSendReminderHandler(deps);
+
+      const result = await handler(validInput, authContext("uid-sender"));
+
+      // now (mocked) is 2026-06-08T12:00:00Z; +24h is 2026-06-09T12:00:00Z
+      expect(result).toEqual({
+        success: true,
+        nextAllowedAtIso: "2026-06-09T12:00:00.000Z",
+      });
+      expect(writes.rateLimitSets).toHaveLength(1);
+      const written = writes.rateLimitSets[0];
+      expect(written.recipientUid).toBe("uid-recipient");
+      expect(written.senderUid).toBe("uid-sender");
+      expect(typeof written.lastSentAt).toBe("object");
+      expect(typeof written.windowStart).toBe("number");
+      expect(written.count).toBeDefined();
+    });
+
+  it("AC-1: happy path calls sendReminderFcm with correct params", async () => {
+    const {deps, fcmDispatch} = createDeps();
+    const handler = createSendReminderHandler(deps);
+
+    await handler(validInput, authContext("uid-sender"));
+
+    expect(fcmDispatch).toHaveBeenCalledTimes(1);
+    const params = fcmDispatch.mock.calls[0][1];
+    expect(params.fromUserId).toBe("uid-sender");
+    expect(params.toUserId).toBe("uid-recipient");
+    expect(params.senderName).toBe("Avtansh");
+    expect(params.amountPaise).toBe(50000);
+    expect(params.contextType).toBe("friendship");
+    expect(params.contextId).toBe("uid-sender_uid-recipient");
+  });
+
+  it("AC-2: happy path emits activity item to recipient ONLY", async () => {
+    const {deps, writes} = createDeps();
+    const handler = createSendReminderHandler(deps);
+
+    await handler(validInput, authContext("uid-sender"));
+
+    expect(writes.activityAdds).toHaveLength(1);
+    const entry = writes.activityAdds[0];
+    expect(entry.recipient).toBe("uid-recipient");
+    expect(entry.payload.type).toBe("reminder");
+    const payload = entry.payload.payload as Record<string, unknown>;
+    expect(payload.senderUid).toBe("uid-sender");
+    expect(payload.recipientUid).toBe("uid-recipient");
+    expect(payload.amountPaise).toBe(50000);
+    expect(payload.contextType).toBe("friendship");
+    expect(payload.contextId).toBe("uid-sender_uid-recipient");
+  });
+
+  // -----------------------------------------------------------------------
+  // AC-3 — unauth
+  // -----------------------------------------------------------------------
+  it("AC-3: throws UNAUTHENTICATED when request.auth is missing", async () => {
+    const {deps, writes, fcmDispatch} = createDeps();
+    const handler = createSendReminderHandler(deps);
+
+    try {
+      await handler(validInput, noAuthContext());
+      fail("Expected HttpsError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpsError);
+      const e = err as HttpsError;
+      expect(e.code).toBe("unauthenticated");
+      expect((e.details as {errorCode: string}).errorCode).toBe(
+        "UNAUTHENTICATED",
+      );
+    }
+    expect(fcmDispatch).not.toHaveBeenCalled();
+    expect(writes.rateLimitSets).toHaveLength(0);
+    expect(writes.activityAdds).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // AC-4 — malformed input
+  // -----------------------------------------------------------------------
+  it("AC-4: throws INVALID_INPUT when toUserId is missing", async () => {
+    const {deps} = createDeps();
+    const handler = createSendReminderHandler(deps);
+
+    try {
+      await handler(
+        {contextType: "friendship", contextId: "uid-sender_uid-recipient"},
+        authContext("uid-sender"),
+      );
+      fail("Expected HttpsError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpsError);
+      const e = err as HttpsError;
+      expect(e.code).toBe("invalid-argument");
+      expect((e.details as {errorCode: string}).errorCode).toBe(
+        "INVALID_INPUT",
+      );
+    }
+  });
+
+  it("AC-4: throws INVALID_INPUT when toUserId is empty string", async () => {
+    const {deps} = createDeps();
+    const handler = createSendReminderHandler(deps);
+    await expect(
+      handler({...validInput, toUserId: ""}, authContext("uid-sender")),
+    ).rejects.toMatchObject({
+      code: "invalid-argument",
+      details: {errorCode: "INVALID_INPUT"},
+    });
+  });
+
+  it("AC-4: throws INVALID_INPUT when contextId is empty string", async () => {
+    const {deps} = createDeps();
+    const handler = createSendReminderHandler(deps);
+    await expect(
+      handler({...validInput, contextId: ""}, authContext("uid-sender")),
+    ).rejects.toMatchObject({
+      code: "invalid-argument",
+      details: {errorCode: "INVALID_INPUT"},
+    });
+  });
+
+  it("AC-4: throws INVALID_INPUT when contextType is invalid", async () => {
+    const {deps} = createDeps();
+    const handler = createSendReminderHandler(deps);
+    await expect(
+      handler(
+        {...validInput, contextType: "wedding" as unknown as "friendship"},
+        authContext("uid-sender"),
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid-argument",
+      details: {errorCode: "INVALID_INPUT"},
+    });
+  });
+
+  it("AC-4: throws INVALID_INPUT when message exceeds 500 chars", async () => {
+    const {deps} = createDeps();
+    const handler = createSendReminderHandler(deps);
+    const tooLong = "x".repeat(501);
+    await expect(
+      handler(
+        {...validInput, message: tooLong},
+        authContext("uid-sender"),
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid-argument",
+      details: {errorCode: "INVALID_INPUT"},
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC-5 — non-member
+  // -----------------------------------------------------------------------
+  it("AC-5: throws NOT_A_MEMBER when caller is not in friendship.memberIds",
+    async () => {
+      const {deps, writes, fcmDispatch} = createDeps({
+        friendship: {
+          exists: true,
+          data: {
+            memberIds: ["uid-other", "uid-recipient"],
+            simplifiedBalances: {
+              "uid-recipient": {"uid-other": 50000},
+            },
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "permission-denied",
+        details: {errorCode: "NOT_A_MEMBER"},
+      });
+      expect(fcmDispatch).not.toHaveBeenCalled();
+      expect(writes.rateLimitSets).toHaveLength(0);
+      expect(writes.activityAdds).toHaveLength(0);
+    });
+
+  it("AC-5: throws NOT_A_MEMBER when friendship doc does not exist",
+    async () => {
+      const {deps} = createDeps({
+        friendship: {exists: false, data: null},
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "permission-denied",
+        details: {errorCode: "NOT_A_MEMBER"},
+      });
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-6 — recipient doesn't owe
+  // -----------------------------------------------------------------------
+  it("AC-6: throws RECIPIENT_DOESNT_OWE when simplifiedBalances has no entry",
+    async () => {
+      const {deps, writes, fcmDispatch} = createDeps({
+        friendship: {
+          exists: true,
+          data: {
+            memberIds: ["uid-sender", "uid-recipient"],
+            simplifiedBalances: {},
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "failed-precondition",
+        details: {errorCode: "RECIPIENT_DOESNT_OWE"},
+      });
+      expect(fcmDispatch).not.toHaveBeenCalled();
+      expect(writes.rateLimitSets).toHaveLength(0);
+      expect(writes.activityAdds).toHaveLength(0);
+    });
+
+  it("AC-6: throws RECIPIENT_DOESNT_OWE when sender is the debtor",
+    async () => {
+      const {deps} = createDeps({
+        friendship: {
+          exists: true,
+          data: {
+            memberIds: ["uid-sender", "uid-recipient"],
+            simplifiedBalances: {
+              "uid-sender": {"uid-recipient": 50000},
+            },
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "failed-precondition",
+        details: {errorCode: "RECIPIENT_DOESNT_OWE"},
+      });
+    });
+
+  it("AC-6: throws RECIPIENT_DOESNT_OWE when owed amount is zero",
+    async () => {
+      const {deps} = createDeps({
+        friendship: {
+          exists: true,
+          data: {
+            memberIds: ["uid-sender", "uid-recipient"],
+            simplifiedBalances: {
+              "uid-recipient": {"uid-sender": 0},
+            },
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "failed-precondition",
+        details: {errorCode: "RECIPIENT_DOESNT_OWE"},
+      });
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-7 / AC-8 — rate limit
+  // -----------------------------------------------------------------------
+  it("AC-7: throws RATE_LIMITED when prior send within 24h window",
+    async () => {
+      // Mock now() = 2026-06-08T12:00:00Z; prior send 12h ago.
+      const twelveHoursAgoMs = new Date("2026-06-08T00:00:00Z").getTime();
+      const {deps, writes, fcmDispatch} = createDeps({
+        rateLimit: {
+          exists: true,
+          data: {
+            lastSentAt: {toMillis: () => twelveHoursAgoMs},
+            count: 1,
+            windowStart: twelveHoursAgoMs,
+            recipientUid: "uid-recipient",
+            senderUid: "uid-sender",
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      try {
+        await handler(validInput, authContext("uid-sender"));
+        fail("Expected RATE_LIMITED");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpsError);
+        const e = err as HttpsError;
+        expect(e.code).toBe("resource-exhausted");
+        const details = e.details as {
+          errorCode: string;
+          nextAllowedAtIso: string;
+        };
+        expect(details.errorCode).toBe("RATE_LIMITED");
+        // lastSentAt + 24h = 2026-06-09T00:00:00.000Z
+        expect(details.nextAllowedAtIso).toBe("2026-06-09T00:00:00.000Z");
+      }
+      expect(fcmDispatch).not.toHaveBeenCalled();
+      expect(writes.rateLimitSets).toHaveLength(0);
+    });
+
+  it("AC-8: passes when prior send was > 24h ago and writes new rate-limit",
+    async () => {
+      // Mock now() = 2026-06-08T12:00:00Z; prior send 25h ago.
+      const twentyFiveHoursAgoMs =
+        new Date("2026-06-07T11:00:00Z").getTime();
+      const {deps, writes} = createDeps({
+        rateLimit: {
+          exists: true,
+          data: {
+            lastSentAt: {toMillis: () => twentyFiveHoursAgoMs},
+            count: 1,
+            windowStart: twentyFiveHoursAgoMs,
+            recipientUid: "uid-recipient",
+            senderUid: "uid-sender",
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      const result = await handler(validInput, authContext("uid-sender"));
+      expect(result.success).toBe(true);
+      expect(writes.rateLimitSets).toHaveLength(1);
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-9 — prefs disabled
+  // -----------------------------------------------------------------------
+  it("AC-9: throws RECIPIENT_PREFS_DISABLED when recipient prefs.reminder=false",
+    async () => {
+      const {deps, writes, fcmDispatch} = createDeps({
+        recipient: {
+          exists: true,
+          data: {
+            displayName: "Priya",
+            fcmTokens: ["tokRec"],
+            notificationPrefs: {
+              newExpense: true,
+              settlement: true,
+              reminder: false,
+            },
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "failed-precondition",
+        details: {errorCode: "RECIPIENT_PREFS_DISABLED"},
+      });
+      expect(fcmDispatch).not.toHaveBeenCalled();
+      expect(writes.rateLimitSets).toHaveLength(0);
+      expect(writes.activityAdds).toHaveLength(0);
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-10 — no tokens
+  // -----------------------------------------------------------------------
+  it("AC-10: throws RECIPIENT_NO_TOKENS when recipient has empty fcmTokens",
+    async () => {
+      const {deps, writes, fcmDispatch} = createDeps({
+        recipient: {
+          exists: true,
+          data: {
+            displayName: "Priya",
+            fcmTokens: [],
+            notificationPrefs: {reminder: true},
+          },
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "failed-precondition",
+        details: {errorCode: "RECIPIENT_NO_TOKENS"},
+      });
+      expect(fcmDispatch).not.toHaveBeenCalled();
+      expect(writes.rateLimitSets).toHaveLength(0);
+      expect(writes.activityAdds).toHaveLength(0);
+    });
+
+  it("AC-10: throws RECIPIENT_NO_TOKENS when fcmTokens field is missing",
+    async () => {
+      const {deps} = createDeps({
+        recipient: {
+          exists: true,
+          data: {displayName: "Priya", notificationPrefs: {reminder: true}},
+        },
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "failed-precondition",
+        details: {errorCode: "RECIPIENT_NO_TOKENS"},
+      });
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-11 — full-failure dispatch
+  // -----------------------------------------------------------------------
+  it("AC-11: throws FCM_DISPATCH_FAILED when dispatch reports zero succeeded",
+    async () => {
+      const {deps, writes, fcmDispatch} = createDeps();
+      fcmDispatch.mockResolvedValueOnce({
+        succeeded: 0,
+        failed: 2,
+        pruned: ["tokRec1", "tokRec2"],
+        suppressedByPrefs: 0,
+        skippedEmptyTokens: 0,
+        skippedMissingUser: 0,
+      });
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(validInput, authContext("uid-sender")),
+      ).rejects.toMatchObject({
+        code: "unavailable",
+        details: {errorCode: "FCM_DISPATCH_FAILED"},
+      });
+      // Rate-limit NOT recorded on full-failure dispatch.
+      expect(writes.rateLimitSets).toHaveLength(0);
+      // Activity NOT emitted either — no "send" happened.
+      expect(writes.activityAdds).toHaveLength(0);
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-12 — group-context forward-compat
+  // -----------------------------------------------------------------------
+  it("AC-12: throws GROUP_CONTEXT_NOT_SUPPORTED for contextType='group'",
+    async () => {
+      const {deps, writes, fcmDispatch} = createDeps();
+      const handler = createSendReminderHandler(deps);
+
+      await expect(
+        handler(
+          {...validInput, contextType: "group", contextId: "grp-1"},
+          authContext("uid-sender"),
+        ),
+      ).rejects.toMatchObject({
+        code: "unimplemented",
+        details: {errorCode: "GROUP_CONTEXT_NOT_SUPPORTED"},
+      });
+      expect(fcmDispatch).not.toHaveBeenCalled();
+      expect(writes.rateLimitSets).toHaveLength(0);
+    });
+
+  // -----------------------------------------------------------------------
+  // AC-19 — PII guard in structured logs
+  // -----------------------------------------------------------------------
+  it("AC-19: log events hash all uid params and never include raw uids",
+    async () => {
+      const {deps, logger} = createDeps();
+      const handler = createSendReminderHandler(deps);
+
+      await handler(validInput, authContext("uid-sender"));
+
+      const raw = JSON.stringify(logger.calls);
+      expect(raw).not.toContain("uid-sender");
+      expect(raw).not.toContain("uid-recipient");
+
+      // Verify the attempted + succeeded logs were emitted with hashed ids.
+      const attempted = logger.calls.find(
+        (c) => c.data?.event === "reminder_send_attempted",
+      );
+      expect(attempted).toBeDefined();
+      expect(attempted!.data!.senderUidHash).toMatch(/^[0-9a-f]{16}$/);
+      expect(attempted!.data!.recipientUidHash).toMatch(/^[0-9a-f]{16}$/);
+
+      const succeeded = logger.calls.find(
+        (c) => c.data?.event === "reminder_send_succeeded",
+      );
+      expect(succeeded).toBeDefined();
+      expect(succeeded!.data!.contextIdHash).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+  it("AC-19: rate-limited log event hashes recipient and contextId", async () => {
+    const twelveHoursAgoMs = new Date("2026-06-08T00:00:00Z").getTime();
+    const {deps, logger} = createDeps({
+      rateLimit: {
+        exists: true,
+        data: {
+          lastSentAt: {toMillis: () => twelveHoursAgoMs},
+          count: 1,
+          windowStart: twelveHoursAgoMs,
+        },
+      },
+    });
+    const handler = createSendReminderHandler(deps);
+
+    try {
+      await handler(validInput, authContext("uid-sender"));
+    } catch {
+      // expected
+    }
+    const log = logger.calls.find(
+      (c) => c.data?.event === "reminder_send_rate_limited",
+    );
+    expect(log).toBeDefined();
+    expect(log!.data!.senderUidHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(log!.data!.recipientUidHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(log!.data!.nextAllowedAtIso).toBe("2026-06-09T00:00:00.000Z");
+  });
+
+  it("AC-19: optional message body never appears in logs (only presence)",
+    async () => {
+      const {deps, logger} = createDeps();
+      const handler = createSendReminderHandler(deps);
+
+      await handler(
+        {...validInput, message: "Pay me back already!!"},
+        authContext("uid-sender"),
+      );
+
+      const raw = JSON.stringify(logger.calls);
+      expect(raw).not.toContain("Pay me back");
+      const succeeded = logger.calls.find(
+        (c) => c.data?.event === "reminder_send_succeeded",
+      );
+      expect(succeeded).toBeDefined();
+      expect(succeeded!.data!.messageLength).toBe(21);
+    });
+});

--- a/functions/test/triggers/on-expense-write/activity-validator.test.ts
+++ b/functions/test/triggers/on-expense-write/activity-validator.test.ts
@@ -15,6 +15,7 @@ import type {
   ExpenseAddedPayload,
   ExpenseDeletedPayload,
   ExpenseEditedPayload,
+  ReminderPayload,
   SettlementPayload,
 } from "../../../src/triggers/on-expense-write/payload-builder";
 
@@ -418,3 +419,144 @@ describe("validateActivityPayload — settlement (FR-AC-01)", () => {
   });
 });
 
+
+// ===========================================================================
+// FR-SE-09: reminder event-type validator extension
+// ===========================================================================
+
+function validReminderPayload(
+  overrides: Partial<ReminderPayload> = {},
+): ReminderPayload {
+  return {
+    senderUid: "uid-sender",
+    recipientUid: "uid-recipient",
+    contextType: "friendship",
+    contextId: "uid-sender_uid-recipient",
+    amountPaise: 50000,
+    ...overrides,
+  };
+}
+
+describe("validateActivityPayload — reminder (FR-SE-09)", () => {
+  it("accepts a minimal valid payload (no message)", () => {
+    expect(() =>
+      validateActivityPayload("reminder", validReminderPayload()),
+    ).not.toThrow();
+  });
+
+  it("accepts a valid payload with optional message", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({message: "Please settle up when you can."}),
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts a payload with message at maximum length (500 chars)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({message: "x".repeat(500)}),
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects payload with message longer than 500 chars", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({message: "x".repeat(501)}),
+      ),
+    ).toThrow(/message.*500/);
+  });
+
+  it("rejects payload missing senderUid", () => {
+    const bad = validReminderPayload();
+    delete (bad as Partial<ReminderPayload>).senderUid;
+    expect(() =>
+      validateActivityPayload("reminder", bad as ReminderPayload),
+    ).toThrow(/missing required field 'senderUid'/);
+  });
+
+  it("rejects payload missing recipientUid", () => {
+    const bad = validReminderPayload();
+    delete (bad as Partial<ReminderPayload>).recipientUid;
+    expect(() =>
+      validateActivityPayload("reminder", bad as ReminderPayload),
+    ).toThrow(/missing required field 'recipientUid'/);
+  });
+
+  it("rejects payload with empty senderUid string", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({senderUid: ""}),
+      ),
+    ).toThrow(/senderUid must be a non-empty string/);
+  });
+
+  it("rejects payload with empty recipientUid string", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({recipientUid: ""}),
+      ),
+    ).toThrow(/recipientUid must be a non-empty string/);
+  });
+
+  it("rejects payload with non-integer amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({amountPaise: 100.5}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects payload with zero amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({amountPaise: 0}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects payload with negative amountPaise", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({amountPaise: -100}),
+      ),
+    ).toThrow(/amountPaise must be a positive integer/);
+  });
+
+  it("rejects invalid contextType (defence-in-depth)", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({
+          contextType: "wedding" as unknown as "friendship" | "group",
+        }),
+      ),
+    ).toThrow(/contextType must be 'friendship' or 'group'/);
+  });
+
+  it("rejects empty contextId", () => {
+    expect(() =>
+      validateActivityPayload(
+        "reminder",
+        validReminderPayload({contextId: ""}),
+      ),
+    ).toThrow(/contextId must be a non-empty string/);
+  });
+
+  it("rejects payload where message is non-string (when present)", () => {
+    const bad = validReminderPayload();
+    (bad as {message: unknown}).message = 42;
+    expect(() => validateActivityPayload("reminder", bad)).toThrow(
+      /message.*string/,
+    );
+  });
+});

--- a/functions/test/triggers/on-expense-write/function.test.ts
+++ b/functions/test/triggers/on-expense-write/function.test.ts
@@ -50,10 +50,12 @@ beforeEach(() => {
 function createMockNotificationsApi(): NotificationsApi & {
   sendExpenseNotification: jest.Mock;
   sendSettlementNotification: jest.Mock;
+  sendReminderNotification: jest.Mock;
 } {
   return {
     sendExpenseNotification: jest.fn().mockResolvedValue(undefined),
     sendSettlementNotification: jest.fn().mockResolvedValue(undefined),
+    sendReminderNotification: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/functions/test/triggers/on-settlement-write/function.test.ts
+++ b/functions/test/triggers/on-settlement-write/function.test.ts
@@ -52,10 +52,12 @@ beforeEach(() => {
 function createMockNotificationsApi(): NotificationsApi & {
   sendExpenseNotification: jest.Mock;
   sendSettlementNotification: jest.Mock;
+  sendReminderNotification: jest.Mock;
 } {
   return {
     sendExpenseNotification: jest.fn().mockResolvedValue(undefined),
     sendSettlementNotification: jest.fn().mockResolvedValue(undefined),
+    sendReminderNotification: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/lib/features/friends/presentation/friend_detail_screen.dart
+++ b/lib/features/friends/presentation/friend_detail_screen.dart
@@ -11,6 +11,9 @@ import 'package:onebytwo/features/friends/presentation/widgets/friend_detail_hea
 import 'package:onebytwo/features/friends/presentation/widgets/friend_detail_states.dart';
 import 'package:onebytwo/features/friends/presentation/widgets/friend_detail_timeline.dart';
 import 'package:onebytwo/features/friends/presentation/widgets/obt_settle_up_card.dart';
+import 'package:onebytwo/features/reminders/application/reminder_cooldown_provider.dart';
+import 'package:onebytwo/features/reminders/application/send_reminder_controller.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
 import 'package:onebytwo/features/settlements/application/settle_up_telemetry.dart';
 import 'package:onebytwo/features/settlements/presentation/settle_up_bottom_sheet.dart';
 
@@ -106,6 +109,15 @@ class _FriendDetailScreenState extends ConsumerState<FriendDetailScreen> {
                         suggestedAmountPaise: state.header.netBalancePaise
                             .abs(),
                         onSettleUp: () => _onSettleUpTapped(context, state),
+                      )
+                    else if (state.header.balanceState == BalanceState.owed)
+                      _ReceivingDirectionCard(
+                        friendshipId: widget.friendshipId,
+                        otherDisplayName: state.header.displayName,
+                        otherPhotoUrl: state.header.photoUrl,
+                        suggestedAmountPaise: state.header.netBalancePaise
+                            .abs(),
+                        otherUserUid: widget.otherUserUid,
                       ),
                     FriendDetailTimelineWidget(
                       timeline: state.timeline,
@@ -218,5 +230,104 @@ class _FriendDetailScreenState extends ConsumerState<FriendDetailScreen> {
         suggestedAmountPaise: state.header.netBalancePaise.abs(),
       ),
     );
+  }
+}
+
+/// FR-SE-09 receiving-direction host for the OBTSettleUpCard.
+///
+/// Owns its own [ConsumerState] so it can watch the per-friendship
+/// `reminderCooldownProvider` (which drives the live disabled state +
+/// countdown caption) AND listen for [SendReminderController] state
+/// transitions to surface per-error-code snackbars without leaking
+/// into the parent [FriendDetailScreen].
+class _ReceivingDirectionCard extends ConsumerStatefulWidget {
+  const _ReceivingDirectionCard({
+    required this.friendshipId,
+    required this.otherDisplayName,
+    required this.otherPhotoUrl,
+    required this.suggestedAmountPaise,
+    required this.otherUserUid,
+  });
+
+  final String friendshipId;
+  final String otherDisplayName;
+  final String? otherPhotoUrl;
+  final int suggestedAmountPaise;
+  final String otherUserUid;
+
+  @override
+  ConsumerState<_ReceivingDirectionCard> createState() =>
+      _ReceivingDirectionCardState();
+}
+
+class _ReceivingDirectionCardState
+    extends ConsumerState<_ReceivingDirectionCard> {
+  @override
+  Widget build(BuildContext context) {
+    final cooldown = ref.watch(reminderCooldownProvider(widget.friendshipId));
+
+    ref.listen<SendReminderState>(
+      sendReminderControllerProvider(widget.friendshipId),
+      (previous, next) {
+        if (!mounted) return;
+        if (next is SendReminderError) {
+          _surfaceErrorSnackbar(context, next.error);
+        }
+      },
+    );
+
+    return OBTSettleUpCard(
+      payerDisplayName: widget.otherDisplayName,
+      payerPhotoUrl: widget.otherPhotoUrl,
+      payeeDisplayName: 'You',
+      payeePhotoUrl: null,
+      suggestedAmountPaise: widget.suggestedAmountPaise,
+      onSettleUp: () {},
+      isReceivingDirection: true,
+      nextAllowedAt: cooldown,
+      onSendReminder: () => _onSendReminderTapped(context),
+    );
+  }
+
+  Future<void> _onSendReminderTapped(BuildContext context) async {
+    final controller = ref.read(
+      sendReminderControllerProvider(widget.friendshipId).notifier,
+    );
+    await controller.send(
+      toUserId: widget.otherUserUid,
+      contextType: 'friendship',
+      contextId: widget.friendshipId,
+    );
+  }
+
+  void _surfaceErrorSnackbar(BuildContext context, ReminderSendResult error) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+
+    final text = switch (error) {
+      ReminderSendRateLimited(:final nextAllowedAt) => _rateLimitedSnackbar(
+        nextAllowedAt,
+      ),
+      ReminderSendRecipientPrefsDisabled() =>
+        '${widget.otherDisplayName} has notifications turned off.',
+      ReminderSendRecipientNoTokens() =>
+        "${widget.otherDisplayName} hasn't enabled push notifications yet.",
+      ReminderSendRecipientDoesntOwe() =>
+        "${widget.otherDisplayName}'s balance has changed. Pull to refresh.",
+      ReminderSendFailed() => 'Reminder could not be sent. Please try again.',
+      ReminderSendSuccess() => null,
+    };
+
+    if (text == null) return;
+    messenger.showSnackBar(SnackBar(content: Text(text)));
+  }
+
+  String _rateLimitedSnackbar(DateTime nextAllowedAt) {
+    final remaining = nextAllowedAt.difference(DateTime.now());
+    final h = remaining.inHours;
+    final m = remaining.inMinutes.remainder(60);
+    final hm = h > 0 ? '${h}h ${m}m' : '${m.clamp(1, 59)}m';
+    return 'You can send another reminder to '
+        '${widget.otherDisplayName} in $hm.';
   }
 }

--- a/lib/features/friends/presentation/widgets/obt_settle_up_card.dart
+++ b/lib/features/friends/presentation/widgets/obt_settle_up_card.dart
@@ -1,28 +1,41 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:onebytwo/core/formatters/inr_formatter.dart';
 
-/// Settle Up CTA card (FR-SE-07 / SCR-23 / design-system §13).
+/// Settle Up CTA card (FR-SE-07 / SCR-23 / design-system §13) — with
+/// the FR-SE-09 receiving-direction variant.
 ///
 /// Renders a payer-avatar → arrow → payee-avatar row with a centred
-/// suggested amount and a Settle Up call-to-action. Hosts:
-/// - Friend Detail screen (FR-SE-05 / PR #43 — this PR's wired call site)
-/// - Home Dashboard (FR-HD-02 — deferred; planned future use site)
-/// - Group Detail (FR-GR-04 — deferred; planned future use site)
+/// suggested amount and a Settle Up / Send Reminder call-to-action.
 ///
-/// Architectural placement (Architect Notes §2.6): the widget lives
-/// under `lib/features/friends/presentation/widgets/` for PR #43
-/// because the only wired host is `FriendDetailScreen`. When the Home
-/// Dashboard ships, that PR will lift this widget into a shared
-/// design-system folder (`lib/core/widgets/cards/`) per the
-/// `OBTAmountInput` extraction precedent from PR #38.
+/// **Settling-direction** (default; [isReceivingDirection] == false):
+/// the authenticated user owes the friend; the CTA reads "Settle Up"
+/// and fires [onSettleUp].
+///
+/// **Receiving-direction** (FR-SE-09; [isReceivingDirection] == true):
+/// the friend owes the authenticated user; the CTA reads "Send
+/// Reminder" and fires [onSendReminder]. When [nextAllowedAt] is in
+/// the future, the button is disabled and a live countdown caption
+/// is shown ("Next reminder in 23h 59m").
+///
+/// Hosts:
+/// - Friend Detail screen — both directional branches.
+/// - Home Dashboard (FR-HD-02 — deferred; planned future use site).
+/// - Group Detail (FR-GR-04 — deferred; planned future use site).
+///
+/// Architectural placement (FR-SE-09 Architect Notes §2.7): the
+/// widget lives under `lib/features/friends/presentation/widgets/`
+/// — extraction to `lib/core/widgets/cards/` remains DEFERRED until
+/// a second host needs it (precedent: `OBTAmountInput` in PR #38).
 ///
 /// Invariant compliance:
 /// - **Invariant 1 (paise)**: [suggestedAmountPaise] is `int`; display
 ///   uses `formatInrFromPaise()`. No inline `/100` math.
 /// - **Invariant 2 (`simplifiedBalances` read-only)**: this widget is
 ///   presentational and never touches Firestore.
-class OBTSettleUpCard extends StatelessWidget {
+class OBTSettleUpCard extends StatefulWidget {
   /// Creates an [OBTSettleUpCard].
   const OBTSettleUpCard({
     required this.payerDisplayName,
@@ -31,6 +44,9 @@ class OBTSettleUpCard extends StatelessWidget {
     required this.payeePhotoUrl,
     required this.suggestedAmountPaise,
     required this.onSettleUp,
+    this.isReceivingDirection = false,
+    this.onSendReminder,
+    this.nextAllowedAt,
     super.key,
   });
 
@@ -52,12 +68,96 @@ class OBTSettleUpCard extends StatelessWidget {
   /// Fires when the user taps the Settle Up CTA. The host is
   /// responsible for opening the Settle Up bottom sheet (or
   /// equivalent) and for firing the `settle_up_tapped` telemetry
-  /// event.
+  /// event. Ignored on the receiving-direction branch.
   final VoidCallback onSettleUp;
+
+  /// When true, the card renders in the receiving-direction variant
+  /// (FR-SE-09): CTA reads "Send Reminder"; tapping fires
+  /// [onSendReminder] (which MUST be provided when this is true).
+  final bool isReceivingDirection;
+
+  /// Fires when the user taps the Send Reminder CTA on the
+  /// receiving-direction variant. Required when
+  /// [isReceivingDirection] is true.
+  final VoidCallback? onSendReminder;
+
+  /// Server-returned earliest time at which the next reminder may be
+  /// sent. When in the future, the receiving-direction button is
+  /// disabled with a live countdown caption. Ignored on the
+  /// settling-direction branch.
+  final DateTime? nextAllowedAt;
+
+  @override
+  State<OBTSettleUpCard> createState() => _OBTSettleUpCardState();
+}
+
+class _OBTSettleUpCardState extends State<OBTSettleUpCard> {
+  Timer? _tick;
+
+  @override
+  void initState() {
+    super.initState();
+    _maybeStartTick();
+  }
+
+  @override
+  void didUpdateWidget(covariant OBTSettleUpCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.nextAllowedAt != widget.nextAllowedAt) {
+      _tick?.cancel();
+      _tick = null;
+      _maybeStartTick();
+    }
+  }
+
+  @override
+  void dispose() {
+    _tick?.cancel();
+    super.dispose();
+  }
+
+  void _maybeStartTick() {
+    final next = widget.nextAllowedAt;
+    if (!widget.isReceivingDirection || next == null) return;
+    if (next.isBefore(DateTime.now())) return;
+    _tick = Timer.periodic(const Duration(seconds: 30), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  bool get _isReminderCooling {
+    if (!widget.isReceivingDirection) return false;
+    final next = widget.nextAllowedAt;
+    if (next == null) return false;
+    return next.isAfter(DateTime.now());
+  }
+
+  String _cooldownCaption() {
+    final next = widget.nextAllowedAt!;
+    final remaining = next.difference(DateTime.now());
+    final h = remaining.inHours;
+    final m = remaining.inMinutes.remainder(60);
+    if (h > 0) return 'Next reminder in ${h}h ${m}m';
+    if (m > 0) return 'Next reminder in ${m}m';
+    return 'Next reminder shortly';
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isReceiving = widget.isReceivingDirection;
+    final cooling = _isReminderCooling;
+    final ctaLabel = isReceiving ? 'Send Reminder' : 'Settle Up';
+    final ctaIcon = isReceiving
+        ? Icons.notifications_active_outlined
+        : Icons.handshake_outlined;
+    final VoidCallback? ctaOnPressed;
+    if (isReceiving) {
+      ctaOnPressed = cooling ? null : widget.onSendReminder;
+    } else {
+      ctaOnPressed = widget.onSettleUp;
+    }
+
     return Card(
       margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       elevation: 0,
@@ -72,26 +172,26 @@ class OBTSettleUpCard extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 _AvatarLabel(
-                  displayName: payerDisplayName,
-                  photoUrl: payerPhotoUrl,
+                  displayName: widget.payerDisplayName,
+                  photoUrl: widget.payerPhotoUrl,
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8),
                   child: Icon(
                     Icons.arrow_forward,
                     color: theme.colorScheme.primary,
-                    semanticLabel: 'pays',
+                    semanticLabel: isReceiving ? 'owes' : 'pays',
                   ),
                 ),
                 _AvatarLabel(
-                  displayName: payeeDisplayName,
-                  photoUrl: payeePhotoUrl,
+                  displayName: widget.payeeDisplayName,
+                  photoUrl: widget.payeePhotoUrl,
                 ),
               ],
             ),
             const SizedBox(height: 8),
             Text(
-              formatInrFromPaise(suggestedAmountPaise),
+              formatInrFromPaise(widget.suggestedAmountPaise),
               style: theme.textTheme.headlineSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -100,11 +200,20 @@ class OBTSettleUpCard extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: FilledButton.icon(
-                onPressed: onSettleUp,
-                icon: const Icon(Icons.handshake_outlined),
-                label: const Text('Settle Up'),
+                onPressed: ctaOnPressed,
+                icon: Icon(ctaIcon),
+                label: Text(ctaLabel),
               ),
             ),
+            if (cooling) ...[
+              const SizedBox(height: 8),
+              Text(
+                _cooldownCaption(),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/features/reminders/application/reminder_cooldown_provider.dart
+++ b/lib/features/reminders/application/reminder_cooldown_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// FR-SE-09 per-friendship send-reminder cooldown.
+///
+/// Holds the server-returned `nextAllowedAt` timestamp from the most
+/// recent successful or rate-limited send to a given recipient,
+/// keyed by `friendshipId`. The OBTSettleUpCard receiving-direction
+/// variant watches this provider to render the disabled-with-
+/// countdown state.
+///
+/// v1.0 architect call (§2.6 of FR-SE-09-send-reminder.md): IN-MEMORY
+/// ONLY. The provider RESETS on app launch (ProviderContainer
+/// disposal). The server is the authoritative gate per
+/// `notifications.md §6.1`; the client provider is a best-effort UX
+/// optimisation so the user doesn't tap a button only to be told the
+/// reminder was already sent.
+///
+/// A future PR paired with `shared_preferences` adoption (deferred
+/// from PR #53 §2.6) may persist the cooldown across launches.
+final reminderCooldownProvider = StateProvider.family<DateTime?, String>(
+  (ref, friendshipId) => null,
+);

--- a/lib/features/reminders/application/reminder_telemetry.dart
+++ b/lib/features/reminders/application/reminder_telemetry.dart
@@ -1,0 +1,65 @@
+/// Telemetry event-name and parameter-key constants for the FR-SE-09
+/// send-reminder feature.
+///
+/// Every payload that carries a `friendship_id`-derived value MUST
+/// pass the raw value through `hashFriendshipId` from
+/// `lib/core/telemetry/event_id_hash.dart` before emission. The
+/// parameter-key convention (ADR-0013) is to append `_hash` to make
+/// the hashing visible at the call site.
+///
+/// Reference: `docs/sprint-zero/stories/FR-SE-09-send-reminder.md`
+/// Telemetry Contract section (seven client events).
+abstract final class ReminderTelemetry {
+  // -----------------------------------------------------------------
+  // Event names — mirror of the server-side `reminder_send_*` family
+  // (FR-SE-09 architect notes Telemetry Contract).
+  // -----------------------------------------------------------------
+
+  /// User tapped the "Send Reminder" CTA on the OBTSettleUpCard
+  /// receiving-direction variant. Fires before the callable is
+  /// invoked. Payload: `friendship_id_hash`.
+  static const String tapped = 'reminder_send_tapped';
+
+  /// Callable returned success and the rate-limit window was opened.
+  /// Payload: `friendship_id_hash`.
+  static const String succeeded = 'reminder_send_succeeded';
+
+  /// Callable returned `RATE_LIMITED`. Payload: `friendship_id_hash`,
+  /// `next_allowed_in_seconds`.
+  static const String rateLimited = 'reminder_send_rate_limited';
+
+  /// Callable returned `RECIPIENT_PREFS_DISABLED`. Payload:
+  /// `friendship_id_hash`.
+  static const String recipientPrefsDisabled =
+      'reminder_send_recipient_prefs_disabled';
+
+  /// Callable returned `RECIPIENT_NO_TOKENS`. Payload:
+  /// `friendship_id_hash`.
+  static const String recipientNoTokens = 'reminder_send_recipient_no_tokens';
+
+  /// Callable returned `RECIPIENT_DOESNT_OWE` — race-condition where
+  /// `simplifiedBalances` drifted between render and tap. Payload:
+  /// `friendship_id_hash`.
+  static const String recipientDoesntOwe = 'reminder_send_recipient_doesnt_owe';
+
+  /// Catch-all for `FCM_DISPATCH_FAILED`, `INTERNAL`,
+  /// `GROUP_CONTEXT_NOT_SUPPORTED`, or non-callable network failures.
+  /// Payload: `friendship_id_hash`, `error_code`.
+  static const String failed = 'reminder_send_failed';
+
+  // -----------------------------------------------------------------
+  // Parameter-key constants
+  // -----------------------------------------------------------------
+
+  /// Hashed friendship-id (see `hashFriendshipId`). PII guard per
+  /// ADR-0013.
+  static const String paramFriendshipIdHash = 'friendship_id_hash';
+
+  /// Seconds until the next allowed reminder send (positive integer).
+  /// Only present on [rateLimited].
+  static const String paramNextAllowedInSeconds = 'next_allowed_in_seconds';
+
+  /// The server-side `details.errorCode` (or `'UNKNOWN'`). Only
+  /// present on [failed].
+  static const String paramErrorCode = 'error_code';
+}

--- a/lib/features/reminders/application/send_reminder_controller.dart
+++ b/lib/features/reminders/application/send_reminder_controller.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/core/telemetry/event_id_hash.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/reminders/application/reminder_cooldown_provider.dart';
+import 'package:onebytwo/features/reminders/application/reminder_telemetry.dart';
+import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
+
+/// State for [SendReminderController].
+@immutable
+sealed class SendReminderState {
+  /// Creates a [SendReminderState].
+  const SendReminderState();
+}
+
+/// Initial state — no send in flight, no recent outcome.
+class SendReminderIdle extends SendReminderState {
+  /// Creates a [SendReminderIdle].
+  const SendReminderIdle();
+}
+
+/// A send is in flight. UI shows a progress indicator on the CTA.
+class SendReminderSending extends SendReminderState {
+  /// Creates a [SendReminderSending].
+  const SendReminderSending();
+}
+
+/// The send succeeded. UI may switch to a disabled-with-countdown
+/// state via the cooldown provider.
+class SendReminderSuccess extends SendReminderState {
+  /// Creates a [SendReminderSuccess].
+  const SendReminderSuccess({required this.nextAllowedAt});
+
+  /// Server-returned earliest next-allowed time.
+  final DateTime nextAllowedAt;
+}
+
+/// The send failed with one of the typed [ReminderSendResult] error
+/// variants. UI surfaces a per-variant snackbar.
+class SendReminderError extends SendReminderState {
+  /// Creates a [SendReminderError].
+  const SendReminderError(this.error);
+
+  /// The discriminated error variant.
+  final ReminderSendResult error;
+}
+
+/// Riverpod 2.x [StateNotifier] driving the "Send Reminder" CTA on
+/// the OBTSettleUpCard receiving-direction variant.
+///
+/// Mirrors the SettleUpController precedent: sealed-state hierarchy,
+/// repository + analytics injected via constructor, telemetry single-
+/// fire discipline (events fire once per transition; concurrent
+/// `send()` is short-circuited while the previous send is in flight).
+///
+/// Side effects:
+///   - On success / RATE_LIMITED, updates [reminderCooldownProvider]
+///     for the friendshipId so the OBTSettleUpCard receiving-direction
+///     button is disabled with a countdown caption.
+///   - Emits `reminder_send_*` telemetry per [ReminderTelemetry] with
+///     hashed `friendship_id_hash` parameters (ADR-0013 PII guard).
+class SendReminderController extends StateNotifier<SendReminderState> {
+  /// Creates a [SendReminderController].
+  SendReminderController({
+    required this.friendshipId,
+    required ReminderRepository repository,
+    required AnalyticsService analytics,
+    required void Function(DateTime?) writeCooldown,
+  }) : _repository = repository,
+       _analytics = analytics,
+       _writeCooldown = writeCooldown,
+       super(const SendReminderIdle());
+
+  /// The friendship document ID (`uid-a_uid-b`).
+  final String friendshipId;
+
+  final ReminderRepository _repository;
+  final AnalyticsService _analytics;
+  final void Function(DateTime?) _writeCooldown;
+
+  /// Invokes the `sendReminderNotification` callable and drives the
+  /// state machine through Sending → (Success | Error).
+  ///
+  /// Concurrent calls while in [SendReminderSending] are no-ops to
+  /// prevent double-sends. v1.0 callers always omit [message] — the
+  /// server defaults to a hardcoded copy per architect §2.5.
+  Future<void> send({
+    required String toUserId,
+    required String contextType,
+    required String contextId,
+    String? message,
+  }) async {
+    if (state is SendReminderSending) return;
+
+    _logTapped();
+    state = const SendReminderSending();
+
+    final result = await _repository.sendReminder(
+      toUserId: toUserId,
+      contextType: contextType,
+      contextId: contextId,
+      message: message,
+    );
+
+    switch (result) {
+      case ReminderSendSuccess(:final nextAllowedAt):
+        _writeCooldown(nextAllowedAt);
+        state = SendReminderSuccess(nextAllowedAt: nextAllowedAt);
+        _logSucceeded();
+      case ReminderSendRateLimited(:final nextAllowedAt):
+        _writeCooldown(nextAllowedAt);
+        state = SendReminderError(result);
+        _logRateLimited(nextAllowedAt);
+      case ReminderSendRecipientDoesntOwe():
+        state = SendReminderError(result);
+        _logRecipientDoesntOwe();
+      case ReminderSendRecipientPrefsDisabled():
+        state = SendReminderError(result);
+        _logRecipientPrefsDisabled();
+      case ReminderSendRecipientNoTokens():
+        state = SendReminderError(result);
+        _logRecipientNoTokens();
+      case ReminderSendFailed(:final errorCode):
+        state = SendReminderError(result);
+        _logFailed(errorCode);
+    }
+  }
+
+  /// Resets the state to [SendReminderIdle]. Hosts may call this
+  /// after surfacing the error snackbar to clear the "error" sticky
+  /// state.
+  void reset() {
+    state = const SendReminderIdle();
+  }
+
+  // ---------------------------------------------------------------
+  // Telemetry helpers
+  // ---------------------------------------------------------------
+
+  Map<String, Object> get _baseParams => {
+    ReminderTelemetry.paramFriendshipIdHash: hashFriendshipId(friendshipId),
+  };
+
+  void _logTapped() {
+    _analytics.logEvent(
+      name: ReminderTelemetry.tapped,
+      parameters: _baseParams,
+    );
+  }
+
+  void _logSucceeded() {
+    _analytics.logEvent(
+      name: ReminderTelemetry.succeeded,
+      parameters: _baseParams,
+    );
+  }
+
+  void _logRateLimited(DateTime nextAllowedAt) {
+    final seconds = nextAllowedAt
+        .difference(DateTime.now())
+        .inSeconds
+        .clamp(0, 86400);
+    _analytics.logEvent(
+      name: ReminderTelemetry.rateLimited,
+      parameters: <String, Object>{
+        ..._baseParams,
+        ReminderTelemetry.paramNextAllowedInSeconds: seconds,
+      },
+    );
+  }
+
+  void _logRecipientPrefsDisabled() {
+    _analytics.logEvent(
+      name: ReminderTelemetry.recipientPrefsDisabled,
+      parameters: _baseParams,
+    );
+  }
+
+  void _logRecipientNoTokens() {
+    _analytics.logEvent(
+      name: ReminderTelemetry.recipientNoTokens,
+      parameters: _baseParams,
+    );
+  }
+
+  void _logRecipientDoesntOwe() {
+    _analytics.logEvent(
+      name: ReminderTelemetry.recipientDoesntOwe,
+      parameters: _baseParams,
+    );
+  }
+
+  void _logFailed(String errorCode) {
+    _analytics.logEvent(
+      name: ReminderTelemetry.failed,
+      parameters: <String, Object>{
+        ..._baseParams,
+        ReminderTelemetry.paramErrorCode: errorCode,
+      },
+    );
+  }
+}
+
+/// Provides a per-friendship [SendReminderController].
+///
+/// The state is per-friendship so two simultaneous Friend Detail
+/// screens do not stomp on each other's send state.
+final sendReminderControllerProvider = StateNotifierProvider.autoDispose
+    .family<SendReminderController, SendReminderState, String>((
+      ref,
+      friendshipId,
+    ) {
+      return SendReminderController(
+        friendshipId: friendshipId,
+        repository: ref.watch(reminderRepositoryProvider),
+        analytics: ref.watch(analyticsServiceProvider),
+        writeCooldown: (value) {
+          ref.read(reminderCooldownProvider(friendshipId).notifier).state =
+              value;
+        },
+      );
+    });

--- a/lib/features/reminders/data/reminder_repository.dart
+++ b/lib/features/reminders/data/reminder_repository.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
+
+/// Callable signature for the `sendReminderNotification` Cloud
+/// Function. Matches the response shape returned by
+/// `FirebaseFunctions.httpsCallable(...).call(...)`.
+typedef ReminderCallable =
+    Future<Map<String, dynamic>> Function(Map<String, dynamic> data);
+
+/// Exception thrown by [ReminderCallable] when the callable rejects
+/// with a typed `HttpsError`. Repository callers should expect this
+/// shape; the production wiring catches `FirebaseFunctionsException`
+/// at the `cloud_functions` boundary and re-throws as
+/// [ReminderCallableException].
+class ReminderCallableException implements Exception {
+  /// Creates a [ReminderCallableException].
+  const ReminderCallableException({
+    required this.code,
+    required this.errorCode,
+    this.nextAllowedAtIso,
+  });
+
+  /// The Firebase `HttpsError.code` (e.g. `'resource-exhausted'`).
+  final String code;
+
+  /// The server-side `details.errorCode` (e.g. `'RATE_LIMITED'`).
+  final String errorCode;
+
+  /// For `RATE_LIMITED` only — the server-returned next-allowed
+  /// timestamp ISO-8601 string.
+  final String? nextAllowedAtIso;
+
+  @override
+  String toString() =>
+      'ReminderCallableException(code: $code, errorCode: $errorCode)';
+}
+
+/// Repository surface for FR-SE-09 Send Reminder.
+///
+/// Wraps the `sendReminderNotification` Cloud Function callable. The
+/// production override in `main.dart` injects a [ReminderCallable]
+/// backed by `FirebaseFunctions.instance.httpsCallable(...)`; tests
+/// inject a fake callable directly so no Firebase initialisation is
+/// needed.
+///
+/// Returns a [ReminderSendResult] discriminated union. Callers
+/// (controller / UI) switch on the runtime type and never inspect
+/// raw exception fields.
+abstract class ReminderRepository {
+  /// Default constructor for sub-classing / fakes.
+  const ReminderRepository._();
+
+  /// Creates a default [ReminderRepository] backed by [callable].
+  const factory ReminderRepository({required ReminderCallable callable}) =
+      ReminderRepositoryImpl;
+
+  /// Invokes the `sendReminderNotification` callable and maps the
+  /// response (or thrown exception) to a [ReminderSendResult].
+  ///
+  /// v1.0 callers always omit [message] — the server defaults to a
+  /// hardcoded copy per architect §2.5.
+  Future<ReminderSendResult> sendReminder({
+    required String toUserId,
+    required String contextType,
+    required String contextId,
+    String? message,
+  });
+}
+
+/// Concrete implementation of [ReminderRepository].
+class ReminderRepositoryImpl extends ReminderRepository {
+  /// Creates a [ReminderRepositoryImpl] with the given [callable].
+  const ReminderRepositoryImpl({required ReminderCallable callable})
+    : _callable = callable,
+      super._();
+
+  final ReminderCallable _callable;
+
+  @override
+  Future<ReminderSendResult> sendReminder({
+    required String toUserId,
+    required String contextType,
+    required String contextId,
+    String? message,
+  }) async {
+    try {
+      final payload = <String, dynamic>{
+        'toUserId': toUserId,
+        'contextType': contextType,
+        'contextId': contextId,
+      };
+      if (message != null) payload['message'] = message;
+
+      final response = await _callable(payload);
+      final nextAllowedAtIso = response['nextAllowedAtIso'] as String?;
+      if (nextAllowedAtIso == null) {
+        return ReminderSendFailed('UNKNOWN');
+      }
+      return ReminderSendSuccess(
+        nextAllowedAt: DateTime.parse(nextAllowedAtIso),
+      );
+    } on ReminderCallableException catch (e) {
+      switch (e.errorCode) {
+        case 'RATE_LIMITED':
+          final iso = e.nextAllowedAtIso;
+          if (iso == null) return ReminderSendFailed('RATE_LIMITED');
+          return ReminderSendRateLimited(nextAllowedAt: DateTime.parse(iso));
+        case 'RECIPIENT_DOESNT_OWE':
+          return const ReminderSendRecipientDoesntOwe();
+        case 'RECIPIENT_PREFS_DISABLED':
+          return const ReminderSendRecipientPrefsDisabled();
+        case 'RECIPIENT_NO_TOKENS':
+          return const ReminderSendRecipientNoTokens();
+        default:
+          return ReminderSendFailed(e.errorCode);
+      }
+    } on Exception {
+      return ReminderSendFailed('UNKNOWN');
+    }
+  }
+}
+
+/// Provides a [ReminderRepository]. Production overrides in
+/// `main.dart` with the `cloud_functions`-backed callable; tests
+/// override with a fake.
+final reminderRepositoryProvider = Provider<ReminderRepository>((ref) {
+  throw UnimplementedError(
+    'reminderRepositoryProvider must be overridden with a '
+    'ReminderCallable backed by FirebaseFunctions in main.dart.',
+  );
+});

--- a/lib/features/reminders/data/reminder_repository.dart
+++ b/lib/features/reminders/data/reminder_repository.dart
@@ -102,8 +102,9 @@ class ReminderRepositoryImpl extends ReminderRepository {
       if (message != null) payload['message'] = message;
 
       final response = await _callable(payload);
+      final success = response['success'];
       final nextAllowedAtIso = response['nextAllowedAtIso'] as String?;
-      if (nextAllowedAtIso == null) {
+      if (success != true || nextAllowedAtIso == null) {
         return ReminderSendFailed('UNKNOWN');
       }
       return ReminderSendSuccess(

--- a/lib/features/reminders/data/reminder_repository.dart
+++ b/lib/features/reminders/data/reminder_repository.dart
@@ -2,6 +2,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
 
+// ignore_for_file: one_member_abstracts
+//
+// The abstract class exists because [ReminderRepository] is a typed
+// factory constructor surface that hides the concrete
+// [ReminderRepositoryImpl]; this is the established pattern in the
+// codebase (see [SettlementRepository] in
+// lib/features/settlements/data/). Single-method-abstracts is the
+// signal here that the repository is a one-call surface.
+
 /// Callable signature for the `sendReminderNotification` Cloud
 /// Function. Matches the response shape returned by
 /// `FirebaseFunctions.httpsCallable(...).call(...)`.
@@ -48,12 +57,12 @@ class ReminderCallableException implements Exception {
 /// (controller / UI) switch on the runtime type and never inspect
 /// raw exception fields.
 abstract class ReminderRepository {
-  /// Default constructor for sub-classing / fakes.
-  const ReminderRepository._();
-
   /// Creates a default [ReminderRepository] backed by [callable].
   const factory ReminderRepository({required ReminderCallable callable}) =
       ReminderRepositoryImpl;
+
+  /// Default constructor for sub-classing / fakes.
+  const ReminderRepository._();
 
   /// Invokes the `sendReminderNotification` callable and maps the
   /// response (or thrown exception) to a [ReminderSendResult].

--- a/lib/features/reminders/domain/reminder_send_error.dart
+++ b/lib/features/reminders/domain/reminder_send_error.dart
@@ -1,0 +1,69 @@
+/// FR-SE-09 Send Reminder — typed result hierarchy.
+///
+/// Discriminated union returned by [ReminderRepository.sendReminder].
+/// The success variant lives in `reminder_send_success.dart` via
+/// `part`; this file holds the seven error variants that mirror the
+/// typed `HttpsError.details.errorCode` values surfaced by the
+/// `sendReminderNotification` callable.
+library reminder_send_result;
+
+part 'reminder_send_success.dart';
+
+/// Sealed base class — every [ReminderRepository.sendReminder]
+/// outcome is one of the implementing variants. UI consumers should
+/// switch on the runtime type and never instantiate the base class
+/// themselves.
+sealed class ReminderSendResult {
+  /// Creates a [ReminderSendResult].
+  const ReminderSendResult();
+}
+
+/// The callable rejected the request because a prior send to the
+/// same recipient happened within the last 24 hours.
+class ReminderSendRateLimited extends ReminderSendResult {
+  /// Creates a [ReminderSendRateLimited] with the server-returned
+  /// [nextAllowedAt] timestamp.
+  const ReminderSendRateLimited({required this.nextAllowedAt});
+
+  /// Earliest UTC time the sender may issue another reminder to the
+  /// same recipient.
+  final DateTime nextAllowedAt;
+}
+
+/// The recipient does not owe the sender per `simplifiedBalances`
+/// on the parent context. Race-condition outcome (the friend may
+/// have just settled between render and tap).
+class ReminderSendRecipientDoesntOwe extends ReminderSendResult {
+  /// Creates a [ReminderSendRecipientDoesntOwe].
+  const ReminderSendRecipientDoesntOwe();
+}
+
+/// The recipient has `notificationPrefs.reminder == false` and has
+/// opted out of reminder notifications. The rate-limit is NOT
+/// consumed.
+class ReminderSendRecipientPrefsDisabled extends ReminderSendResult {
+  /// Creates a [ReminderSendRecipientPrefsDisabled].
+  const ReminderSendRecipientPrefsDisabled();
+}
+
+/// The recipient has no FCM tokens registered (they have not granted
+/// push permission). The rate-limit is NOT consumed.
+class ReminderSendRecipientNoTokens extends ReminderSendResult {
+  /// Creates a [ReminderSendRecipientNoTokens].
+  const ReminderSendRecipientNoTokens();
+}
+
+/// Catch-all for any other callable failure: network unreachable,
+/// `INTERNAL`, `FCM_DISPATCH_FAILED`, `GROUP_CONTEXT_NOT_SUPPORTED`,
+/// or a non-callable Dart-side exception. The [errorCode] is the
+/// server-side `details.errorCode` when available, or `'UNKNOWN'`
+/// for opaque non-callable failures.
+class ReminderSendFailed extends ReminderSendResult {
+  /// Creates a [ReminderSendFailed].
+  ReminderSendFailed(this.errorCode);
+
+  /// Server-side error code (e.g. `'FCM_DISPATCH_FAILED'`, `'INTERNAL'`,
+  /// `'GROUP_CONTEXT_NOT_SUPPORTED'`) or `'UNKNOWN'` for opaque
+  /// non-callable failures.
+  final String errorCode;
+}

--- a/lib/features/reminders/domain/reminder_send_error.dart
+++ b/lib/features/reminders/domain/reminder_send_error.dart
@@ -1,15 +1,15 @@
 /// FR-SE-09 Send Reminder — typed result hierarchy.
 ///
-/// Discriminated union returned by [ReminderRepository.sendReminder].
+/// Discriminated union returned by `ReminderRepository.sendReminder`.
 /// The success variant lives in `reminder_send_success.dart` via
 /// `part`; this file holds the seven error variants that mirror the
 /// typed `HttpsError.details.errorCode` values surfaced by the
 /// `sendReminderNotification` callable.
-library reminder_send_result;
+library;
 
 part 'reminder_send_success.dart';
 
-/// Sealed base class — every [ReminderRepository.sendReminder]
+/// Sealed base class — every `ReminderRepository.sendReminder`
 /// outcome is one of the implementing variants. UI consumers should
 /// switch on the runtime type and never instantiate the base class
 /// themselves.

--- a/lib/features/reminders/domain/reminder_send_success.dart
+++ b/lib/features/reminders/domain/reminder_send_success.dart
@@ -1,0 +1,21 @@
+/// FR-SE-09 Send Reminder — typed success result.
+///
+/// Returned by [ReminderRepository.sendReminder] when the
+/// `sendReminderNotification` callable resolves with `{ success: true,
+/// nextAllowedAtIso }`. The `nextAllowedAt` field is the server-
+/// computed earliest time at which the same sender may dispatch
+/// another reminder to the same recipient (24h after the successful
+/// send per SRS §4.6).
+part of reminder_send_result;
+
+/// The successful variant of [ReminderSendResult].
+class ReminderSendSuccess extends ReminderSendResult {
+  /// Creates a [ReminderSendSuccess].
+  const ReminderSendSuccess({required this.nextAllowedAt});
+
+  /// Earliest UTC time the sender may issue another reminder to the
+  /// same recipient. Mirrored to `reminderCooldownProvider` by the
+  /// send controller so the OBTSettleUpCard receiving-direction
+  /// button is disabled until this time has passed.
+  final DateTime nextAllowedAt;
+}

--- a/lib/features/reminders/domain/reminder_send_success.dart
+++ b/lib/features/reminders/domain/reminder_send_success.dart
@@ -1,12 +1,12 @@
 /// FR-SE-09 Send Reminder — typed success result.
 ///
-/// Returned by [ReminderRepository.sendReminder] when the
+/// Returned by `ReminderRepository.sendReminder` when the
 /// `sendReminderNotification` callable resolves with `{ success: true,
 /// nextAllowedAtIso }`. The `nextAllowedAt` field is the server-
 /// computed earliest time at which the same sender may dispatch
 /// another reminder to the same recipient (24h after the successful
 /// send per SRS §4.6).
-part of reminder_send_result;
+part of 'reminder_send_error.dart';
 
 /// The successful variant of [ReminderSendResult].
 class ReminderSendSuccess extends ReminderSendResult {

--- a/test/features/friends/friend_detail_screen_widget_test.dart
+++ b/test/features/friends/friend_detail_screen_widget_test.dart
@@ -31,7 +31,6 @@ import 'package:onebytwo/features/friends/presentation/friend_detail_screen.dart
 import 'package:onebytwo/features/friends/presentation/widgets/obt_settle_up_card.dart';
 import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
 import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
-import 'package:onebytwo/features/reminders/domain/reminder_send_success.dart';
 import 'package:onebytwo/features/settlements/application/settle_up_telemetry.dart';
 import 'package:onebytwo/features/settlements/data/settlement_repository.dart';
 import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
@@ -794,9 +793,11 @@ void main() {
     testWidgets(
       'tapping Send Reminder fires the controller and updates cooldown',
       (tester) async {
-        final repo = _StaticReminderRepository(() => ReminderSendSuccess(
-              nextAllowedAt: DateTime.now().add(const Duration(hours: 24)),
-            ));
+        final repo = _StaticReminderRepository(
+          () => ReminderSendSuccess(
+            nextAllowedAt: DateTime.now().add(const Duration(hours: 24)),
+          ),
+        );
         final state = FriendDetailStatePopulated(
           header: _header(
             netBalancePaise: 5000,
@@ -830,80 +831,70 @@ void main() {
       },
     );
 
-    testWidgets(
-      'RATE_LIMITED surfaces snackbar with countdown',
-      (tester) async {
-        final nextAt = DateTime.now().add(
-          const Duration(hours: 5, minutes: 32),
-        );
-        final repo = _StaticReminderRepository(
-          () => ReminderSendRateLimited(nextAllowedAt: nextAt),
-        );
-        final state = FriendDetailStatePopulated(
-          header: _header(
-            netBalancePaise: 5000,
-            balanceState: BalanceState.owed,
-            displayName: 'Bina',
-          ),
-          timeline: const [],
-        );
+    testWidgets('RATE_LIMITED surfaces snackbar with countdown', (
+      tester,
+    ) async {
+      final nextAt = DateTime.now().add(const Duration(hours: 5, minutes: 32));
+      final repo = _StaticReminderRepository(
+        () => ReminderSendRateLimited(nextAllowedAt: nextAt),
+      );
+      final state = FriendDetailStatePopulated(
+        header: _header(
+          netBalancePaise: 5000,
+          balanceState: BalanceState.owed,
+          displayName: 'Bina',
+        ),
+        timeline: const [],
+      );
 
-        await tester.pumpWidget(
-          _buildSubject(
-            initialValue: AsyncData(state),
-            analytics: analytics,
-            settlementRepository: FakeSettlementRepository(),
-            reminderRepository: repo,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _buildSubject(
+          initialValue: AsyncData(state),
+          analytics: analytics,
+          settlementRepository: FakeSettlementRepository(),
+          reminderRepository: repo,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Send Reminder'));
-        await tester.pump();
+      await tester.tap(find.text('Send Reminder'));
+      await tester.pump();
 
-        expect(find.byType(SnackBar), findsOneWidget);
-        expect(
-          find.textContaining('Bina'),
-          findsOneWidget,
-        );
-      },
-    );
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.textContaining('Bina'), findsOneWidget);
+    });
 
-    testWidgets(
-      'RECIPIENT_PREFS_DISABLED surfaces a prefs-off snackbar',
-      (tester) async {
-        final repo = _StaticReminderRepository(
-          () => const ReminderSendRecipientPrefsDisabled(),
-        );
-        final state = FriendDetailStatePopulated(
-          header: _header(
-            netBalancePaise: 5000,
-            balanceState: BalanceState.owed,
-            displayName: 'Bina',
-          ),
-          timeline: const [],
-        );
+    testWidgets('RECIPIENT_PREFS_DISABLED surfaces a prefs-off snackbar', (
+      tester,
+    ) async {
+      final repo = _StaticReminderRepository(
+        () => const ReminderSendRecipientPrefsDisabled(),
+      );
+      final state = FriendDetailStatePopulated(
+        header: _header(
+          netBalancePaise: 5000,
+          balanceState: BalanceState.owed,
+          displayName: 'Bina',
+        ),
+        timeline: const [],
+      );
 
-        await tester.pumpWidget(
-          _buildSubject(
-            initialValue: AsyncData(state),
-            analytics: analytics,
-            settlementRepository: FakeSettlementRepository(),
-            reminderRepository: repo,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _buildSubject(
+          initialValue: AsyncData(state),
+          analytics: analytics,
+          settlementRepository: FakeSettlementRepository(),
+          reminderRepository: repo,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Send Reminder'));
-        await tester.pump();
+      await tester.tap(find.text('Send Reminder'));
+      await tester.pump();
 
-        expect(find.byType(SnackBar), findsOneWidget);
-        expect(
-          find.textContaining('notifications turned off'),
-          findsOneWidget,
-        );
-      },
-    );
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.textContaining('notifications turned off'), findsOneWidget);
+    });
   });
 }
 

--- a/test/features/friends/friend_detail_screen_widget_test.dart
+++ b/test/features/friends/friend_detail_screen_widget_test.dart
@@ -802,7 +802,6 @@ void main() {
           header: _header(
             netBalancePaise: 5000,
             balanceState: BalanceState.owed,
-            displayName: 'Bina',
           ),
           timeline: [
             TimelineExpense(
@@ -839,11 +838,7 @@ void main() {
         () => ReminderSendRateLimited(nextAllowedAt: nextAt),
       );
       final state = FriendDetailStatePopulated(
-        header: _header(
-          netBalancePaise: 5000,
-          balanceState: BalanceState.owed,
-          displayName: 'Bina',
-        ),
+        header: _header(netBalancePaise: 5000, balanceState: BalanceState.owed),
         timeline: const [],
       );
 
@@ -861,7 +856,13 @@ void main() {
       await tester.pump();
 
       expect(find.byType(SnackBar), findsOneWidget);
-      expect(find.textContaining('Bina'), findsOneWidget);
+      // The snackbar text mentions the friend's display name and the
+      // remaining cooldown ("...in 5h 31m." or similar).
+      final snackbarText = find.descendant(
+        of: find.byType(SnackBar),
+        matching: find.textContaining('Bina'),
+      );
+      expect(snackbarText, findsOneWidget);
     });
 
     testWidgets('RECIPIENT_PREFS_DISABLED surfaces a prefs-off snackbar', (
@@ -871,11 +872,7 @@ void main() {
         () => const ReminderSendRecipientPrefsDisabled(),
       );
       final state = FriendDetailStatePopulated(
-        header: _header(
-          netBalancePaise: 5000,
-          balanceState: BalanceState.owed,
-          displayName: 'Bina',
-        ),
+        header: _header(netBalancePaise: 5000, balanceState: BalanceState.owed),
         timeline: const [],
       );
 
@@ -893,7 +890,13 @@ void main() {
       await tester.pump();
 
       expect(find.byType(SnackBar), findsOneWidget);
-      expect(find.textContaining('notifications turned off'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(SnackBar),
+          matching: find.textContaining('notifications turned off'),
+        ),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/features/friends/friend_detail_screen_widget_test.dart
+++ b/test/features/friends/friend_detail_screen_widget_test.dart
@@ -29,6 +29,9 @@ import 'package:onebytwo/features/expenses/presentation/add_expense_bottom_sheet
 import 'package:onebytwo/features/friends/application/friend_detail_provider.dart';
 import 'package:onebytwo/features/friends/presentation/friend_detail_screen.dart';
 import 'package:onebytwo/features/friends/presentation/widgets/obt_settle_up_card.dart';
+import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_success.dart';
 import 'package:onebytwo/features/settlements/application/settle_up_telemetry.dart';
 import 'package:onebytwo/features/settlements/data/settlement_repository.dart';
 import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
@@ -203,6 +206,7 @@ Widget _buildSubject({
   required FakeAnalyticsService analytics,
   FakeExpenseRepository? expenseRepository,
   FakeSettlementRepository? settlementRepository,
+  ReminderRepository? reminderRepository,
 }) {
   return ProviderScope(
     overrides: [
@@ -215,6 +219,8 @@ Widget _buildSubject({
         expenseRepositoryProvider.overrideWithValue(expenseRepository),
       if (settlementRepository != null)
         settlementRepositoryProvider.overrideWithValue(settlementRepository),
+      if (reminderRepository != null)
+        reminderRepositoryProvider.overrideWithValue(reminderRepository),
       friendDetailProvider(_args).overrideWith((ref) {
         switch (initialValue) {
           case AsyncData(:final value):
@@ -624,7 +630,8 @@ void main() {
     });
 
     testWidgets(
-      'does NOT render the OBTSettleUpCard in the owed direction (§2.5 omit)',
+      'renders the receiving-direction OBTSettleUpCard in the owed direction '
+      '(FR-SE-09 supersedes the PR #43 §2.5 omit)',
       (tester) async {
         final state = FriendDetailStatePopulated(
           header: _header(
@@ -643,11 +650,18 @@ void main() {
             initialValue: AsyncData(state),
             analytics: analytics,
             settlementRepository: FakeSettlementRepository(),
+            reminderRepository: _StaticReminderRepository(
+              () => ReminderSendSuccess(
+                nextAllowedAt: DateTime.now().add(const Duration(hours: 24)),
+              ),
+            ),
           ),
         );
         await tester.pumpAndSettle();
 
-        expect(find.byType(OBTSettleUpCard), findsNothing);
+        expect(find.byType(OBTSettleUpCard), findsOneWidget);
+        expect(find.text('Send Reminder'), findsOneWidget);
+        expect(find.text('Settle Up'), findsNothing);
       },
     );
 
@@ -771,4 +785,149 @@ void main() {
       );
     });
   });
+
+  // ===================================================================
+  // FR-SE-09 — Send Reminder receiving-direction wiring
+  // ===================================================================
+
+  group('Send Reminder wiring (FR-SE-09)', () {
+    testWidgets(
+      'tapping Send Reminder fires the controller and updates cooldown',
+      (tester) async {
+        final repo = _StaticReminderRepository(() => ReminderSendSuccess(
+              nextAllowedAt: DateTime.now().add(const Duration(hours: 24)),
+            ));
+        final state = FriendDetailStatePopulated(
+          header: _header(
+            netBalancePaise: 5000,
+            balanceState: BalanceState.owed,
+            displayName: 'Bina',
+          ),
+          timeline: [
+            TimelineExpense(
+              doc: _expense(description: 'Tea', date: DateTime(2026, 6)),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          _buildSubject(
+            initialValue: AsyncData(state),
+            analytics: analytics,
+            settlementRepository: FakeSettlementRepository(),
+            reminderRepository: repo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Send Reminder'));
+        await tester.pumpAndSettle();
+
+        expect(repo.callCount, 1);
+        expect(repo.lastToUserId, 'uid-friend');
+        expect(repo.lastContextId, 'uid-friend_uid-me');
+        expect(repo.lastContextType, 'friendship');
+      },
+    );
+
+    testWidgets(
+      'RATE_LIMITED surfaces snackbar with countdown',
+      (tester) async {
+        final nextAt = DateTime.now().add(
+          const Duration(hours: 5, minutes: 32),
+        );
+        final repo = _StaticReminderRepository(
+          () => ReminderSendRateLimited(nextAllowedAt: nextAt),
+        );
+        final state = FriendDetailStatePopulated(
+          header: _header(
+            netBalancePaise: 5000,
+            balanceState: BalanceState.owed,
+            displayName: 'Bina',
+          ),
+          timeline: const [],
+        );
+
+        await tester.pumpWidget(
+          _buildSubject(
+            initialValue: AsyncData(state),
+            analytics: analytics,
+            settlementRepository: FakeSettlementRepository(),
+            reminderRepository: repo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Send Reminder'));
+        await tester.pump();
+
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(
+          find.textContaining('Bina'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'RECIPIENT_PREFS_DISABLED surfaces a prefs-off snackbar',
+      (tester) async {
+        final repo = _StaticReminderRepository(
+          () => const ReminderSendRecipientPrefsDisabled(),
+        );
+        final state = FriendDetailStatePopulated(
+          header: _header(
+            netBalancePaise: 5000,
+            balanceState: BalanceState.owed,
+            displayName: 'Bina',
+          ),
+          timeline: const [],
+        );
+
+        await tester.pumpWidget(
+          _buildSubject(
+            initialValue: AsyncData(state),
+            analytics: analytics,
+            settlementRepository: FakeSettlementRepository(),
+            reminderRepository: repo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Send Reminder'));
+        await tester.pump();
+
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(
+          find.textContaining('notifications turned off'),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+}
+
+/// Static reminder repository for widget-test wiring.
+class _StaticReminderRepository implements ReminderRepository {
+  _StaticReminderRepository(this._produce);
+
+  final ReminderSendResult Function() _produce;
+  int callCount = 0;
+  String? lastToUserId;
+  String? lastContextType;
+  String? lastContextId;
+
+  @override
+  Future<ReminderSendResult> sendReminder({
+    required String toUserId,
+    required String contextType,
+    required String contextId,
+    String? message,
+  }) async {
+    callCount += 1;
+    lastToUserId = toUserId;
+    lastContextType = contextType;
+    lastContextId = contextId;
+    return _produce();
+  }
 }

--- a/test/features/friends/presentation/widgets/obt_settle_up_card_test.dart
+++ b/test/features/friends/presentation/widgets/obt_settle_up_card_test.dart
@@ -40,7 +40,7 @@ void main() {
 
       expect(find.text('Settle Up'), findsOneWidget);
       expect(find.text('Send Reminder'), findsNothing);
-      expect(find.text('\u20B9500'), findsOneWidget);
+      expect(find.text('\u20B9500.00'), findsOneWidget);
 
       await tester.tap(find.text('Settle Up'));
       await tester.pump();
@@ -69,7 +69,7 @@ void main() {
 
       expect(find.text('Send Reminder'), findsOneWidget);
       expect(find.text('Settle Up'), findsNothing);
-      expect(find.text('\u20B9500'), findsOneWidget);
+      expect(find.text('\u20B9500.00'), findsOneWidget);
     });
 
     testWidgets('tapping Send Reminder fires onSendReminder', (tester) async {

--- a/test/features/friends/presentation/widgets/obt_settle_up_card_test.dart
+++ b/test/features/friends/presentation/widgets/obt_settle_up_card_test.dart
@@ -17,22 +17,26 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:onebytwo/features/friends/presentation/widgets/obt_settle_up_card.dart';
 
-Widget _wrap(Widget child) =>
-    MaterialApp(home: Scaffold(body: child));
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
   group('OBTSettleUpCard — settling-direction (default)', () {
-    testWidgets('renders Settle Up CTA and fires onSettleUp on tap',
-        (tester) async {
+    testWidgets('renders Settle Up CTA and fires onSettleUp on tap', (
+      tester,
+    ) async {
       var settleTapped = 0;
-      await tester.pumpWidget(_wrap(OBTSettleUpCard(
-        payerDisplayName: 'You',
-        payerPhotoUrl: null,
-        payeeDisplayName: 'Priya',
-        payeePhotoUrl: null,
-        suggestedAmountPaise: 50000,
-        onSettleUp: () => settleTapped += 1,
-      )));
+      await tester.pumpWidget(
+        _wrap(
+          OBTSettleUpCard(
+            payerDisplayName: 'You',
+            payerPhotoUrl: null,
+            payeeDisplayName: 'Priya',
+            payeePhotoUrl: null,
+            suggestedAmountPaise: 50000,
+            onSettleUp: () => settleTapped += 1,
+          ),
+        ),
+      );
 
       expect(find.text('Settle Up'), findsOneWidget);
       expect(find.text('Send Reminder'), findsNothing);
@@ -45,18 +49,23 @@ void main() {
   });
 
   group('OBTSettleUpCard — receiving-direction (FR-SE-09)', () {
-    testWidgets('renders Send Reminder CTA when isReceivingDirection=true',
-        (tester) async {
-      await tester.pumpWidget(_wrap(OBTSettleUpCard(
-        payerDisplayName: 'Priya',
-        payerPhotoUrl: null,
-        payeeDisplayName: 'You',
-        payeePhotoUrl: null,
-        suggestedAmountPaise: 50000,
-        onSettleUp: () {},
-        isReceivingDirection: true,
-        onSendReminder: () {},
-      )));
+    testWidgets('renders Send Reminder CTA when isReceivingDirection=true', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          OBTSettleUpCard(
+            payerDisplayName: 'Priya',
+            payerPhotoUrl: null,
+            payeeDisplayName: 'You',
+            payeePhotoUrl: null,
+            suggestedAmountPaise: 50000,
+            onSettleUp: () {},
+            isReceivingDirection: true,
+            onSendReminder: () {},
+          ),
+        ),
+      );
 
       expect(find.text('Send Reminder'), findsOneWidget);
       expect(find.text('Settle Up'), findsNothing);
@@ -65,16 +74,20 @@ void main() {
 
     testWidgets('tapping Send Reminder fires onSendReminder', (tester) async {
       var reminderTapped = 0;
-      await tester.pumpWidget(_wrap(OBTSettleUpCard(
-        payerDisplayName: 'Priya',
-        payerPhotoUrl: null,
-        payeeDisplayName: 'You',
-        payeePhotoUrl: null,
-        suggestedAmountPaise: 50000,
-        onSettleUp: () {},
-        isReceivingDirection: true,
-        onSendReminder: () => reminderTapped += 1,
-      )));
+      await tester.pumpWidget(
+        _wrap(
+          OBTSettleUpCard(
+            payerDisplayName: 'Priya',
+            payerPhotoUrl: null,
+            payeeDisplayName: 'You',
+            payeePhotoUrl: null,
+            suggestedAmountPaise: 50000,
+            onSettleUp: () {},
+            isReceivingDirection: true,
+            onSendReminder: () => reminderTapped += 1,
+          ),
+        ),
+      );
 
       await tester.tap(find.text('Send Reminder'));
       await tester.pump();
@@ -85,17 +98,21 @@ void main() {
         'nextAllowedAt is in the future', (tester) async {
       final future = DateTime.now().add(const Duration(hours: 5, minutes: 32));
       var reminderTapped = 0;
-      await tester.pumpWidget(_wrap(OBTSettleUpCard(
-        payerDisplayName: 'Priya',
-        payerPhotoUrl: null,
-        payeeDisplayName: 'You',
-        payeePhotoUrl: null,
-        suggestedAmountPaise: 50000,
-        onSettleUp: () {},
-        isReceivingDirection: true,
-        onSendReminder: () => reminderTapped += 1,
-        nextAllowedAt: future,
-      )));
+      await tester.pumpWidget(
+        _wrap(
+          OBTSettleUpCard(
+            payerDisplayName: 'Priya',
+            payerPhotoUrl: null,
+            payeeDisplayName: 'You',
+            payeePhotoUrl: null,
+            suggestedAmountPaise: 50000,
+            onSettleUp: () {},
+            isReceivingDirection: true,
+            onSendReminder: () => reminderTapped += 1,
+            nextAllowedAt: future,
+          ),
+        ),
+      );
 
       final button = tester.widget<FilledButton>(find.byType(FilledButton));
       expect(button.onPressed, isNull);
@@ -105,20 +122,25 @@ void main() {
       expect(captionFinder, findsOneWidget);
     });
 
-    testWidgets('button is enabled when nextAllowedAt is in the past',
-        (tester) async {
+    testWidgets('button is enabled when nextAllowedAt is in the past', (
+      tester,
+    ) async {
       final past = DateTime.now().subtract(const Duration(minutes: 1));
-      await tester.pumpWidget(_wrap(OBTSettleUpCard(
-        payerDisplayName: 'Priya',
-        payerPhotoUrl: null,
-        payeeDisplayName: 'You',
-        payeePhotoUrl: null,
-        suggestedAmountPaise: 50000,
-        onSettleUp: () {},
-        isReceivingDirection: true,
-        onSendReminder: () {},
-        nextAllowedAt: past,
-      )));
+      await tester.pumpWidget(
+        _wrap(
+          OBTSettleUpCard(
+            payerDisplayName: 'Priya',
+            payerPhotoUrl: null,
+            payeeDisplayName: 'You',
+            payeePhotoUrl: null,
+            suggestedAmountPaise: 50000,
+            onSettleUp: () {},
+            isReceivingDirection: true,
+            onSendReminder: () {},
+            nextAllowedAt: past,
+          ),
+        ),
+      );
 
       final button = tester.widget<FilledButton>(find.byType(FilledButton));
       expect(button.onPressed, isNotNull);

--- a/test/features/friends/presentation/widgets/obt_settle_up_card_test.dart
+++ b/test/features/friends/presentation/widgets/obt_settle_up_card_test.dart
@@ -1,0 +1,128 @@
+// OBTSettleUpCard widget tests (FR-SE-07 / FR-SE-09).
+//
+// Covers both directional variants:
+//   - Settling-direction (existing): CTA reads "Settle Up", fires
+//     onSettleUp on tap.
+//   - Receiving-direction (FR-SE-09): CTA reads "Send Reminder",
+//     fires onSendReminder on tap. When nextAllowedAt is in the
+//     future, the button is disabled with a cooldown caption.
+//
+// Written test-first; the receiving-direction parameters will fail
+// to compile until the OBTSettleUpCard extension lands.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:onebytwo/features/friends/presentation/widgets/obt_settle_up_card.dart';
+
+Widget _wrap(Widget child) =>
+    MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('OBTSettleUpCard — settling-direction (default)', () {
+    testWidgets('renders Settle Up CTA and fires onSettleUp on tap',
+        (tester) async {
+      var settleTapped = 0;
+      await tester.pumpWidget(_wrap(OBTSettleUpCard(
+        payerDisplayName: 'You',
+        payerPhotoUrl: null,
+        payeeDisplayName: 'Priya',
+        payeePhotoUrl: null,
+        suggestedAmountPaise: 50000,
+        onSettleUp: () => settleTapped += 1,
+      )));
+
+      expect(find.text('Settle Up'), findsOneWidget);
+      expect(find.text('Send Reminder'), findsNothing);
+      expect(find.text('\u20B9500'), findsOneWidget);
+
+      await tester.tap(find.text('Settle Up'));
+      await tester.pump();
+      expect(settleTapped, 1);
+    });
+  });
+
+  group('OBTSettleUpCard — receiving-direction (FR-SE-09)', () {
+    testWidgets('renders Send Reminder CTA when isReceivingDirection=true',
+        (tester) async {
+      await tester.pumpWidget(_wrap(OBTSettleUpCard(
+        payerDisplayName: 'Priya',
+        payerPhotoUrl: null,
+        payeeDisplayName: 'You',
+        payeePhotoUrl: null,
+        suggestedAmountPaise: 50000,
+        onSettleUp: () {},
+        isReceivingDirection: true,
+        onSendReminder: () {},
+      )));
+
+      expect(find.text('Send Reminder'), findsOneWidget);
+      expect(find.text('Settle Up'), findsNothing);
+      expect(find.text('\u20B9500'), findsOneWidget);
+    });
+
+    testWidgets('tapping Send Reminder fires onSendReminder', (tester) async {
+      var reminderTapped = 0;
+      await tester.pumpWidget(_wrap(OBTSettleUpCard(
+        payerDisplayName: 'Priya',
+        payerPhotoUrl: null,
+        payeeDisplayName: 'You',
+        payeePhotoUrl: null,
+        suggestedAmountPaise: 50000,
+        onSettleUp: () {},
+        isReceivingDirection: true,
+        onSendReminder: () => reminderTapped += 1,
+      )));
+
+      await tester.tap(find.text('Send Reminder'));
+      await tester.pump();
+      expect(reminderTapped, 1);
+    });
+
+    testWidgets('button is disabled and shows cooldown caption when '
+        'nextAllowedAt is in the future', (tester) async {
+      final future = DateTime.now().add(const Duration(hours: 5, minutes: 32));
+      var reminderTapped = 0;
+      await tester.pumpWidget(_wrap(OBTSettleUpCard(
+        payerDisplayName: 'Priya',
+        payerPhotoUrl: null,
+        payeeDisplayName: 'You',
+        payeePhotoUrl: null,
+        suggestedAmountPaise: 50000,
+        onSettleUp: () {},
+        isReceivingDirection: true,
+        onSendReminder: () => reminderTapped += 1,
+        nextAllowedAt: future,
+      )));
+
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+
+      // Caption with hours + minutes count down.
+      final captionFinder = find.textContaining('Next reminder in');
+      expect(captionFinder, findsOneWidget);
+    });
+
+    testWidgets('button is enabled when nextAllowedAt is in the past',
+        (tester) async {
+      final past = DateTime.now().subtract(const Duration(minutes: 1));
+      await tester.pumpWidget(_wrap(OBTSettleUpCard(
+        payerDisplayName: 'Priya',
+        payerPhotoUrl: null,
+        payeeDisplayName: 'You',
+        payeePhotoUrl: null,
+        suggestedAmountPaise: 50000,
+        onSettleUp: () {},
+        isReceivingDirection: true,
+        onSendReminder: () {},
+        nextAllowedAt: past,
+      )));
+
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNotNull);
+      expect(find.textContaining('Next reminder in'), findsNothing);
+    });
+  });
+}

--- a/test/features/reminders/application/reminder_cooldown_provider_test.dart
+++ b/test/features/reminders/application/reminder_cooldown_provider_test.dart
@@ -18,19 +18,15 @@ void main() {
     test('initial value is null for any friendshipId', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
-      expect(
-        container.read(reminderCooldownProvider('uid-a_uid-b')),
-        isNull,
-      );
+      expect(container.read(reminderCooldownProvider('uid-a_uid-b')), isNull);
     });
 
     test('set value is held for the same friendshipId', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final next = DateTime.utc(2026, 6, 9, 12);
-      container
-          .read(reminderCooldownProvider('uid-a_uid-b').notifier)
-          .state = next;
+      container.read(reminderCooldownProvider('uid-a_uid-b').notifier).state =
+          next;
       expect(
         container.read(reminderCooldownProvider('uid-a_uid-b')),
         equals(next),
@@ -41,13 +37,9 @@ void main() {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final t1 = DateTime.utc(2026, 6, 9, 12);
-      container
-          .read(reminderCooldownProvider('uid-a_uid-b').notifier)
-          .state = t1;
-      expect(
-        container.read(reminderCooldownProvider('uid-c_uid-d')),
-        isNull,
-      );
+      container.read(reminderCooldownProvider('uid-a_uid-b').notifier).state =
+          t1;
+      expect(container.read(reminderCooldownProvider('uid-c_uid-d')), isNull);
       expect(
         container.read(reminderCooldownProvider('uid-a_uid-b')),
         equals(t1),
@@ -57,17 +49,13 @@ void main() {
     test('resets to null when the container is disposed and re-created '
         '(in-memory only)', () {
       final container1 = ProviderContainer();
-      container1
-          .read(reminderCooldownProvider('uid-a_uid-b').notifier)
-          .state = DateTime.utc(2026, 6, 9, 12);
+      container1.read(reminderCooldownProvider('uid-a_uid-b').notifier).state =
+          DateTime.utc(2026, 6, 9, 12);
       container1.dispose();
 
       final container2 = ProviderContainer();
       addTearDown(container2.dispose);
-      expect(
-        container2.read(reminderCooldownProvider('uid-a_uid-b')),
-        isNull,
-      );
+      expect(container2.read(reminderCooldownProvider('uid-a_uid-b')), isNull);
     });
   });
 }

--- a/test/features/reminders/application/reminder_cooldown_provider_test.dart
+++ b/test/features/reminders/application/reminder_cooldown_provider_test.dart
@@ -1,0 +1,73 @@
+// FR-SE-09 reminderCooldownProvider unit tests.
+//
+// The cooldown provider holds an optional `DateTime` (the
+// `nextAllowedAt` server response) per friendshipId. v1.0 is in-
+// memory only — the provider RESETS on app launch (provider container
+// disposal) per architect §2.6 of FR-SE-09-send-reminder.md. The
+// server is the authoritative gate.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:onebytwo/features/reminders/application/reminder_cooldown_provider.dart';
+
+void main() {
+  group('reminderCooldownProvider', () {
+    test('initial value is null for any friendshipId', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(
+        container.read(reminderCooldownProvider('uid-a_uid-b')),
+        isNull,
+      );
+    });
+
+    test('set value is held for the same friendshipId', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final next = DateTime.utc(2026, 6, 9, 12);
+      container
+          .read(reminderCooldownProvider('uid-a_uid-b').notifier)
+          .state = next;
+      expect(
+        container.read(reminderCooldownProvider('uid-a_uid-b')),
+        equals(next),
+      );
+    });
+
+    test('per-friendship isolation — sibling friendshipIds independent', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final t1 = DateTime.utc(2026, 6, 9, 12);
+      container
+          .read(reminderCooldownProvider('uid-a_uid-b').notifier)
+          .state = t1;
+      expect(
+        container.read(reminderCooldownProvider('uid-c_uid-d')),
+        isNull,
+      );
+      expect(
+        container.read(reminderCooldownProvider('uid-a_uid-b')),
+        equals(t1),
+      );
+    });
+
+    test('resets to null when the container is disposed and re-created '
+        '(in-memory only)', () {
+      final container1 = ProviderContainer();
+      container1
+          .read(reminderCooldownProvider('uid-a_uid-b').notifier)
+          .state = DateTime.utc(2026, 6, 9, 12);
+      container1.dispose();
+
+      final container2 = ProviderContainer();
+      addTearDown(container2.dispose);
+      expect(
+        container2.read(reminderCooldownProvider('uid-a_uid-b')),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/reminders/application/send_reminder_controller_test.dart
+++ b/test/features/reminders/application/send_reminder_controller_test.dart
@@ -21,7 +21,6 @@ import 'package:onebytwo/features/reminders/application/reminder_telemetry.dart'
 import 'package:onebytwo/features/reminders/application/send_reminder_controller.dart';
 import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
 import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
-import 'package:onebytwo/features/reminders/domain/reminder_send_success.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes
@@ -81,132 +80,137 @@ ProviderContainer _createContainer({
 
 void main() {
   group('SendReminderController.send', () {
-    test('happy path emits Sending → Success and sets cooldownProvider',
-        () async {
-      final repo = FakeReminderRepository()
-        ..produceResult = () => ReminderSendSuccess(
-              nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
-            );
-      final analytics = FakeAnalyticsService();
-      final container = _createContainer(repo: repo, analytics: analytics);
-      addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+    test(
+      'happy path emits Sending → Success and sets cooldownProvider',
+      () async {
+        final repo = FakeReminderRepository()
+          ..produceResult = () =>
+              ReminderSendSuccess(nextAllowedAt: DateTime.utc(2026, 6, 9, 12));
+        final analytics = FakeAnalyticsService();
+        final container = _createContainer(repo: repo, analytics: analytics);
+        addTearDown(container.dispose);
+        final controller = container.read(
+          sendReminderControllerProvider(_friendshipId).notifier,
+        );
 
-      final transitions = <SendReminderState>[];
-      container.listen<SendReminderState>(
-        sendReminderControllerProvider(_friendshipId),
-        (_, next) => transitions.add(next),
-        fireImmediately: true,
-      );
+        final transitions = <SendReminderState>[];
+        container.listen<SendReminderState>(
+          sendReminderControllerProvider(_friendshipId),
+          (_, next) => transitions.add(next),
+          fireImmediately: true,
+        );
 
-      await controller.send(
-        toUserId: _recipientUid,
-        contextType: 'friendship',
-        contextId: _friendshipId,
-      );
+        await controller.send(
+          toUserId: _recipientUid,
+          contextType: 'friendship',
+          contextId: _friendshipId,
+        );
 
-      expect(repo.callCount, 1);
-      expect(repo.capturedToUserId, _recipientUid);
-      expect(repo.capturedContextId, _friendshipId);
-      expect(transitions.first, isA<SendReminderIdle>());
-      expect(
-        transitions.any((s) => s is SendReminderSending),
-        isTrue,
-      );
-      expect(transitions.last, isA<SendReminderSuccess>());
+        expect(repo.callCount, 1);
+        expect(repo.capturedToUserId, _recipientUid);
+        expect(repo.capturedContextId, _friendshipId);
+        expect(transitions.first, isA<SendReminderIdle>());
+        expect(transitions.any((s) => s is SendReminderSending), isTrue);
+        expect(transitions.last, isA<SendReminderSuccess>());
 
-      // Cooldown provider was set to the server-returned nextAllowedAt.
-      expect(
-        container.read(reminderCooldownProvider(_friendshipId)),
-        equals(DateTime.utc(2026, 6, 9, 12)),
-      );
+        // Cooldown provider was set to the server-returned nextAllowedAt.
+        expect(
+          container.read(reminderCooldownProvider(_friendshipId)),
+          equals(DateTime.utc(2026, 6, 9, 12)),
+        );
 
-      // Telemetry: reminder_send_tapped + reminder_send_succeeded.
-      final names = analytics.events.map((e) => e.name).toList();
-      expect(names, contains(ReminderTelemetry.tapped));
-      expect(names, contains(ReminderTelemetry.succeeded));
-      final succeeded = analytics.events.firstWhere(
-        (e) => e.name == ReminderTelemetry.succeeded,
-      );
-      expect(
-        succeeded.parameters?[ReminderTelemetry.paramFriendshipIdHash],
-        equals(hashFriendshipId(_friendshipId)),
-      );
-    });
+        // Telemetry: reminder_send_tapped + reminder_send_succeeded.
+        final names = analytics.events.map((e) => e.name).toList();
+        expect(names, contains(ReminderTelemetry.tapped));
+        expect(names, contains(ReminderTelemetry.succeeded));
+        final succeeded = analytics.events.firstWhere(
+          (e) => e.name == ReminderTelemetry.succeeded,
+        );
+        expect(
+          succeeded.parameters?[ReminderTelemetry.paramFriendshipIdHash],
+          equals(hashFriendshipId(_friendshipId)),
+        );
+      },
+    );
 
-    test('RATE_LIMITED transitions to Error + sets cooldown to server time',
-        () async {
-      final nextAt = DateTime.utc(2026, 6, 8, 23, 30);
-      final repo = FakeReminderRepository()
-        ..produceResult = () => ReminderSendRateLimited(nextAllowedAt: nextAt);
-      final analytics = FakeAnalyticsService();
-      final container = _createContainer(repo: repo, analytics: analytics);
-      addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+    test(
+      'RATE_LIMITED transitions to Error + sets cooldown to server time',
+      () async {
+        final nextAt = DateTime.utc(2026, 6, 8, 23, 30);
+        final repo = FakeReminderRepository()
+          ..produceResult = () =>
+              ReminderSendRateLimited(nextAllowedAt: nextAt);
+        final analytics = FakeAnalyticsService();
+        final container = _createContainer(repo: repo, analytics: analytics);
+        addTearDown(container.dispose);
+        final controller = container.read(
+          sendReminderControllerProvider(_friendshipId).notifier,
+        );
 
-      await controller.send(
-        toUserId: _recipientUid,
-        contextType: 'friendship',
-        contextId: _friendshipId,
-      );
+        await controller.send(
+          toUserId: _recipientUid,
+          contextType: 'friendship',
+          contextId: _friendshipId,
+        );
 
-      final state = container.read(
-        sendReminderControllerProvider(_friendshipId),
-      );
-      expect(state, isA<SendReminderError>());
-      final err = state as SendReminderError;
-      expect(err.error, isA<ReminderSendRateLimited>());
+        final state = container.read(
+          sendReminderControllerProvider(_friendshipId),
+        );
+        expect(state, isA<SendReminderError>());
+        final err = state as SendReminderError;
+        expect(err.error, isA<ReminderSendRateLimited>());
 
-      // Cooldown provider matches the server's nextAllowedAt.
-      expect(
-        container.read(reminderCooldownProvider(_friendshipId)),
-        equals(nextAt),
-      );
+        // Cooldown provider matches the server's nextAllowedAt.
+        expect(
+          container.read(reminderCooldownProvider(_friendshipId)),
+          equals(nextAt),
+        );
 
-      final names = analytics.events.map((e) => e.name).toList();
-      expect(names, contains(ReminderTelemetry.rateLimited));
-      final rl = analytics.events.firstWhere(
-        (e) => e.name == ReminderTelemetry.rateLimited,
-      );
-      expect(rl.parameters?[ReminderTelemetry.paramNextAllowedInSeconds],
-          isA<int>());
-    });
+        final names = analytics.events.map((e) => e.name).toList();
+        expect(names, contains(ReminderTelemetry.rateLimited));
+        final rl = analytics.events.firstWhere(
+          (e) => e.name == ReminderTelemetry.rateLimited,
+        );
+        expect(
+          rl.parameters?[ReminderTelemetry.paramNextAllowedInSeconds],
+          isA<int>(),
+        );
+      },
+    );
 
-    test('RECIPIENT_PREFS_DISABLED → Error + prefs telemetry; no cooldown set',
-        () async {
-      final repo = FakeReminderRepository()
-        ..produceResult = () => const ReminderSendRecipientPrefsDisabled();
-      final analytics = FakeAnalyticsService();
-      final container = _createContainer(repo: repo, analytics: analytics);
-      addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+    test(
+      'RECIPIENT_PREFS_DISABLED → Error + prefs telemetry; no cooldown set',
+      () async {
+        final repo = FakeReminderRepository()
+          ..produceResult = () => const ReminderSendRecipientPrefsDisabled();
+        final analytics = FakeAnalyticsService();
+        final container = _createContainer(repo: repo, analytics: analytics);
+        addTearDown(container.dispose);
+        final controller = container.read(
+          sendReminderControllerProvider(_friendshipId).notifier,
+        );
 
-      await controller.send(
-        toUserId: _recipientUid,
-        contextType: 'friendship',
-        contextId: _friendshipId,
-      );
+        await controller.send(
+          toUserId: _recipientUid,
+          contextType: 'friendship',
+          contextId: _friendshipId,
+        );
 
-      final state = container.read(
-        sendReminderControllerProvider(_friendshipId),
-      );
-      expect(state, isA<SendReminderError>());
-      expect(
-        (state as SendReminderError).error,
-        isA<ReminderSendRecipientPrefsDisabled>(),
-      );
-      expect(
-        container.read(reminderCooldownProvider(_friendshipId)),
-        isNull,
-      );
-      expect(
-        analytics.events.map((e) => e.name),
-        contains(ReminderTelemetry.recipientPrefsDisabled),
-      );
-    });
+        final state = container.read(
+          sendReminderControllerProvider(_friendshipId),
+        );
+        expect(state, isA<SendReminderError>());
+        expect(
+          (state as SendReminderError).error,
+          isA<ReminderSendRecipientPrefsDisabled>(),
+        );
+        expect(container.read(reminderCooldownProvider(_friendshipId)), isNull);
+        expect(
+          analytics.events.map((e) => e.name),
+          contains(ReminderTelemetry.recipientPrefsDisabled),
+        );
+      },
+    );
 
     test('RECIPIENT_NO_TOKENS → Error + no-tokens telemetry', () async {
       final repo = FakeReminderRepository()
@@ -214,8 +218,9 @@ void main() {
       final analytics = FakeAnalyticsService();
       final container = _createContainer(repo: repo, analytics: analytics);
       addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+      final controller = container.read(
+        sendReminderControllerProvider(_friendshipId).notifier,
+      );
 
       await controller.send(
         toUserId: _recipientUid,
@@ -235,8 +240,9 @@ void main() {
       final analytics = FakeAnalyticsService();
       final container = _createContainer(repo: repo, analytics: analytics);
       addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+      final controller = container.read(
+        sendReminderControllerProvider(_friendshipId).notifier,
+      );
 
       await controller.send(
         toUserId: _recipientUid,
@@ -250,39 +256,44 @@ void main() {
       );
     });
 
-    test('ReminderSendFailed → Error + failed telemetry with error_code',
-        () async {
-      final repo = FakeReminderRepository()
-        ..produceResult = () => ReminderSendFailed('FCM_DISPATCH_FAILED');
-      final analytics = FakeAnalyticsService();
-      final container = _createContainer(repo: repo, analytics: analytics);
-      addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+    test(
+      'ReminderSendFailed → Error + failed telemetry with error_code',
+      () async {
+        final repo = FakeReminderRepository()
+          ..produceResult = () => ReminderSendFailed('FCM_DISPATCH_FAILED');
+        final analytics = FakeAnalyticsService();
+        final container = _createContainer(repo: repo, analytics: analytics);
+        addTearDown(container.dispose);
+        final controller = container.read(
+          sendReminderControllerProvider(_friendshipId).notifier,
+        );
 
-      await controller.send(
-        toUserId: _recipientUid,
-        contextType: 'friendship',
-        contextId: _friendshipId,
-      );
+        await controller.send(
+          toUserId: _recipientUid,
+          contextType: 'friendship',
+          contextId: _friendshipId,
+        );
 
-      final failed = analytics.events.firstWhere(
-        (e) => e.name == ReminderTelemetry.failed,
-      );
-      expect(failed.parameters?[ReminderTelemetry.paramErrorCode],
-          equals('FCM_DISPATCH_FAILED'));
-    });
+        final failed = analytics.events.firstWhere(
+          (e) => e.name == ReminderTelemetry.failed,
+        );
+        expect(
+          failed.parameters?[ReminderTelemetry.paramErrorCode],
+          equals('FCM_DISPATCH_FAILED'),
+        );
+      },
+    );
 
     test('telemetry never logs raw friendshipId — PII guard', () async {
       final repo = FakeReminderRepository()
-        ..produceResult = () => ReminderSendSuccess(
-              nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
-            );
+        ..produceResult = () =>
+            ReminderSendSuccess(nextAllowedAt: DateTime.utc(2026, 6, 9, 12));
       final analytics = FakeAnalyticsService();
       final container = _createContainer(repo: repo, analytics: analytics);
       addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+      final controller = container.read(
+        sendReminderControllerProvider(_friendshipId).notifier,
+      );
 
       await controller.send(
         toUserId: _recipientUid,
@@ -297,37 +308,40 @@ void main() {
       expect(serialized, contains(hashFriendshipId(_friendshipId)));
     });
 
-    test('concurrent send() calls — second is short-circuited while sending',
-        () async {
-      var resolvedFirst = false;
-      final repo = FakeReminderRepository()
-        ..produceResult = () {
-          resolvedFirst = true;
-          return ReminderSendSuccess(
-            nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
-          );
-        };
-      final analytics = FakeAnalyticsService();
-      final container = _createContainer(repo: repo, analytics: analytics);
-      addTearDown(container.dispose);
-      final controller = container
-          .read(sendReminderControllerProvider(_friendshipId).notifier);
+    test(
+      'concurrent send() calls — second is short-circuited while sending',
+      () async {
+        var resolvedFirst = false;
+        final repo = FakeReminderRepository()
+          ..produceResult = () {
+            resolvedFirst = true;
+            return ReminderSendSuccess(
+              nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
+            );
+          };
+        final analytics = FakeAnalyticsService();
+        final container = _createContainer(repo: repo, analytics: analytics);
+        addTearDown(container.dispose);
+        final controller = container.read(
+          sendReminderControllerProvider(_friendshipId).notifier,
+        );
 
-      final first = controller.send(
-        toUserId: _recipientUid,
-        contextType: 'friendship',
-        contextId: _friendshipId,
-      );
-      // Second concurrent call should be a no-op while the first is in
-      // flight.
-      final second = controller.send(
-        toUserId: _recipientUid,
-        contextType: 'friendship',
-        contextId: _friendshipId,
-      );
-      await Future.wait([first, second]);
-      expect(resolvedFirst, isTrue);
-      expect(repo.callCount, 1);
-    });
+        final first = controller.send(
+          toUserId: _recipientUid,
+          contextType: 'friendship',
+          contextId: _friendshipId,
+        );
+        // Second concurrent call should be a no-op while the first is in
+        // flight.
+        final second = controller.send(
+          toUserId: _recipientUid,
+          contextType: 'friendship',
+          contextId: _friendshipId,
+        );
+        await Future.wait([first, second]);
+        expect(resolvedFirst, isTrue);
+        expect(repo.callCount, 1);
+      },
+    );
   });
 }

--- a/test/features/reminders/application/send_reminder_controller_test.dart
+++ b/test/features/reminders/application/send_reminder_controller_test.dart
@@ -1,0 +1,333 @@
+// FR-SE-09 SendReminderController state-machine tests.
+//
+// Mirrors test/features/settlements/settle_up_controller_test.dart:
+// fake repository + fake analytics service, no Firebase required.
+//
+// The controller drives the in-progress / success / error states for
+// the "Send Reminder" button on the OBTSettleUpCard receiving-direction
+// variant, sets the reminderCooldownProvider on success or RATE_LIMITED,
+// and emits the reminder_send_* client telemetry family with hashed
+// friendship_id parameters per ADR-0013.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:onebytwo/core/telemetry/event_id_hash.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/reminders/application/reminder_cooldown_provider.dart';
+import 'package:onebytwo/features/reminders/application/reminder_telemetry.dart';
+import 'package:onebytwo/features/reminders/application/send_reminder_controller.dart';
+import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_success.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeReminderRepository implements ReminderRepository {
+  ReminderSendResult Function()? produceResult;
+  String? capturedToUserId;
+  String? capturedContextType;
+  String? capturedContextId;
+  String? capturedMessage;
+  int callCount = 0;
+
+  @override
+  Future<ReminderSendResult> sendReminder({
+    required String toUserId,
+    required String contextType,
+    required String contextId,
+    String? message,
+  }) async {
+    callCount += 1;
+    capturedToUserId = toUserId;
+    capturedContextType = contextType;
+    capturedContextId = contextId;
+    capturedMessage = message;
+    return (produceResult ?? () => ReminderSendFailed('UNKNOWN'))();
+  }
+}
+
+class FakeAnalyticsService implements AnalyticsService {
+  final List<({String name, Map<String, Object>? parameters})> events =
+      <({String name, Map<String, Object>? parameters})>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object>? parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+}
+
+const _friendshipId = 'uid-sender_uid-recipient';
+const _recipientUid = 'uid-recipient';
+
+ProviderContainer _createContainer({
+  required FakeReminderRepository repo,
+  required FakeAnalyticsService analytics,
+}) {
+  return ProviderContainer(
+    overrides: [
+      reminderRepositoryProvider.overrideWithValue(repo),
+      analyticsServiceProvider.overrideWithValue(analytics),
+    ],
+  );
+}
+
+void main() {
+  group('SendReminderController.send', () {
+    test('happy path emits Sending → Success and sets cooldownProvider',
+        () async {
+      final repo = FakeReminderRepository()
+        ..produceResult = () => ReminderSendSuccess(
+              nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
+            );
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      final transitions = <SendReminderState>[];
+      container.listen<SendReminderState>(
+        sendReminderControllerProvider(_friendshipId),
+        (_, next) => transitions.add(next),
+        fireImmediately: true,
+      );
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      expect(repo.callCount, 1);
+      expect(repo.capturedToUserId, _recipientUid);
+      expect(repo.capturedContextId, _friendshipId);
+      expect(transitions.first, isA<SendReminderIdle>());
+      expect(
+        transitions.any((s) => s is SendReminderSending),
+        isTrue,
+      );
+      expect(transitions.last, isA<SendReminderSuccess>());
+
+      // Cooldown provider was set to the server-returned nextAllowedAt.
+      expect(
+        container.read(reminderCooldownProvider(_friendshipId)),
+        equals(DateTime.utc(2026, 6, 9, 12)),
+      );
+
+      // Telemetry: reminder_send_tapped + reminder_send_succeeded.
+      final names = analytics.events.map((e) => e.name).toList();
+      expect(names, contains(ReminderTelemetry.tapped));
+      expect(names, contains(ReminderTelemetry.succeeded));
+      final succeeded = analytics.events.firstWhere(
+        (e) => e.name == ReminderTelemetry.succeeded,
+      );
+      expect(
+        succeeded.parameters?[ReminderTelemetry.paramFriendshipIdHash],
+        equals(hashFriendshipId(_friendshipId)),
+      );
+    });
+
+    test('RATE_LIMITED transitions to Error + sets cooldown to server time',
+        () async {
+      final nextAt = DateTime.utc(2026, 6, 8, 23, 30);
+      final repo = FakeReminderRepository()
+        ..produceResult = () => ReminderSendRateLimited(nextAllowedAt: nextAt);
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      final state = container.read(
+        sendReminderControllerProvider(_friendshipId),
+      );
+      expect(state, isA<SendReminderError>());
+      final err = state as SendReminderError;
+      expect(err.error, isA<ReminderSendRateLimited>());
+
+      // Cooldown provider matches the server's nextAllowedAt.
+      expect(
+        container.read(reminderCooldownProvider(_friendshipId)),
+        equals(nextAt),
+      );
+
+      final names = analytics.events.map((e) => e.name).toList();
+      expect(names, contains(ReminderTelemetry.rateLimited));
+      final rl = analytics.events.firstWhere(
+        (e) => e.name == ReminderTelemetry.rateLimited,
+      );
+      expect(rl.parameters?[ReminderTelemetry.paramNextAllowedInSeconds],
+          isA<int>());
+    });
+
+    test('RECIPIENT_PREFS_DISABLED → Error + prefs telemetry; no cooldown set',
+        () async {
+      final repo = FakeReminderRepository()
+        ..produceResult = () => const ReminderSendRecipientPrefsDisabled();
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      final state = container.read(
+        sendReminderControllerProvider(_friendshipId),
+      );
+      expect(state, isA<SendReminderError>());
+      expect(
+        (state as SendReminderError).error,
+        isA<ReminderSendRecipientPrefsDisabled>(),
+      );
+      expect(
+        container.read(reminderCooldownProvider(_friendshipId)),
+        isNull,
+      );
+      expect(
+        analytics.events.map((e) => e.name),
+        contains(ReminderTelemetry.recipientPrefsDisabled),
+      );
+    });
+
+    test('RECIPIENT_NO_TOKENS → Error + no-tokens telemetry', () async {
+      final repo = FakeReminderRepository()
+        ..produceResult = () => const ReminderSendRecipientNoTokens();
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      expect(
+        analytics.events.map((e) => e.name),
+        contains(ReminderTelemetry.recipientNoTokens),
+      );
+    });
+
+    test('RECIPIENT_DOESNT_OWE → Error + doesnt-owe telemetry', () async {
+      final repo = FakeReminderRepository()
+        ..produceResult = () => const ReminderSendRecipientDoesntOwe();
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      expect(
+        analytics.events.map((e) => e.name),
+        contains(ReminderTelemetry.recipientDoesntOwe),
+      );
+    });
+
+    test('ReminderSendFailed → Error + failed telemetry with error_code',
+        () async {
+      final repo = FakeReminderRepository()
+        ..produceResult = () => ReminderSendFailed('FCM_DISPATCH_FAILED');
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      final failed = analytics.events.firstWhere(
+        (e) => e.name == ReminderTelemetry.failed,
+      );
+      expect(failed.parameters?[ReminderTelemetry.paramErrorCode],
+          equals('FCM_DISPATCH_FAILED'));
+    });
+
+    test('telemetry never logs raw friendshipId — PII guard', () async {
+      final repo = FakeReminderRepository()
+        ..produceResult = () => ReminderSendSuccess(
+              nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
+            );
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      await controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+
+      final serialized = analytics.events
+          .map((e) => '${e.name}::${e.parameters}')
+          .join('|');
+      expect(serialized, isNot(contains(_friendshipId)));
+      expect(serialized, contains(hashFriendshipId(_friendshipId)));
+    });
+
+    test('concurrent send() calls — second is short-circuited while sending',
+        () async {
+      var resolvedFirst = false;
+      final repo = FakeReminderRepository()
+        ..produceResult = () {
+          resolvedFirst = true;
+          return ReminderSendSuccess(
+            nextAllowedAt: DateTime.utc(2026, 6, 9, 12),
+          );
+        };
+      final analytics = FakeAnalyticsService();
+      final container = _createContainer(repo: repo, analytics: analytics);
+      addTearDown(container.dispose);
+      final controller = container
+          .read(sendReminderControllerProvider(_friendshipId).notifier);
+
+      final first = controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+      // Second concurrent call should be a no-op while the first is in
+      // flight.
+      final second = controller.send(
+        toUserId: _recipientUid,
+        contextType: 'friendship',
+        contextId: _friendshipId,
+      );
+      await Future.wait([first, second]);
+      expect(resolvedFirst, isTrue);
+      expect(repo.callCount, 1);
+    });
+  });
+}

--- a/test/features/reminders/data/reminder_repository_test.dart
+++ b/test/features/reminders/data/reminder_repository_test.dart
@@ -86,6 +86,40 @@ void main() {
     );
 
     test(
+      'maps response with success:false to ReminderSendFailed (defensive)',
+      () async {
+        fakeCallable.responseData = {
+          'success': false,
+          'nextAllowedAtIso': '2026-06-09T12:00:00.000Z',
+        };
+
+        final result = await repository.sendReminder(
+          toUserId: 'uid-recipient',
+          contextType: 'friendship',
+          contextId: 'uid-sender_uid-recipient',
+        );
+
+        expect(result, isA<ReminderSendFailed>());
+        expect((result as ReminderSendFailed).errorCode, 'UNKNOWN');
+      },
+    );
+
+    test(
+      'maps response missing nextAllowedAtIso to ReminderSendFailed',
+      () async {
+        fakeCallable.responseData = {'success': true};
+
+        final result = await repository.sendReminder(
+          toUserId: 'uid-recipient',
+          contextType: 'friendship',
+          contextId: 'uid-sender_uid-recipient',
+        );
+
+        expect(result, isA<ReminderSendFailed>());
+      },
+    );
+
+    test(
       'maps RATE_LIMITED to ReminderSendRateLimited with nextAllowedAt',
       () async {
         fakeCallable.throwError = const ReminderCallableException(

--- a/test/features/reminders/data/reminder_repository_test.dart
+++ b/test/features/reminders/data/reminder_repository_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
 import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
-import 'package:onebytwo/features/reminders/domain/reminder_send_success.dart';
 
 /// Configurable callable that simulates the sendReminderNotification
 /// Cloud Function response.
@@ -63,80 +62,87 @@ void main() {
       expect(fakeCallable.capturedData!.containsKey('message'), isFalse);
     });
 
-    test('maps success response to ReminderSendSuccess with nextAllowedAt',
-        () async {
-      fakeCallable.responseData = {
-        'success': true,
-        'nextAllowedAtIso': '2026-06-09T12:00:00.000Z',
-      };
+    test(
+      'maps success response to ReminderSendSuccess with nextAllowedAt',
+      () async {
+        fakeCallable.responseData = {
+          'success': true,
+          'nextAllowedAtIso': '2026-06-09T12:00:00.000Z',
+        };
 
-      final result = await repository.sendReminder(
-        toUserId: 'uid-recipient',
-        contextType: 'friendship',
-        contextId: 'uid-sender_uid-recipient',
-      );
+        final result = await repository.sendReminder(
+          toUserId: 'uid-recipient',
+          contextType: 'friendship',
+          contextId: 'uid-sender_uid-recipient',
+        );
 
-      expect(result, isA<ReminderSendSuccess>());
-      final success = result as ReminderSendSuccess;
-      expect(
-        success.nextAllowedAt.toIso8601String(),
-        '2026-06-09T12:00:00.000Z',
-      );
-    });
+        expect(result, isA<ReminderSendSuccess>());
+        final success = result as ReminderSendSuccess;
+        expect(
+          success.nextAllowedAt.toIso8601String(),
+          '2026-06-09T12:00:00.000Z',
+        );
+      },
+    );
 
-    test('maps RATE_LIMITED to ReminderSendRateLimited with nextAllowedAt',
-        () async {
-      fakeCallable.throwError = const ReminderCallableException(
-        code: 'resource-exhausted',
-        errorCode: 'RATE_LIMITED',
-        nextAllowedAtIso: '2026-06-09T00:00:00.000Z',
-      );
+    test(
+      'maps RATE_LIMITED to ReminderSendRateLimited with nextAllowedAt',
+      () async {
+        fakeCallable.throwError = const ReminderCallableException(
+          code: 'resource-exhausted',
+          errorCode: 'RATE_LIMITED',
+          nextAllowedAtIso: '2026-06-09T00:00:00.000Z',
+        );
 
-      final result = await repository.sendReminder(
-        toUserId: 'uid-recipient',
-        contextType: 'friendship',
-        contextId: 'uid-sender_uid-recipient',
-      );
+        final result = await repository.sendReminder(
+          toUserId: 'uid-recipient',
+          contextType: 'friendship',
+          contextId: 'uid-sender_uid-recipient',
+        );
 
-      expect(result, isA<ReminderSendRateLimited>());
-      final rl = result as ReminderSendRateLimited;
-      expect(rl.nextAllowedAt.toIso8601String(), '2026-06-09T00:00:00.000Z');
-    });
+        expect(result, isA<ReminderSendRateLimited>());
+        final rl = result as ReminderSendRateLimited;
+        expect(rl.nextAllowedAt.toIso8601String(), '2026-06-09T00:00:00.000Z');
+      },
+    );
 
-    test('maps RECIPIENT_DOESNT_OWE to ReminderSendRecipientDoesntOwe',
-        () async {
-      fakeCallable.throwError = const ReminderCallableException(
-        code: 'failed-precondition',
-        errorCode: 'RECIPIENT_DOESNT_OWE',
-      );
+    test(
+      'maps RECIPIENT_DOESNT_OWE to ReminderSendRecipientDoesntOwe',
+      () async {
+        fakeCallable.throwError = const ReminderCallableException(
+          code: 'failed-precondition',
+          errorCode: 'RECIPIENT_DOESNT_OWE',
+        );
 
-      final result = await repository.sendReminder(
-        toUserId: 'uid-recipient',
-        contextType: 'friendship',
-        contextId: 'uid-sender_uid-recipient',
-      );
+        final result = await repository.sendReminder(
+          toUserId: 'uid-recipient',
+          contextType: 'friendship',
+          contextId: 'uid-sender_uid-recipient',
+        );
 
-      expect(result, isA<ReminderSendRecipientDoesntOwe>());
-    });
+        expect(result, isA<ReminderSendRecipientDoesntOwe>());
+      },
+    );
 
-    test('maps RECIPIENT_PREFS_DISABLED to ReminderSendRecipientPrefsDisabled',
-        () async {
-      fakeCallable.throwError = const ReminderCallableException(
-        code: 'failed-precondition',
-        errorCode: 'RECIPIENT_PREFS_DISABLED',
-      );
+    test(
+      'maps RECIPIENT_PREFS_DISABLED to ReminderSendRecipientPrefsDisabled',
+      () async {
+        fakeCallable.throwError = const ReminderCallableException(
+          code: 'failed-precondition',
+          errorCode: 'RECIPIENT_PREFS_DISABLED',
+        );
 
-      final result = await repository.sendReminder(
-        toUserId: 'uid-recipient',
-        contextType: 'friendship',
-        contextId: 'uid-sender_uid-recipient',
-      );
+        final result = await repository.sendReminder(
+          toUserId: 'uid-recipient',
+          contextType: 'friendship',
+          contextId: 'uid-sender_uid-recipient',
+        );
 
-      expect(result, isA<ReminderSendRecipientPrefsDisabled>());
-    });
+        expect(result, isA<ReminderSendRecipientPrefsDisabled>());
+      },
+    );
 
-    test('maps RECIPIENT_NO_TOKENS to ReminderSendRecipientNoTokens',
-        () async {
+    test('maps RECIPIENT_NO_TOKENS to ReminderSendRecipientNoTokens', () async {
       fakeCallable.throwError = const ReminderCallableException(
         code: 'failed-precondition',
         errorCode: 'RECIPIENT_NO_TOKENS',

--- a/test/features/reminders/data/reminder_repository_test.dart
+++ b/test/features/reminders/data/reminder_repository_test.dart
@@ -1,0 +1,200 @@
+// FR-SE-09 ReminderRepository unit tests.
+//
+// Mirrors test/features/friends/matching_repository_test.dart — the
+// callable is mocked behind a typedef so no Firebase initialisation
+// is needed. The repository wraps the `sendReminderNotification`
+// callable and maps Cloud Function exceptions to the typed
+// `ReminderSendResult` discriminated union.
+
+// ignore_for_file: cascade_invocations
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:onebytwo/features/reminders/data/reminder_repository.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
+import 'package:onebytwo/features/reminders/domain/reminder_send_success.dart';
+
+/// Configurable callable that simulates the sendReminderNotification
+/// Cloud Function response.
+class FakeReminderCallable {
+  Map<String, dynamic>? responseData;
+  Exception? throwError;
+  Map<String, dynamic>? capturedData;
+  bool wasCalled = false;
+
+  Future<Map<String, dynamic>> call(Map<String, dynamic> data) async {
+    wasCalled = true;
+    capturedData = data;
+    if (throwError != null) throw throwError!;
+    return responseData!;
+  }
+}
+
+void main() {
+  late FakeReminderCallable fakeCallable;
+  late ReminderRepository repository;
+
+  setUp(() {
+    fakeCallable = FakeReminderCallable();
+    repository = ReminderRepository(callable: fakeCallable.call);
+  });
+
+  group('ReminderRepository.sendReminder', () {
+    test('passes toUserId, contextType, contextId to callable', () async {
+      fakeCallable.responseData = {
+        'success': true,
+        'nextAllowedAtIso': '2026-06-09T12:00:00.000Z',
+      };
+
+      await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(fakeCallable.wasCalled, isTrue);
+      expect(fakeCallable.capturedData!['toUserId'], 'uid-recipient');
+      expect(fakeCallable.capturedData!['contextType'], 'friendship');
+      expect(
+        fakeCallable.capturedData!['contextId'],
+        'uid-sender_uid-recipient',
+      );
+      // v1.0 always omits the optional message field.
+      expect(fakeCallable.capturedData!.containsKey('message'), isFalse);
+    });
+
+    test('maps success response to ReminderSendSuccess with nextAllowedAt',
+        () async {
+      fakeCallable.responseData = {
+        'success': true,
+        'nextAllowedAtIso': '2026-06-09T12:00:00.000Z',
+      };
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendSuccess>());
+      final success = result as ReminderSendSuccess;
+      expect(
+        success.nextAllowedAt.toIso8601String(),
+        '2026-06-09T12:00:00.000Z',
+      );
+    });
+
+    test('maps RATE_LIMITED to ReminderSendRateLimited with nextAllowedAt',
+        () async {
+      fakeCallable.throwError = const ReminderCallableException(
+        code: 'resource-exhausted',
+        errorCode: 'RATE_LIMITED',
+        nextAllowedAtIso: '2026-06-09T00:00:00.000Z',
+      );
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendRateLimited>());
+      final rl = result as ReminderSendRateLimited;
+      expect(rl.nextAllowedAt.toIso8601String(), '2026-06-09T00:00:00.000Z');
+    });
+
+    test('maps RECIPIENT_DOESNT_OWE to ReminderSendRecipientDoesntOwe',
+        () async {
+      fakeCallable.throwError = const ReminderCallableException(
+        code: 'failed-precondition',
+        errorCode: 'RECIPIENT_DOESNT_OWE',
+      );
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendRecipientDoesntOwe>());
+    });
+
+    test('maps RECIPIENT_PREFS_DISABLED to ReminderSendRecipientPrefsDisabled',
+        () async {
+      fakeCallable.throwError = const ReminderCallableException(
+        code: 'failed-precondition',
+        errorCode: 'RECIPIENT_PREFS_DISABLED',
+      );
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendRecipientPrefsDisabled>());
+    });
+
+    test('maps RECIPIENT_NO_TOKENS to ReminderSendRecipientNoTokens',
+        () async {
+      fakeCallable.throwError = const ReminderCallableException(
+        code: 'failed-precondition',
+        errorCode: 'RECIPIENT_NO_TOKENS',
+      );
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendRecipientNoTokens>());
+    });
+
+    test('maps FCM_DISPATCH_FAILED to ReminderSendFailed', () async {
+      fakeCallable.throwError = const ReminderCallableException(
+        code: 'unavailable',
+        errorCode: 'FCM_DISPATCH_FAILED',
+      );
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendFailed>());
+      final failed = result as ReminderSendFailed;
+      expect(failed.errorCode, 'FCM_DISPATCH_FAILED');
+    });
+
+    test('maps an unknown details code to ReminderSendFailed', () async {
+      fakeCallable.throwError = const ReminderCallableException(
+        code: 'internal',
+        errorCode: 'INTERNAL',
+      );
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendFailed>());
+    });
+
+    test('maps a non-callable Exception to ReminderSendFailed', () async {
+      fakeCallable.throwError = Exception('network down');
+
+      final result = await repository.sendReminder(
+        toUserId: 'uid-recipient',
+        contextType: 'friendship',
+        contextId: 'uid-sender_uid-recipient',
+      );
+
+      expect(result, isA<ReminderSendFailed>());
+      final failed = result as ReminderSendFailed;
+      expect(failed.errorCode, 'UNKNOWN');
+    });
+  });
+}

--- a/test/features/reminders/reminders_boundary_contract_test.dart
+++ b/test/features/reminders/reminders_boundary_contract_test.dart
@@ -1,0 +1,144 @@
+// FR-SE-09 reminders feature boundary-contract tests.
+//
+// Mirrors test/features/notifications/notifications_boundary_contract_test.dart.
+// Greps `lib/features/reminders/**` for forbidden patterns that would
+// violate the load-bearing invariants:
+//
+//   - Invariant 1 (paise integers): no `.toDouble()`, no `/ 100`, no
+//     `double ` declarations. The reminder body is server-rendered to
+//     a pre-formatted string; the client just dispatches the callable
+//     and shows server-derived snackbars. Boundary-contract grep is
+//     defence-in-depth (AC-20).
+//
+//   - Invariant 2 (simplifiedBalances server-only): no reference to
+//     the string 'simplifiedBalances' anywhere in the reminders
+//     client feature folder (AC-21).
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('reminders boundary contract — no double / no /100 '
+      '(invariant 1, AC-20)', () {
+    test('lib/features/reminders contains no `.toDouble()`, '
+        '`/ 100`, or `double ` declarations', () {
+      final dir = Directory('lib/features/reminders');
+      if (!dir.existsSync()) {
+        fail(
+          'Expected lib/features/reminders to exist; the feature must '
+          'be scaffolded before this contract test can run.',
+        );
+      }
+
+      final violations = _scanForFloatViolations(dir);
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Boundary violations in lib/features/reminders/**:\n'
+            '${violations.join('\n')}',
+      );
+    });
+  });
+
+  group('reminders boundary contract — no simplifiedBalances '
+      '(invariant 2, AC-21)', () {
+    test('lib/features/reminders contains no reference to '
+        'simplifiedBalances', () {
+      final dir = Directory('lib/features/reminders');
+      if (!dir.existsSync()) {
+        fail('Expected lib/features/reminders to exist');
+      }
+
+      final violations = <String>[];
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart')) continue;
+
+        final lines = entity.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          if (_isCommentLine(line)) continue;
+          if (line.contains('simplifiedBalances')) {
+            violations.add(
+              '${entity.path}:${i + 1}: forbidden reference to '
+              'simplifiedBalances (server-maintained, client-read-only)',
+            );
+          }
+        }
+      }
+
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+  });
+
+  group('reminders boundary contract — FR-SE-09 files exist', () {
+    test('the reminders feature scaffold is present so the recursive '
+        'walks above have something to walk', () {
+      const expected = <String>[
+        'lib/features/reminders/data/reminder_repository.dart',
+        'lib/features/reminders/domain/reminder_send_error.dart',
+        'lib/features/reminders/domain/reminder_send_success.dart',
+        'lib/features/reminders/application/send_reminder_controller.dart',
+        'lib/features/reminders/application/reminder_cooldown_provider.dart',
+        'lib/features/reminders/application/reminder_telemetry.dart',
+      ];
+      final missing = <String>[
+        for (final path in expected)
+          if (!File(path).existsSync()) path,
+      ];
+      expect(
+        missing,
+        isEmpty,
+        reason:
+            'FR-SE-09 added these files; if any is missing, the contract '
+            'is broken and the boundary walks above are unable to enforce '
+            'paise / simplifiedBalances guarantees against the new code '
+            'paths.\nMissing: ${missing.join(', ')}',
+      );
+    });
+  });
+}
+
+List<String> _scanForFloatViolations(Directory dir) {
+  final violations = <String>[];
+  for (final entity in dir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.dart')) continue;
+    violations.addAll(_scanFileForFloatViolations(entity));
+  }
+  return violations;
+}
+
+List<String> _scanFileForFloatViolations(File file) {
+  final violations = <String>[];
+  final lines = file.readAsLinesSync();
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (_isCommentLine(line)) continue;
+
+    if (line.contains('.toDouble()')) {
+      violations.add('${file.path}:${i + 1}: forbidden .toDouble()');
+    }
+    if (line.contains(' double ') || line.contains('(double ')) {
+      violations.add('${file.path}:${i + 1}: forbidden `double` declaration');
+    }
+    if (line.contains(RegExp(r'/\s*100\b')) && !line.contains('~/')) {
+      violations.add(
+        '${file.path}:${i + 1}: forbidden `/ 100` paise division '
+        '(server pre-renders the body string; client does no INR math)',
+      );
+    }
+  }
+  return violations;
+}
+
+bool _isCommentLine(String raw) {
+  final trimmed = raw.trim();
+  return trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*');
+}


### PR DESCRIPTION
## Summary

PR #54 ships **FR-SE-09 — Send Reminder + per-friend 24-hour rate limit**, the first downstream consumer of the FR-AC-03 FCM module shipped in PR #53.

A new `sendReminderNotification` HTTPS callable Cloud Function lets an authenticated user nudge a friend who owes them money. The callable composes:

1. Auth + input validation (UNAUTHENTICATED / INVALID_INPUT).
2. Group-context forward-compat short-circuit (GROUP_CONTEXT_NOT_SUPPORTED) — v1.0 ships friendship-context only.
3. Friendship doc read + membership check (NOT_A_MEMBER).
4. `simplifiedBalances` precondition (RECIPIENT_DOESNT_OWE) — Invariant 2 READ for the precondition, never written.
5. Per-friend 24-hour rate-limit pre-check via the new 5-segment `_rateLimits/{senderUid}/sends/{recipientUid}` extension of the PR #45 canonical container (RATE_LIMITED with `nextAllowedAtIso`).
6. Recipient `notificationPrefs.reminder` gate (RECIPIENT_PREFS_DISABLED) + token presence check (RECIPIENT_NO_TOKENS).
7. FCM dispatch via the new `functions/src/notifications/send-reminder-notification.ts` helper exposed through the `NotificationsApi` surface.
8. Full-failure check (FCM_DISPATCH_FAILED — rate-limit NOT recorded per architect §2.5).
9. Rate-limit document write (`succeeded >= 1` only).
10. Activity-feed emission to recipient ONLY (architect §2.3) via the new `'reminder'` event type added to the existing activity validator.

The client side adds a new `lib/features/reminders/` feature folder (repository + sealed result hierarchy + send controller + in-memory cooldown provider + telemetry constants), extends `OBTSettleUpCard` with a receiving-direction variant (`isReceivingDirection: bool`, `onSendReminder: VoidCallback?`, `nextAllowedAt: DateTime?` parameters; settling-direction call site unaffected), and wires the `BalanceState.owed` branch of `FriendDetailScreen` to render the new card + surface per-error-code snackbars.

Closes the SCR-11 open question ("Should the screen support a 'Send Reminder' action inline (FR-SE-09 is P1)") and the PR #43 §2.5 "owed-direction OBTSettleUpCard omit" deferral.

## Story + Architect Notes

`docs/sprint-zero/stories/FR-SE-09-send-reminder.md` (PM + architect-ratified, 22 ACs, 6 SP).

## Invariants

- **Invariant 1 (paise integers):** the `amountPaise` carry-through path from `simplifiedBalances[recipientUid][senderUid]` → `renderPayload('reminder', ...)` → FCM body string is int end-to-end. ZERO inline `/100` arithmetic. New `test/features/reminders/reminders_boundary_contract_test.dart` enforces; existing `functions/test/boundary-contracts/no-double-on-money-fields.test.ts` auto-covers the new server files.
- **Invariant 2 (`simplifiedBalances` server-only):** the callable READS the field for the precondition check; ZERO new writers. Reminder activity items write to `activity/{recipientUid}/items/{auto}`; rate-limit doc writes to `_rateLimits/...` — neither touches `simplifiedBalances`. Boundary-contract grep enforces zero references in `lib/features/reminders/**`.
- **Invariant 3 (system share sheet):** N/A — reminders use FCM push, not the share sheet.
- **Invariant 4 (single Firebase project):** `.firebaserc` unchanged. FCM admin SDK uses the existing `firebase-admin/app` initialisation.

## Test results

| Layer | Before | After | Delta |
|---|---|---|---|
| Functions Jest | 270 / 20 suites | 316 / 22 suites | +46 tests / +2 suites |
| Flutter | 1083 + 30 skipped | 1115 + 30 skipped | +32 tests |
| Rules | 188 / 9 suites | 188 / 9 suites (UNCHANGED — no rules diff) | 0 |

Per-layer gates: `dart format --set-exit-if-changed .`, `flutter analyze --fatal-infos`, `npm run lint`, `npm run build`, `npm test`, `npm run test:rules` all exit 0 (the rules suite shows 6 pre-existing receipts-test storage emulator failures that also reproduce on `main`; unrelated to this PR).

## Files

**Server (new):** `functions/src/send-reminder-notification/{function,index}.ts`, `functions/src/notifications/send-reminder-notification.ts`, `functions/test/send-reminder-notification/function.test.ts`, `functions/test/notifications/send-reminder-notification.test.ts`.

**Server (extended):** `functions/src/notifications/{types,index}.ts`, `functions/src/triggers/on-expense-write/{payload-builder,activity-validator}.ts`, `functions/src/triggers/{on-expense-write,on-settlement-write}/index.ts` (NotificationsApi shape), `functions/src/index.ts`, `functions/test/triggers/on-expense-write/activity-validator.test.ts`, `functions/test/triggers/{on-expense-write,on-settlement-write}/function.test.ts` (mock shape), `functions/jest.config.js` (test root).

**Client (new):** `lib/features/reminders/data/reminder_repository.dart`, `lib/features/reminders/domain/reminder_send_{error,success}.dart`, `lib/features/reminders/application/{send_reminder_controller,reminder_cooldown_provider,reminder_telemetry}.dart`, `test/features/reminders/data/reminder_repository_test.dart`, `test/features/reminders/application/{send_reminder_controller,reminder_cooldown_provider}_test.dart`, `test/features/reminders/reminders_boundary_contract_test.dart`, `test/features/friends/presentation/widgets/obt_settle_up_card_test.dart`.

**Client (extended):** `lib/features/friends/presentation/widgets/obt_settle_up_card.dart`, `lib/features/friends/presentation/friend_detail_screen.dart`, `test/features/friends/friend_detail_screen_widget_test.dart`.

**Docs:** `docs/sprint-zero/stories/FR-SE-09-send-reminder.md` (NEW), `docs/sprint-zero/sprint-2-plan.md`, `docs/sprint-zero/next-three-prs.md`, `docs/audits/sprint-1/07-bucket-b-burndown.md`.

**Untouched:** `firestore.rules` (the existing `match /_rateLimits/{document=**}` deny-all block already covers the new 5-segment path), `firestore.indexes.json`, `storage.rules`, `pubspec.yaml`, `functions/package.json`, all PR #53 FCM module internals.

## Architect-ratified design calls (per FR-SE-09 story §2.1–§2.10)

- **§2.1 Rate-limit doc path:** `_rateLimits/{senderUid}/sends/{recipientUid}` 5-segment extension of the PR #45 canonical `_rateLimits/{userId}/{category}/{key-or-counter}` container.
- **§2.2 FCM dispatch helper placement:** new `notifications/send-reminder-notification.ts` mirror of the existing two helpers; exposed via `NotificationsApi.sendReminderNotification`.
- **§2.3 Activity emission target:** recipient-only.
- **§2.4 Validator extension scope:** ships in this PR alongside the producer; backwards-compatible.
- **§2.5 Default message + rate-limit-on-failure:** server defaults to `"This is a friendly reminder!"`; rate-limit records on `succeeded >= 1` only (full-failure throws `FCM_DISPATCH_FAILED`).
- **§2.6 Client cooldown persistence:** in-memory Riverpod only; server is authoritative.
- **§2.7 OBTSettleUpCard extension:** in-place — extraction to `lib/core/widgets/cards/` remains deferred per PR #43 §2.6.
- **§2.10 Anticipated docs reconciliations:** `cloud-functions-catalogue.md §7` storage path (`reminders/{senderUid}_{toUserId}`) and `RECIPIENT_NO_TOKENS → success: true` shape are SUPERSEDED by these architect ratifications. A docs roll-up PR may update the catalogue post-merge.

## Explicit deferrals (NOT in this PR)

- **FR-PR-03 / FR-AC-04 notification-preferences UI** — separate P1 story; top candidate for PR #55.
- **Group-context reminder producer** — Sprint 3 groups epic; the callable accepts `contextType: 'group'` as forward-compat input and throws `GROUP_CONTEXT_NOT_SUPPORTED` today.
- **Message-compose dialog** — follow-up UX PR; the callable accepts `message?: string` but client v1.0 always omits it.
- **OBTSettleUpCard extraction to `lib/core/widgets/cards/`** — defer until a second host needs it.
- **Persistent client cooldown via `shared_preferences`** — pairs with the deferred PR #53 §2.6 addendum.
- **Sender-side activity emission** — recipient-only for v1.0.
- **`reminderRepositoryProvider` production wiring via `cloud_functions`** — `cloud_functions` is not yet in pubspec; both this and the existing `matchingRepositoryProvider` are throw-until-overridden today. Tracked as a PR #55 candidate chore.
- **SCR-11 overflow-menu reminder action** — primary surface is the OBTSettleUpCard receiving-direction variant.

## References

- SRS §4.6 (FR-SE-09 — "one reminder per friend per 24 hours"), §4.7 (FR-AC-03 / FR-AC-04 prefs filter consumer), §7.3 (Invariant 1).
- `docs/design/07-technical/notifications.md` §6.1 (Reminder Notifications rate-limit enforcement), §2.2 (reminder template), §2.3 (prefs filter).
- `docs/design/07-technical/cloud-functions-catalogue.md` §7 (sendReminderNotification spec — superseded paths noted above).
- `docs/sprint-zero/stories/FR-AC-03-fcm-push-notifications.md` — immediate predecessor.
- `docs/sprint-zero/stories/CHORE-pr45-lookup-rate-limit-and-pr38-cleanup.md` — PR #45 §2.1 / §2.9 ratifying the `_rateLimits/` container.

Next PR: PR #55 — TBD per architect's call at kickoff (top candidate: FR-PR-03 + FR-AC-04 notification preferences UI).
