### PR TITLE
feat(settlements): FR-SE-08 settlement history screen

### DIFF
--- a/docs/audits/sprint-1/07-bucket-b-burndown.md
+++ b/docs/audits/sprint-1/07-bucket-b-burndown.md
@@ -6,7 +6,7 @@
 > Source: `docs/audits/sprint-1/00-triage-summary.md` (Bucket B section).
 > Detail: `docs/audits/sprint-1/06-deferred-to-sprint-2.md`.
 >
-> Last updated: PR #57 (FR-HD-04 persistent FAB + Add Expense context picker + bundled `currentUserIdProvider` production-wiring closure).
+> Last updated: PR #58 (FR-SE-08 dedicated settlement-history screen, SCR-24 — friendship axis; group axis stubbed pending Sprint 3 Groups epic).
 
 ---
 
@@ -913,4 +913,49 @@ implementation. Tracked as a separate ~1-2 SP investigation
 chore on the PR #58 candidate list.
 
 Net contribution of PR #57 to Bucket-B totals: **0**. The
+remaining count stays at **27 / 37**.
+
+### PR #58 (FR-SE-08 dedicated settlement-history screen — P0 feature)
+
+PR #58 is a **3 SP feature PR** that closes the **FR-SE-08 P0**
+SRS row for the dedicated settlement-history surface (friendship
+axis). PR #42 + PR #43 shipped the in-timeline settlement rows that
+satisfied the v1.0 functional commitment; PR #58 delivers the
+design-spec contract — the dedicated `/settle/history` screen
+(SCR-24). PR #58 ships:
+
+1. `SettlementHistoryScreen` (SCR-24) at
+   `lib/features/settlements/presentation/settlement_history_screen.dart`.
+   Generic over `(contextType, contextId)` — the architectural seam
+   the Sprint 3 Group Detail screen inherits. Four states (loading /
+   populated / empty / error) via inline private widgets.
+2. `settlementHistoryProvider` — a `StreamProvider.family` keyed by
+   `SettlementHistoryArgs { contextType, contextId }`, reusing the
+   PR #42 `watchByContext` read path with a 50-item cap.
+3. `settlement_history_telemetry.dart` — the two pre-declared events
+   (`settlement_history_viewed`, `settlement_history_error`); NEITHER
+   carries `context_id` (PII guard, ADR-0013).
+4. The "View Settlement History" link on `FriendDetailScreen`
+   (populated state only; no entry-point telemetry).
+
+**No Bucket-B items closed by PR #58.** FR-SE-08 is a P0 functional
+requirement (closes an SRS row) rather than a Bucket-B audit item.
+Invariants 1 / 2 / 3 / 4 are all N/A on this read-only client
+surface (no money write paths — the per-row amount flows through
+`formatInrFromPaise()`; no `simplifiedBalances` access; no
+share-sheet code; no new Firebase SDK usage). The
+`settlement_history_pii_leak_test.dart` boundary-contract triad
+(Inv-1 + Inv-2 + PII parameter-key) returns zero violations over
+the three new source files.
+
+**No new Bucket-B items filed by PR #58.** Several follow-ups are
+tracked in `docs/sprint-zero/next-three-prs.md` rather than as
+Bucket-B items: the OBT* primitive extractions (`OBTSkeletonLoader`
+/ `OBTEmptyState` / `OBTErrorState` / `OBTUserAvatar` /
+`OBTRupeeText`), cursor-based pagination beyond 50, Group-context
+push wiring, the settlement-detail screen, per-month grouping, the
+share/export action, and the screen-spec vs telemetry-plan
+`context_id` discrepancy docs cleanup.
+
+Net contribution of PR #58 to Bucket-B totals: **0**. The
 remaining count stays at **27 / 37**.

--- a/docs/copilot_prompts/sprint_2/21.md
+++ b/docs/copilot_prompts/sprint_2/21.md
@@ -1,0 +1,390 @@
+1. 1. 1. You are the OneByTwo orchestrator agent. PR #57 (feat — `OBTFloatingActionButton` design-system primitive + `AddExpenseContextPickerSheet` modal + `AuthenticatedShell` FAB integration + `FriendDetailScreen` FAB refactor with `heroTag: 'friendDetailFab'` + `currentUserIdProvider` production wiring in the `AuthenticatedWithProfile(:final uid)` arm of `lib/main.dart` + 2 new shell telemetry events `fab_tapped` / `expense_context_selected` + `dependencies: [currentUserIdProvider]` 2-character additions on `friendsListProvider` and `activityFeedProvider` to make Riverpod 2.x per-arm scoped overrides invalidate correctly) has merged (squash commit `6ece995`) and the **canonical FAB context-picker funnel** is now live: `lib/main.dart:141-144` overrides `currentUserIdProvider` per-arm so the Friends + Activity tabs no longer throw `UnimplementedError` on first read in production; `lib/features/shell/presentation/authenticated_shell.dart:96-115` `_onFabTapped` fires `fab_tapped` then opens `AddExpenseContextPickerSheet` via `showModalBottomSheet`; the picker's `_onFriendSelected` / `_onGroupsTapped` `await` their `logEvent` calls because they sequence with `Navigator.pop` / `ScaffoldMessenger.showSnackBar` where ordering matters (the FAB-tap path is deliberately fire-and-forget per the in-code comment); `lib/features/friends/presentation/friend_detail_screen.dart:135-140` consumes `OBTFloatingActionButton(heroTag: 'friendDetailFab', onPressed: () => _openAddExpenseSheet(context))` so the hero-tag collision-with-shell scenario is impossible even under future `Stack`-based layering; the shell-level FAB always uses the default `heroTag: 'addExpenseFAB'`. Sprint 2 velocity through end of PR #57: **90 SP across 21 PRs**. We now implement **PR #58: FR-SE-08 dedicated settlement-history screen — UX P0 (friendship axis only; group axis stubbed pending Sprint 3 Groups epic)**. This is the natural follow-on per `docs/sprint-zero/next-three-prs.md` PR #58 candidate list (top entry: "FR-SE-08 dedicated full-history settlement screen at `/settle/history` (P0 — PR #42's in-timeline rows satisfy v1.0 functionally but the dedicated screen is still a v1.0 commitment). Natural pairing with the shell + FAB that PR #56 + PR #57 just shipped because the shared nav surface makes the 'All settlements' deep-link target obvious. ~3-5 SP. **Highest-priority follow-up; top candidate for PR #58.**"). The new work is the **`SettlementHistoryScreen` (SCR-24) at the `/settle/history` route taking `(contextType, contextId, currentUserUid, otherUserUid, otherDisplayName)` navigation arguments + `settlementHistoryProvider` family-keyed `StreamProvider` that reuses the existing `SettlementRepository.watchByContext` from PR #42 + `settlement_history_telemetry.dart` constants for the 2 pre-declared telemetry events (`settlement_history_viewed` + `settlement_history_error` per `telemetry-plan.md §1.3 lines 193-194`) + "View Settlement History" text-link entry point on `FriendDetailScreen` (below the timeline) that pushes the new screen via `MaterialPageRoute` with `contextType: 'friendship'` + `contextId: friendshipId` arguments**. Story points: **3** (1 `SettlementHistoryScreen` widget with populated / empty / loading / error states + settlement-row layout per SCR-24 spec + accessibility labels; 1 `settlementHistoryProvider` + telemetry constants + first-frame `settlement_history_viewed` emission + `settlement_history_error` emission on AsyncError + PII-leak guard test; 1 `FriendDetailScreen` "View Settlement History" link integration + widget tests asserting link is visible in Populated state and hidden in Empty state + integration-style widget test asserting the full `tap link → screen mounts → populated list renders` flow). Escalate to 5 SP only if the architect bundles **either** (a) the `OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` design-system primitive extraction (~3-4 SP — three primitives ratified by `components.md §18-20`; PR #42 + PR #43 deliberately shipped INLINE equivalents per the "second use site" deferral pattern, OUT OF SCOPE), OR (b) cursor-based pagination beyond the 50-item cap (~2-3 SP — `SCR-24 §Edge Cases item 1` allows the v1.0 fallback of "fetches the most recent 50 settlements with a 'Load more' button at the bottom" OR a simpler 50-item-hard-cap-with-footer-note; OUT OF SCOPE pending evidence of >50-settlement friendships), OR (c) the FR-EX-06-parallel settlement edit/delete flow (~3-5 SP — separate later PR; the settlements collection schema supports `deleted: false → true` via `firestore.rules isValidSettlementUpdate` per PR #37, but the client-side edit/delete UI is a separate story, OUT OF SCOPE), OR (d) the `OBTRupeeText` primitive long-deferred since PR #52 (~1 SP — would be the second use site if the architect chooses to extract it here; the new screen's settlement-row amount is the natural second consumer; RECOMMENDED defer since the existing PR #57 convention is `formatInrFromPaise()` direct calls). RECOMMENDED: ship the screen + provider + telemetry + the FriendDetailScreen link integration with the 50-item hard cap (no "Load more" footer) + inline empty/error/loading widgets mirroring the PR #42 `FriendDetail*State` pattern + `formatInrFromPaise()` direct calls (no `OBTRupeeText` extraction); defer everything else.
+2. 
+3. 2. 2. The numbering continues from PR #57 — **PR #58 is the next FEATURE PR (P0).** The post-PR-#57 sequence so far: #57 (PR — feat shell, merged `6ece995`), no new issues filed during PR #57 review (the reviewer's three recommendations were addressed in-PR via commits `744614b` rename of the rogue prompt-file commit + `9590ffa` bundled the `currentUserIdProvider` rehoming follow-up tracking entry + the `_onFabTapped` fire-and-forget telemetry comment before merge). Issues #47 (rules-hardening — Sprint 3 candidate), #49 (orphan-cleanup — FUTURE), #50 (trigger no-op optimisation — **EXPLICITLY CONSTRAINED** by FR-EX-07 AC-2) remain OPEN and are NOT touched by PR #58. The orchestrator should not assume PR #59 == GitHub issue 59 — issues and PRs share the same sequential namespace, so any new issues filed during PR #58 will consume intermediate numbers. **Pre-merge CI title-lint gotcha (verified PR #45 through PR #57):** the workflow regex `[a-z0-9_-]+` rejects comma-separated scopes — use a single-token scope, and the SUBJECT (everything after `<scope>: `) must be ≤ 72 characters total. Since this PR adds a new SCR-24 screen under `lib/features/settlements/presentation/` (the existing settlements feature folder), recommend the scope `settlements` (consistent with the feature-folder naming convention used by every prior PR — `feat(activity)`, `feat(notifications)`, `feat(reminders)`, `feat(profile)`, `feat(shell)`). Suggested title (53 chars): `feat(settlements): FR-SE-08 settlement history screen`. Alternative scope `friends` is a poorer match because the new screen lives in `lib/features/settlements/presentation/` and the only `friends/` touch is a one-line "View Settlement History" link addition — the centre of mass is unambiguously in settlements. RECOMMENDED `feat(settlements)` because the screen IS the second screen under that folder (alongside the existing `settle_up_bottom_sheet.dart` from PR #43) AND closes a P0 SRS row owned by the settle-up surface AND the new telemetry events use the `settlement_*` naming prefix consistent with `settle_up_*` from PR #43.
+4. 
+5. 3. 3. PR #58 is the **first PR that introduces a `SettlementHistoryScreen`**, the **first PR that consumes `SettlementRepository.watchByContext` from a UI surface other than the friend-detail timeline composer** (the existing `friend_detail_provider.dart` composes `watchExpensesByFriendship` + `watchByContext('friendship', ...)` into the intermixed timeline; this new screen reads `watchByContext('friendship', ...)` directly), the **first PR that emits the pre-declared `settlement_history_viewed` + `settlement_history_error` events** (both pre-declared in `telemetry-plan.md §1.3 lines 193-194`; no telemetry-plan append needed), the **first PR that ships a screen taking generic `(contextType, contextId)` navigation arguments** (the architectural seam for the Sprint 3 Groups epic — the Group-detail screen will push the same `SettlementHistoryScreen` with `contextType: 'group'`), and the **first PR that closes a P0 SRS row (FR-SE-08) for the dedicated settlement-history surface specifically** (the FR-FR-04 in-timeline rows from PR #42 + PR #43 satisfy the v1.0 functional commitment but the dedicated `/settle/history` route is the design-spec contract). The seams are already in place:
+6.    - **Client side — `SettlementRepository.watchByContext` (PR #42 read path):** the existing repository at `lib/features/settlements/data/settlement_repository.dart:147-156` already returns a `Stream<List<SettlementDoc>>` filtered by `contextType + contextId` AND already excludes soft-deleted entries at the repository layer (line 154). The Firestore composite index `(contextType ASC, contextId ASC, date DESC)` shipped in PR #42 satisfies the canonical query without `FAILED_PRECONDITION`. The new screen consumes this stream verbatim — ZERO changes to `settlement_repository.dart` or `firestore.indexes.json`.
+7.    - **Client side — `currentUserIdProvider` (PR #57 production wiring):** the new screen does NOT read `currentUserIdProvider` directly (the `(contextType, contextId)` arguments fully scope the query). Per architect §2.x — RECOMMENDED pass `currentUserUid` as a screen constructor argument so the screen is provider-agnostic and the friendship-context push from `FriendDetailScreen` threads `currentUserUid: widget.currentUserUid` (matches the existing 3-arg `FriendDetailScreen` constructor convention).
+8.    - **Client side — existing `FriendDetailScreen` (PR #42 SCR-11):** the screen at `lib/features/friends/presentation/friend_detail_screen.dart` currently renders the header + (optional) settle-up card + intermixed top-5 timeline (`FriendDetailTimelineWidget`) inside a `SingleChildScrollView`. **EXTEND** by adding a "View Settlement History" `TextButton` row BELOW the timeline (per SCR-24 §Navigation `Reachable from` row). Visibility logic per architect §2.x — RECOMMENDED show the link UNCONDITIONALLY in the Populated state AND HIDE in the Empty state. The tap handler pushes `MaterialPageRoute(builder: (_) => SettlementHistoryScreen(contextType: 'friendship', contextId: widget.friendshipId, currentUserUid: widget.currentUserUid, otherUserUid: widget.otherUserUid, otherDisplayName: state.header.displayName))`. NO entry-point telemetry event — the destination's `settlement_history_viewed` captures the funnel arrival per architect §2.6.
+9.    - **Client side — NEW `SettlementHistoryScreen`:**
+10.      - **NEW** `lib/features/settlements/presentation/settlement_history_screen.dart` `extends ConsumerStatefulWidget` (state-ful for the one-shot `_logViewedOnce` post-frame callback that fires `settlement_history_viewed` exactly once on the first populated frame — mirrors the `FriendDetailScreen._loggedView` pattern from PR #42). Constructor: 5-arg `SettlementHistoryScreen({required this.contextType, required this.contextId, required this.currentUserUid, required this.otherUserUid, required this.otherDisplayName, super.key})`. Body: `Scaffold(appBar: AppBar(title: const Text('Settlement History')), body: switch (asyncSettlements) { AsyncData(:final value) => value.isEmpty ? _SettlementHistoryEmptyState() : _SettlementHistoryList(...), AsyncLoading() => _SettlementHistoryLoadingState(), AsyncError(:final error) => _SettlementHistoryErrorState(error: error, onRetry: () => ref.invalidate(settlementHistoryProvider(args))) })`. The 50-item hard cap is enforced at the PROVIDER layer per architect §2.2.
+11.    - **Client side — NEW `settlementHistoryProvider`:**
+12.      - **NEW** `lib/features/settlements/application/settlement_history_provider.dart`. Pattern: `final settlementHistoryProvider = StreamProvider.family<List<SettlementDoc>, SettlementHistoryArgs>((ref, args) { final repo = ref.watch(settlementRepositoryProvider); return repo.watchByContext(contextType: args.contextType, contextId: args.contextId).map((all) => all.take(50).toList(growable: false)); });` with `@immutable class SettlementHistoryArgs` defining `==` / `hashCode` for the family-key contract. NO `dependencies: [settlementRepositoryProvider]` — the repository is a root-scope provider with no per-arm override (unlike `currentUserIdProvider`).
+13.    - **Client side — NEW `settlement_history_telemetry.dart`:**
+14.      - **NEW** `lib/features/settlements/application/settlement_history_telemetry.dart` with constants: `settlementHistoryViewedEvent = 'settlement_history_viewed'`, `settlementHistoryErrorEvent = 'settlement_history_error'`, `contextTypeParam = 'context_type'`, `itemCountParam = 'item_count'`, `errorCodeParam = 'error_code'`, `contextTypeFriendship = 'friendship'`, `contextTypeGroup = 'group'`. **PII guard (ADR-0013):** NEITHER event payload carries `contextId` (which would be a UID-composite `{uidA}_{uidB}` for the friendship axis); the `telemetry-plan.md §1.3 lines 193-194` pre-declarations OMIT `context_id` deliberately. The screen-spec at SCR-24 §Telemetry Events lists `context_id` but the telemetry-plan is the authoritative source; architect ratifies the telemetry-plan version at §2.9. Error-code derivation: `'permission-denied'` / `'unavailable'` / `'unknown'` per architect §2.8.
+15.    - **Client side — NEW per-row widget + inline empty/loading/error states (per PR #42 precedent):**
+16.      - Per-row layout per `SCR-24 §Settlement Row Layout` lines 195-208: date `dd MMM yyyy` IST (per SRS §5.9; inline above each row per architect §2.7) + `CircleAvatar` payer (no `OBTUserAvatar` extraction — deferred per architect §2.3) + arrow icon + `CircleAvatar` payee + `formatInrFromPaise(amountPaise)` in `primary` colour + muted note text (hidden if `null`). Minimum row height: 64 dp (ensures 48×48 dp tap targets with padding per SRS §5.6).
+17.      - `_SettlementHistoryLoadingState extends StatelessWidget` — `Center(child: CircularProgressIndicator())` per PR #42 precedent.
+18.      - `_SettlementHistoryEmptyState extends StatelessWidget` — `Center(child: Column(children: [Icon(Icons.history), Text('No settlements yet'), Text('Once you settle up, it will appear here.')]))` per SCR-24 §States row 3. NO CTA button.
+19.      - `_SettlementHistoryErrorState extends StatelessWidget` — `Center(child: Column(children: [Icon(Icons.error_outline), Text('Something went wrong'), Text('We could not load settlement history. Please try again.'), FilledButton(onPressed: onRetry, child: const Text('Retry'))]))` per SCR-24 §States row 4. The "Contact Support" link (FR-PR-05) is OUT OF SCOPE for this PR (separate P0 story; the FR-PR-05 PR will rip up every "Contact Support" placeholder across the app).
+20.    - **Telemetry contract (two events, both pre-declared in telemetry-plan.md §1.3 lines 193-194):**
+21.      - **`settlement_history_viewed`** (`context_type: string` ∈ {friendship, group}, `item_count: int`). Fires EXACTLY ONCE on the first populated frame via `addPostFrameCallback` (mirrors `FriendDetailScreen._logViewedOnce`). The `item_count` is the length of the projected list AFTER the 50-item cap (so a 75-settlement context emits `item_count: 50`). PII guard per ADR-0013: `context_type` is a SAFE non-identifying enum token; `item_count` is a non-PII integer; no UID-derived parameters.
+22.      - **`settlement_history_error`** (`error_code: string` ∈ {permission-denied, unavailable, unknown, …}, `context_type: string` ∈ {friendship, group}). Fires on AsyncError. PII guard: `error_code` is a SAFE Firebase error-code enum; `context_type` is a SAFE non-identifying enum token; no UID-derived parameters.
+23.    - **No new server-side surface.** Zero changes to `functions/src/**`. The screen READS the existing `settlements` collection via the existing Firestore Security Rules (PR #37); zero rules changes.
+24.    - **No new Firestore index.** The existing composite `(contextType ASC, contextId ASC, date DESC)` from PR #42 covers the canonical query. `firestore.indexes.json` UNCHANGED.
+25. 
+26. 4. 4. PR #58 has **one mandatory cross-PR integration**: the **`FriendDetailScreen` "View Settlement History" link entry point** (entry-point wiring; ~5 LOC + 2 widget tests; ~0.2 SP). Without it, the new screen is orphaned (no production route to it; tests can mount it directly but a user has no path). PR #58 must NOT bundle: the FR-EX-06-parallel settlement edit/delete flow (separate later PR; ~3-5 SP), the FR-PR-05 Contact Support `mailto:` flow (separate P0 story; the new screen's error-state Retry button is the v1.0 fallback and the "Contact Support" link in SCR-24 §States row 4 is explicitly deferred), the `OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` / `OBTUserAvatar` / `OBTRupeeText` design-system primitive extractions (each a separate tracked follow-up; ~1 SP each), cursor-based pagination beyond the 50-item cap (defer until evidence of >50-settlement friendships in production), the Group-context push wiring (Sprint 3 Groups epic — the screen TAKES a `contextType` argument and the friendship arm is wired; the group arm is wired by the Sprint 3 GroupDetailScreen PR), the real-time fade-in animation for newly-arriving settlements (SCR-24 §Edge Cases item 2 — polish), the context-deleted snackbar + auto-back (SCR-24 §Edge Cases item 3 — edge case; defer), the per-month section-header grouping (SCR-24 §Open Questions item 3 — defer; flat list per the wireframe), the settlement-row tap-to-detail navigation (SCR-24 §Open Questions item 1 — no settlement detail screen exists; defer), the share/export action in the app bar (SCR-24 §Open Questions item 2 — v1.1), the `app_settings` / `permission_handler` Open Settings CTA chore (separate ~1-2 SP follow-up per PR #55 deviation 1), the `shared_preferences` adoption (still deferred per PR #54 §2.6 + PR #55 §2.4), the `cloud-functions-catalogue.md §7` docs roll-up (separate cosmetic chore PR), the activity-writer rename cleanup (still deferred per PR #52 §2.3), the FR-SE-09 message-compose dialog follow-up (separate UX PR), Issue #47 rules-hardening (separate chore), Issue #49 orphan-cleanup (FUTURE), Issue #50 trigger no-op optimisation (EXPLICITLY CONSTRAINED), FR-PR-02 phone-number-change flow (separate P1), FR-AU-09 account-deletion flow (separate P1), the `currentUserIdProvider` rehoming (separate tracked follow-up per PR #57 review recommendation 2; ~1 SP — wait for the next unrelated consumer), the `OBTFloatingActionButton` spring-physics polish (separate ~1 SP follow-up per PR #57 architect §2.2), the `shellNavigationControllerProvider` follow-up to PR #56 (defer to FR-AC-05 cold-start deep-link expansion), the FR-HD-01..04 home dashboard implementation (separate P0 story; ~5-8 SP), the `go_router` migration (Sprint 3 standalone chore), the storage-rules `firestore.get()` cross-collection investigation chore (separate ~1-2 SP investigation per PR #57 Phase 4 QA discovery), the `profile_placeholder_screen.dart` dead-code cleanup (still deferred per PR #56 §2.10 reconciliation 1).
+27. 
+28. 5. 5. Read before starting:
+29.    - `.github/copilot-instructions.md`
+30.    - `.github/shared/invariants.md` — invariant 1 (paise integers — N/A on the screen surface; the per-row amount goes through `formatInrFromPaise(int)`; the boundary-contract grep is defence-in-depth), invariant 2 (`simplifiedBalances` server-only — N/A; the screen READS the top-level `settlements/{id}` documents via `SettlementRepository.watchByContext` and never touches `simplifiedBalances`), invariant 3 (system share sheet — N/A; the share/export action is deferred per §3 above), invariant 4 (single Firebase project — N/A; no new Firebase SDK usage).
+31.    - `.github/shared/coding-standards.md` — Dart, Riverpod, widget-test, Conventional Commits rules. The PR is 100% client-side (no Functions changes); the Dart half is load-bearing.
+32.    - **Memory: PR# references in code/test files are forbidden.** Repository memory: "Do not include PR numbers (e.g. 'PR #36', 'PR #37') in comments or descriptions inside code or test files. PR references belong in docs and commit messages only." Reinforced during the PR #56 review. Use design-spec references (`SCR-24`, `telemetry-plan.md §1.3 lines 193-194`) in code comments instead.
+33.    - **Memory: dart format.** Repository memory: "CI runs Flutter 3.44.1 and gates on `dart format --set-exit-if-changed .`. Always run `dart format .` locally before pushing — `flutter analyze` alone does not catch formatter drift."
+34.    - **Memory: commit message scope.** Repository memory: "PR title lint enforces conventional commit scope `[a-z0-9_-]+` — a single token only." AND subject must be ≤ 72 chars. Recommend `feat(settlements): FR-SE-08 settlement history screen` (53 chars).
+35.    - **Memory: telemetry PII hashing.** Repository memory: "Use hashFriendshipId() in lib/core/telemetry/event_id_hash.dart for any telemetry parameter that would otherwise carry a deterministic friendshipId or other UID-composite identifier." The new `settlement_history_viewed` and `settlement_history_error` events carry NO `context_id` parameter (telemetry-plan §1.3 lines 193-194 deliberately OMIT it) — no hashing required, but DEFENCE-IN-DEPTH PII-leak test SHOULD assert that the events emitted by the screen do not include any `uid` / `userId` / `friendship_id` / `friendship_id_hash` / `context_id` parameter.
+36.    - **Memory: Firestore composite indexes.** The existing `(contextType ASC, contextId ASC, date DESC)` composite from PR #42 covers the canonical screen query; ZERO changes to `firestore.indexes.json`.
+37.    - **Memory: branch naming.** `user/avtanshgupta/MMDD/<short-kebab>` — for today (2026-06-12) use `user/avtanshgupta/0612/fr-se-08-settlement-history`.
+38.    - `.github/shared/decision-log.md` — ADR-0006 (Riverpod state management — the screen is a `ConsumerStatefulWidget` consuming the new `settlementHistoryProvider`), ADR-0007 (feature-first folder layout — screen + provider + telemetry constants under `lib/features/settlements/`), ADR-0013 (PII hashing — see memory above).
+39.    - `docs/patterns/feature-pr-conventions.md` — Feature-First Folder Layout, Telemetry-Event Discipline.
+40.    - `docs/OneByTwo_Requirements_Spec.md` — section 4.6 (FR-SE-01..09 — FR-SE-08 specifically is the P0 closure target of this PR), section 6.3 items 6 + 7 (settlement history per friend / per group), section 6.4 (empty / loading / error state requirements), section 5.6 (accessibility — 48×48 dp tap targets, WCAG 2.1 AA contrast, dynamic font scaling, screen-reader semantics), section 5.9 (`dd MMM yyyy` IST date format), section 5.10 (telemetry contract).
+41.    - `docs/design/01-information-architecture/navigation-flow.md §1` — the `MainTabs` subgraph (PR #56 reads); the `/settle/history` route lives OUTSIDE the MainTabs (pushed via `MaterialPageRoute.push` from `FriendDetailScreen`); architect §2.1 ratifies the route name as `/settle/history` (per SCR-24 §Screen Identity Route row, NOT `/settlements/history` despite the `next-three-prs.md` shorthand).
+42.    - `docs/design/02-design-system/components.md` — section §18 (`OBTEmptyState` — DEFERRED, inline equivalent), §19 (`OBTErrorState` — DEFERRED, inline equivalent), §20 (`OBTSkeletonLoader` — DEFERRED, plain `CircularProgressIndicator`), §5 (`OBTRupeeText` — DEFERRED, direct `formatInrFromPaise()`).
+43.    - `docs/design/04-wireframes/settle-up-flow.md §4` — Settlement History wireframe (lines 326-400).
+44.    - `docs/design/06-screen-specs/23-28-settle-activity-profile.md §SCR-24` — full screen spec (lines 153-253). The AC test names MUST match the spec sections exactly.
+45.    - `docs/design/07-technical/telemetry-plan.md §1.3 lines 193-194` — `settlement_history_viewed` and `settlement_history_error` event contracts (already pre-declared).
+46.    - `docs/design/07-technical/error-and-empty-state-taxonomy.md` — the canonical mapping from `AsyncError` → user-facing error states.
+47.    - `lib/features/settlements/data/settlement_repository.dart` lines 147-156 — the `SettlementRepository.watchByContext` API. UNCHANGED.
+48.    - `lib/features/settlements/domain/settlement_doc.dart` — the `SettlementDoc` shape. UNCHANGED.
+49.    - `lib/features/settlements/README.md` — read the `Out of scope for PR #43` line 173 confirming FR-SE-08 P0 was deferred; PR #58 closes that deferral. UPDATE the README's "Implemented scope" section + remove the line 173 deferral entry.
+50.    - `lib/features/friends/presentation/friend_detail_screen.dart` lines 75-141 — the screen being EXTENDED with the "View Settlement History" link.
+51.    - `lib/features/friends/presentation/widgets/friend_detail_timeline.dart` — read the existing `_SettlementRow` widget for visual consistency. UNCHANGED.
+52.    - `lib/features/friends/application/friend_detail_provider.dart` — read for the `FriendDetailArgs` family-key pattern (the new `SettlementHistoryArgs` mirrors this).
+53.    - `lib/features/friends/application/user_profile_provider.dart` — read for the `userProfileProvider.family(uid)` cached lookup pattern.
+54.    - `lib/core/formatters/inr_formatter.dart` — the `formatInrFromPaise(int)` canonical paise→INR conversion.
+55.    - `lib/core/telemetry/event_id_hash.dart` — the `hashFriendshipId()` PII-hash utility. NOT called by the new screen; the PII-leak test asserts no such literals.
+56.    - `lib/features/auth/application/analytics_provider.dart` — the `analyticsServiceProvider` consumed for `logEvent`. UNCHANGED.
+57.    - **NEW** `docs/sprint-zero/stories/FR-SE-08-settlement-history.md` — the feature story to create in Phase 1.
+58.    - **NEW** `lib/features/settlements/presentation/settlement_history_screen.dart` — the SCR-24 screen.
+59.    - **NEW** `lib/features/settlements/application/settlement_history_provider.dart` — the family-keyed StreamProvider + SettlementHistoryArgs family-key value type.
+60.    - **NEW** `lib/features/settlements/application/settlement_history_telemetry.dart` — event-name + parameter-key constants.
+61.    - **EXTEND** `lib/features/friends/presentation/friend_detail_screen.dart` Populated-state body to add the "View Settlement History" `TextButton` below the timeline.
+62.    - **EXTEND** `lib/features/settlements/README.md` — update "Implemented scope" with the new screen; remove the line-173 FR-SE-08 deferral entry.
+63.    - **NEW** `test/features/settlements/settlement_history_screen_test.dart` — populated state (3-row list rendered in date-desc order); empty state ("No settlements yet" centred); loading state (`CircularProgressIndicator` centred); error state (Retry button re-invalidates the provider); 50-item cap (76-item input yields 50 visible rows); date format (`dd MMM yyyy` IST per SRS §5.9); amount format (`formatInrFromPaise` per Inv-1); per-row note rendering (visible when non-null, hidden when null); accessibility labels per SCR-24 §Accessibility; `settlement_history_viewed` fires EXACTLY ONCE on first populated frame with the correct `context_type` + `item_count`; `settlement_history_error` fires on AsyncError with the correct `error_code` + `context_type`.
+64.    - **NEW** `test/features/settlements/settlement_history_provider_test.dart` — provider tests (resolves to the repository stream; 50-item cap applied; family-key identity contract; provider invalidation drops cached subscriptions).
+65.    - **NEW** `test/features/settlements/settlement_history_telemetry_test.dart` — constants match the telemetry-plan §1.3 lines 193-194 contracts.
+66.    - **NEW** `test/features/settlements/settlement_history_pii_leak_test.dart` — PII-leak grep over the 3 new files asserting ZERO `userId` / `uid` / `friendship_id` / `friendship_id_hash` / `context_id` literals + ZERO references to `simplifiedBalances` + ZERO `.toDouble()` / `parseFloat` / `/ 100` / `.toFixed` / `double ` declarations (Inv-1 + Inv-2 + PII boundary-contract triad).
+67.    - **EXTEND** `test/features/friends/friend_detail_screen_widget_test.dart` — add 3 new test cases: AC-16 link visible in Populated state, AC-17 link hidden in Empty state, AC-18 link tap pushes `SettlementHistoryScreen` with correct args.
+68.    - `firestore.rules` — UNCHANGED.
+69.    - `firestore.indexes.json` — UNCHANGED (existing composite covers the screen query).
+70.    - `storage.rules` — UNCHANGED.
+71.    - `functions/package.json` — UNCHANGED.
+72.    - `functions/src/**` — UNCHANGED (zero new server-side code).
+73.    - `pubspec.yaml` — UNCHANGED (no new dependencies; the screen uses only `flutter/material.dart` + `flutter_riverpod` + `intl` for date formatting which is already a transitive dep via `flutter_localizations`).
+74.    - `pubspec.lock` — UNCHANGED.
+75.    - `ios/Podfile.lock` — UNCHANGED (no new FlutterFire plugins).
+76.    - `docs/sprint-zero/sprint-2-plan.md` — add PR #58 row (3 SP; cumulative 93 SP / 22 PRs).
+77.    - `docs/sprint-zero/next-three-prs.md` — roll PR #58 to merged; PR #59 / #60 / #61 candidates (top remaining: FR-PR-05 Contact Support `mailto:` flow; `app_settings` Open Settings CTA chore; `currentUserIdProvider` rehoming).
+78.    - `docs/audits/sprint-1/07-bucket-b-burndown.md` — PR #58 entry; **CLOSES** FR-SE-08 P0.
+79.    - **CI hygiene** — `dart format .` MUST be run before push. `flutter analyze --fatal-infos` MUST exit 0. `flutter pub get` should be a no-op. **Functions hygiene** — `npm run lint && npm run build && npm test` MUST be green (UNCHANGED — 319 / 22 suites); `npm run test:rules` MUST show the same 6 pre-existing storage-rules failures (environmental, not a regression).
+80. 
+81. 6. 6. Honour the four invariants. Invariant 1 (paise integers) is **N/A** on the screen surface — no monetary write paths flow through the new code (READ-ONLY); the per-row display amount is rendered via `formatInrFromPaise(int)`. The PII-leak test at `test/features/settlements/settlement_history_pii_leak_test.dart` is the defence-in-depth assertion. Invariant 2 (`simplifiedBalances` server-only) is **N/A** — the screen READS `settlements/{id}` documents via `SettlementRepository.watchByContext` and never references `simplifiedBalances`. Invariant 3 is N/A. Invariant 4 is N/A.
+82. 
+83. ────────────────────────────────────────
+84. PHASE 0 — DEPENDENCY-DAG CHECK
+85. ────────────────────────────────────────
+86. 
+87. 0.1  Confirm PR #57 has merged to main and the post-merge state is clean:
+88.      - `git log --oneline -1` on `main` shows `6ece995 feat(shell): FR-HD-04 persistent FAB + context picker (#57)`.
+89.      - `lib/features/shell/presentation/authenticated_shell.dart` exists with the `floatingActionButton: OBTFloatingActionButton(...)` slot + `_onFabTapped` handler (lines 96-115).
+90.      - `lib/core/widgets/nav/obt_floating_action_button.dart` exists.
+91.      - `lib/features/shell/presentation/add_expense_context_picker_sheet.dart` exists.
+92.      - `lib/features/shell/application/shell_telemetry.dart` exists with the `fab_tapped` + `expense_context_selected` constants.
+93.      - `lib/main.dart:141-144` overrides `currentUserIdProvider` per-arm.
+94.      - `lib/features/friends/application/friends_list_provider.dart` has `dependencies: [currentUserIdProvider]` on `friendsListProvider`.
+95.      - `lib/features/activity/application/activity_feed_provider.dart` has `dependencies: [currentUserIdProvider]` on `activityFeedProvider`.
+96.      - `flutter analyze --fatal-infos` exits 0.
+97.      - `flutter test` exits 0 (1243 pass / 30 skipped post-PR-#57).
+98.      - `cd functions && npm run lint && npm run build && npm test` exit 0 (22 suites / 319 tests pass — unchanged).
+99.      - `cd functions && npm run test:rules` shows the pre-existing 6 storage-rules failures (UNCHANGED).
+100.      - `dart format --set-exit-if-changed .` exits 0.
+101.      - `.firebaserc` contains exactly one project.
+102.      - Issues #47, #49, #50 are OPEN and unchanged.
+103. 
+104. 0.2  **Phase 0 critical discovery — telemetry-plan vs screen-spec discrepancy on `context_id`.** The screen spec at `SCR-24 §Telemetry Events` lists `context_id` as a parameter for both events. The telemetry-plan at §1.3 lines 193-194 deliberately OMITS `context_id`. The architect ratifies the telemetry-plan version at §2.9 per the PII guard precedent (`context_id` for the friendship axis is a UID-composite `{uidA}_{uidB}` that must NOT be emitted raw per ADR-0013). Tracked as a docs-cleanup follow-up.
+105. 
+106. 0.3  Walk the dependency DAG for the new screen:
+107.      - **`SettlementRepository.watchByContext`** (PR #42 read path) — UNCHANGED.
+108.      - **Firestore composite index `(contextType ASC, contextId ASC, date DESC)`** (PR #42) — UNCHANGED.
+109.      - **`settlementRepositoryProvider`** (PR #42 root-scope) — consumed via `ref.watch`.
+110.      - **`formatInrFromPaise(int)`** (Inv-1 boundary) — per-row amount.
+111.      - **`analyticsServiceProvider`** — consumed for the 2 telemetry events.
+112.      - **`FriendDetailScreen`** (PR #42 SCR-11) — EXTENDED with the link.
+113.      - **`FriendDetailTimelineWidget`** (PR #42) — UNCHANGED.
+114.      - **Telemetry pre-declarations** in `telemetry-plan.md §1.3 lines 193-194` — authoritative.
+115. 
+116. 0.4  Confirm DoR for the FR-SE-08 story:
+117.      - **No story file exists yet** — `docs/sprint-zero/stories/FR-SE-08-settlement-history.md` must be created by the PM in Phase 1.
+118.      - Story points: **3 SP**.
+119.      - The story must explicitly enumerate: (a) the GitHub issue this PR closes — **none for FR-SE-08 itself** (P0 SRS row 4.6 line 227), (b) the four-invariant applicability assessment (all N/A), (c) the telemetry contract (2 events pre-declared in `telemetry-plan.md §1.3 lines 193-194`; NEITHER carries `context_id`), (d) the explicit decision on the route name (architect §2.1), (e) the explicit decision on the 50-item cap location (architect §2.2), (f) the explicit decision on inline empty/loading/error widgets vs primitive extraction (architect §2.3), (g) the explicit decision on the constructor args (architect §2.4), (h) the explicit decision on the `FriendDetailScreen` link visibility (architect §2.5), (i) the explicit decision on the entry-point telemetry event (architect §2.6 — defer `view_all_settlements_tapped`), (j) the explicit decision on the date format + inline rendering (architect §2.7).
+120. 
+121. 0.5  Cross-reference the burndown:
+122.      - PR #58 closes **the FR-SE-08 P0 SRS row** (dedicated settlement-history screen for the friendship axis; the group axis is wired by the Sprint 3 GroupDetailScreen PR).
+123.      - PR #58 makes partial progress on **UX foundation hardening** — the `/settle/history` route is the canonical settlement-history surface.
+124.      - PR #58 introduces **`settlementHistoryProvider`** as the first family-keyed StreamProvider in the settlements feature folder.
+125.      - Issues #47, #49, #50 remain OPEN and are NOT touched by PR #58.
+126.      - PR #58 may file follow-up issues for: primitive extractions, settlement detail screen, per-month grouping, pagination beyond 50, Group-context push wiring, settlement edit/delete flow.
+127. 
+128. ────────────────────────────────────────
+129. PHASE 1 — STORY READINESS (PM)
+130. ────────────────────────────────────────
+131. 
+132. PM agent creates the feature story `docs/sprint-zero/stories/FR-SE-08-settlement-history.md` using the SRS §13.2 feature format. Story points: **3** (per §0.4).
+133. 
+134. Required Given/When/Then ACs (each MUST be testable):
+135. 
+136.   **Screen render + state contract**
+137. 
+138.   - **AC-1 — Populated state renders settlements in date-desc order.** Given `settlementHistoryProvider` returns 3 settlements with dates `2025-03-25`, `2025-03-18`, `2025-02-02`, when the screen is mounted, then 3 settlement rows are rendered in that exact order (no client-side sort — the repository's stream guarantees date-desc).
+139.   - **AC-2 — Empty state renders the canonical empty placeholder.** Given `settlementHistoryProvider` returns an empty list, when the screen is mounted, then a `Center(Column(...))` with `Icon(Icons.history)` + `Text('No settlements yet')` + `Text('Once you settle up, it will appear here.')` renders AND NO Retry button renders (per SCR-24 §States row 3: "No CTA button").
+140.   - **AC-3 — Loading state renders a centred `CircularProgressIndicator`.** Given `settlementHistoryProvider` is `AsyncLoading`, when the screen is mounted, then a `Center(CircularProgressIndicator())` renders.
+141.   - **AC-4 — Error state renders the canonical error placeholder with Retry.** Given `settlementHistoryProvider` is `AsyncError`, when the screen is mounted, then a `Center(Column(...))` with `Icon(Icons.error_outline)` + `Text('Something went wrong')` + `Text('We could not load settlement history. Please try again.')` + `FilledButton(child: Text('Retry'))` renders. Tapping Retry calls `ref.invalidate(settlementHistoryProvider(args))` AND the provider re-subscribes.
+142.   - **AC-5 — 50-item cap.** Given `settlementHistoryProvider` is fed a 76-item upstream stream, when projected, then the screen renders exactly 50 rows AND the `settlement_history_viewed` event fires with `item_count: 50` (not 76).
+143. 
+144.   **Settlement-row layout contract (per SCR-24 §Settlement Row Layout)**
+145. 
+146.   - **AC-6 — Date format.** Given a settlement with `date: DateTime(2025, 3, 25)`, when its row renders, then the date is displayed as `'25 Mar 2025'` (per SRS §5.9 `dd MMM yyyy` IST).
+147.   - **AC-7 — Amount format.** Given a settlement with `amountPaise: 80000`, when its row renders, then the amount is displayed as `'₹800.00'` via `formatInrFromPaise(80000)` (Inv-1 boundary).
+148.   - **AC-8 — Note rendering.** Given a settlement with `note: 'GPay transfer'`, when its row renders, then the note text is visible below the amount; given `note: null`, when its row renders, then NO note text widget is in the tree.
+149.   - **AC-9 — Avatar + arrow row.** Given a settlement with `fromUserId: currentUid` + `toUserId: otherUid`, when its row renders, then the payer avatar shows the current user's initials AND the payee avatar shows the friend's display-name initials AND a directional arrow icon is between them.
+150.   - **AC-10 — Row tap target.** Given any settlement row, when measured, then its rendered height is ≥ 64 dp (per SCR-24 §Settlement Row Layout last paragraph).
+151. 
+152.   **Accessibility (per SCR-24 §Accessibility)**
+153. 
+154.   - **AC-11 — Screen title semantic header.** Given the screen is mounted, when scanned for semantics, then a semantic node with label `'Settlement History'` AND `isHeader: true` exists.
+155.   - **AC-12 — Settlement-row semantic label.** Given a settlement row for `from=You, to=Priya, amount=Rs800.00, date=25 Mar 2025, note='GPay transfer'`, when scanned for semantics, then a semantic node with label `'You paid Priya rupees 800.00 on 25 Mar 2025. Note: GPay transfer.'` exists. Given a `note: null` settlement, the label substitutes `'Note: no note.'`.
+156. 
+157.   **Telemetry contract (both events pre-declared in telemetry-plan.md §1.3 lines 193-194)**
+158. 
+159.   - **AC-13 — `settlement_history_viewed` fires exactly once on first populated frame.** Given the screen mounts and transitions Loading → AsyncData([3 items]), when one frame has been pumped, then exactly one `settlement_history_viewed` event has fired with `{context_type: 'friendship', item_count: 3}`. Subsequent rebuilds (e.g. provider stream emits a new value) do NOT re-fire.
+160.   - **AC-14 — `settlement_history_error` fires on AsyncError.** Given the screen mounts and the provider yields AsyncError, when one frame has been pumped, then exactly one `settlement_history_error` event has fired with `{error_code: '<mapped code>', context_type: 'friendship'}`.
+161.   - **AC-15 — Telemetry PII guard.** Given the `settlement_history_viewed` and `settlement_history_error` events fire, when scanned, then NEITHER payload includes a `userId` / `uid` / `friendship_id` / `friendship_id_hash` / `context_id` parameter. The PII-leak grep test asserts the source files contain no such literals.
+162. 
+163.   **`FriendDetailScreen` "View Settlement History" link integration**
+164. 
+165.   - **AC-16 — Link visible in Populated state.** Given `friendDetailProvider` returns `FriendDetailStatePopulated`, when the screen is mounted, then a `TextButton` with label `'View Settlement History'` is rendered below the `FriendDetailTimelineWidget`.
+166.   - **AC-17 — Link hidden in Empty state.** Given `friendDetailProvider` returns `FriendDetailStateEmpty`, when the screen is mounted, then NO `TextButton` with label `'View Settlement History'` is in the tree.
+167.   - **AC-18 — Link tap pushes `SettlementHistoryScreen` with correct args.** Given the Populated state is mounted, when the user taps the "View Settlement History" link, then a `MaterialPageRoute` is pushed AND its `builder` returns a `SettlementHistoryScreen` with `contextType: 'friendship'`, `contextId: '<friendshipId>'`, `currentUserUid: '<currentUid>'`, `otherUserUid: '<otherUid>'`, `otherDisplayName: '<state.header.displayName>'`.
+168. 
+169.   **Cross-cutting and negative guards**
+170. 
+171.   - **AC-19 — Invariant 1 boundary contract.** Given the PR diff, when scanned for `.toDouble()`, `parseFloat`, `/ 100`, `.toFixed`, or `double ` declarations on the new files, then ZERO violations exist anywhere in `lib/features/settlements/presentation/settlement_history_screen.dart`, `lib/features/settlements/application/settlement_history_provider.dart`, or `lib/features/settlements/application/settlement_history_telemetry.dart`.
+172.   - **AC-20 — Invariant 2 negative guard.** Given the PR diff, when scanned, then ZERO references to `simplifiedBalances` exist anywhere in the 3 new files.
+173. 
+174. ────────────────────────────────────────
+175. PHASE 2 — ARCHITECT HAND-OFF
+176. ────────────────────────────────────────
+177. 
+178. Architect agent appends `## Architect Notes` to the story ratifying:
+179. 
+180. 2.1  **Route name.** RATIFY: `/settle/history` per `SCR-24 §Screen Identity Route` row. No `go_router` migration in this PR — the route is pushed via `MaterialPageRoute.push` from `FriendDetailScreen`.
+181. 
+182. 2.2  **50-item cap location.** RATIFY: enforced at the PROVIDER layer (`settlementHistoryProvider` pipes `.take(50)` over the upstream stream). No "Load more" footer for v1.0 per SCR-24 §Edge Cases item 1.
+183. 
+184. 2.3  **Inline empty/loading/error widgets (NO primitive extraction).** RATIFY: ship `_SettlementHistoryEmptyState`, `_SettlementHistoryLoadingState`, `_SettlementHistoryErrorState` as private widgets (mirrors the PR #42 `friend_detail_states.dart` precedent). DEFER `OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` / `OBTUserAvatar` / `OBTRupeeText` to separate chores.
+185. 
+186. 2.4  **Screen constructor args.** RATIFY: 5-arg `SettlementHistoryScreen({required this.contextType, required this.contextId, required this.currentUserUid, required this.otherUserUid, required this.otherDisplayName, super.key})`. Provider-agnostic — no `currentUserIdProvider` read inside the screen.
+187. 
+188. 2.5  **`FriendDetailScreen` link visibility.** RATIFY: unconditionally visible in `FriendDetailStatePopulated`; HIDDEN in `FriendDetailStateEmpty`. The link sits BELOW the `FriendDetailTimelineWidget` inside the `SingleChildScrollView`.
+189. 
+190. 2.6  **Entry-point telemetry OUT OF SCOPE.** RATIFY: do NOT emit a `view_all_settlements_tapped` event from the link tap. The destination's `settlement_history_viewed` captures the funnel arrival; an additional entry-point event would over-instrument.
+191. 
+192. 2.7  **Date format + per-row inline.** RATIFY: `dd MMM yyyy` IST per SRS §5.9, rendered INLINE above each row (not as a section header per SCR-24 §Open Questions item 3 defer). The `intl` package's `DateFormat('dd MMM yyyy', 'en_IN')` is already transitively available via `flutter_localizations`; no new dependency.
+193. 
+194. 2.8  **Error-code mapping table.** RATIFY: `'permission-denied' → 'permission-denied'`, `'unavailable' → 'unavailable'`, any other `FirebaseException.code → e.code`, any non-Firebase error → `'unknown'`. Mirrors the existing `SettlementCreateError` mapping from PR #43.
+195. 
+196. 2.9  **Telemetry-plan vs screen-spec discrepancy on `context_id`.** RATIFY: the telemetry-plan §1.3 lines 193-194 version is authoritative (NO `context_id` parameter on either event); the screen spec at SCR-24 §Telemetry Events lists `context_id` and is INCORRECT (parallel discrepancy on `settle_up_screen_viewed` at SCR-23 line 116). The PII-leak test asserts the events emit no `context_id`. The screen-spec docs cleanup is a tracked follow-up.
+197. 
+198. 2.10  **Files to touch (exhaustive — anything outside this set is scope creep):** [list per §5 above]
+199. 
+200. 2.11  **Files explicitly NOT to touch (negative scope guardrails):**
+201.      - `firestore.rules`, `firestore.indexes.json`, `storage.rules` — UNCHANGED.
+202.      - `functions/package.json`, all of `functions/src/**`, all of `functions/test/**` — UNCHANGED.
+203.      - `lib/features/settlements/data/**` (the repository is UNCHANGED).
+204.      - `lib/features/settlements/domain/**` (the `SettlementDoc` shape is UNCHANGED).
+205.      - `lib/features/settlements/presentation/settle_up_bottom_sheet.dart` — UNCHANGED.
+206.      - `lib/features/expenses/**`, `lib/features/activity/**`, `lib/features/notifications/**`, `lib/features/reminders/**`, `lib/features/profile/**`, `lib/features/auth/**`, `lib/features/shell/**` — UNCHANGED.
+207.      - `lib/features/friends/**` except `friend_detail_screen.dart` (link integration) — UNCHANGED.
+208.      - `lib/core/**` — UNCHANGED.
+209.      - `pubspec.yaml`, `pubspec.lock`, `ios/Podfile.lock` — UNCHANGED.
+210.      - `.github/workflows/*.yml` — UNCHANGED.
+211.      - `docs/design/**` — read-only references; no spec updates in this PR (the SCR-24 vs telemetry-plan `context_id` discrepancy is tracked but NOT fixed in this PR).
+212. 
+213. 2.12  **Anticipated reconciliations:**
+214.      1. `lib/features/profile/presentation/profile_placeholder_screen.dart` still exists alongside the real `profile_screen.dart` (PR #55/#56/#57 §2.10 reconciliation 1). Still NOT touched.
+215.      2. The `currentUserIdProvider` rehoming follow-up from PR #57 review recommendation 2 remains tracked; not addressed here.
+216.      3. The 6 pre-existing storage-rules receipt-tests failures remain pre-existing; not addressed.
+217.      4. The screen-spec vs telemetry-plan `context_id` discrepancy is documented but not fixed here.
+218.      5. The 5 OBT* primitive extractions (`OBTSkeletonLoader`, `OBTEmptyState`, `OBTErrorState`, `OBTUserAvatar`, `OBTRupeeText`) are all tracked follow-ups; not addressed here.
+219. 
+220. ────────────────────────────────────────
+221. PHASE 3 — SCOPE GUARDRAILS
+222. ────────────────────────────────────────
+223. 
+224. WHAT GOES IN PR #58:
+225. 
+226.   - All files listed in §2.10.
+227.   - `SettlementHistoryScreen` (NEW; under `lib/features/settlements/presentation/`).
+228.   - `settlementHistoryProvider` + `SettlementHistoryArgs` (NEW; under `lib/features/settlements/application/`).
+229.   - `settlement_history_telemetry.dart` constants (NEW; under `lib/features/settlements/application/`).
+230.   - `FriendDetailScreen` "View Settlement History" link integration.
+231.   - `lib/features/settlements/README.md` "Implemented scope" extension + line-173 deferral removal.
+232.   - New widget + provider + telemetry + PII-leak + friend-detail-extension tests.
+233.   - Story + Architect Notes.
+234.   - Plan + burndown roll-ups (Phase 7).
+235. 
+236. WHAT DOES NOT GO IN PR #58:
+237. 
+238.   - **Settlement edit/delete flow (FR-EX-06 parallel)** — separate later PR.
+239.   - **Group-context push wiring** — Sprint 3 Groups epic.
+240.   - **Cursor-based pagination beyond 50 items** — defer until evidence.
+241.   - **`OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` / `OBTUserAvatar` / `OBTRupeeText` primitive extractions** — separate chores.
+242.   - **Real-time fade-in animation** — SCR-24 §Edge Cases item 2 polish.
+243.   - **Context-deleted snackbar + auto-back** — SCR-24 §Edge Cases item 3 edge case.
+244.   - **Per-month section-header grouping** — SCR-24 §Open Questions item 3.
+245.   - **Settlement-row tap-to-detail navigation** — SCR-24 §Open Questions item 1.
+246.   - **Share/export action in the app bar** — SCR-24 §Open Questions item 2 v1.1.
+247.   - **`view_all_settlements_tapped` entry-point telemetry** — over-instrumentation per §2.6.
+248.   - **`currentUserIdProvider` rehoming** — separate ~1 SP follow-up.
+249.   - **Screen-spec vs telemetry-plan `context_id` discrepancy fix** — separate docs-cleanup chore.
+250.   - **FR-PR-05 Contact Support `mailto:` flow** — separate P0 story.
+251.   - **FR-HD-01..04 home dashboard implementation** — separate P0 story.
+252.   - **FR-PR-02, FR-AU-09, go_router, Issue #47/#49/#50, app_settings chore, shared_preferences, profile_placeholder cleanup** — all separate.
+253. 
+254. If an agent suggests any of: "while we're shipping the screen, let's also wire the Group axis", "let's also extract OBTSkeletonLoader / OBTEmptyState / OBTErrorState since this is their first use site", "let's also add cursor-based pagination since 50 is arbitrary", "let's also add the real-time fade-in", "let's also rehome currentUserIdProvider", "let's also fix the screen-spec vs telemetry-plan context_id discrepancy", "let's also extract OBTUserAvatar since we have 3 use sites now" — REFUSE.
+255. 
+256. ────────────────────────────────────────
+257. PHASE 4 — TEST-FIRST DISCIPLINE
+258. ────────────────────────────────────────
+259. 
+260. PR #58 follows the standard test-first cadence:
+261. 
+262. 1. Snapshot the pre-fix baseline: 1243 Flutter / 30 skipped; 319 functions / 22 suites.
+263. 2. Write the failing Flutter tests FIRST:
+264.    - `settlement_history_screen_test.dart` (populated / empty / loading / error / 50-cap / date / amount / note / avatar / row height / accessibility / telemetry-viewed / telemetry-error).
+265.    - `settlement_history_provider_test.dart` (resolves to repo stream; 50-cap applied; family-key identity; invalidation).
+266.    - `settlement_history_telemetry_test.dart` (constants match the pre-declared contracts).
+267.    - `settlement_history_pii_leak_test.dart` (Inv-1 + Inv-2 + PII boundary-contract triad).
+268.    - Extend `friend_detail_screen_widget_test.dart` with AC-16 / AC-17 / AC-18 link visibility + push tests.
+269. 3. Implement Flutter source:
+270.    - `settlement_history_telemetry.dart` (constants).
+271.    - `settlement_history_provider.dart` (StreamProvider.family + Args value type).
+272.    - `settlement_history_screen.dart` (screen + inline states + per-row widget).
+273.    - `friend_detail_screen.dart` extension (link integration).
+274.    - `settlements/README.md` extension (Implemented scope update + line-173 deferral removal).
+275. 4. Re-run `dart format --set-exit-if-changed .` — 0 changes.
+276. 5. Re-run `flutter analyze --fatal-infos` — "No issues found".
+277. 6. Re-run `flutter test` — expected 1243 + ~25 new = ~1268 tests pass.
+278. 7. Re-run `cd functions && npm run lint && npm run build && npm test` — 319 (UNCHANGED).
+279. 8. Re-run `cd functions && npm run test:rules` — UNCHANGED (6 pre-existing failures remain).
+280. 9. Manual smoke (Phase 5 §10).
+281. 
+282. ────────────────────────────────────────
+283. PHASE 5 — EXECUTION PROTOCOL
+284. ────────────────────────────────────────
+285. 
+286. Mirror the PR #57 commit cadence:
+287. 
+288.  1. PM creates story `docs/sprint-zero/stories/FR-SE-08-settlement-history.md`. Commits as `docs(stories): PR #58 FR-SE-08 settlement history story`.
+289.  2. Architect appends `## Architect Notes` (§2.1–§2.12). Commits as `docs(stories): PR #58 architect notes`.
+290.  3. Flutter-dev writes failing tests. Commits as `test(settlements): FR-SE-08 settlement history screen tests`.
+291.  4. Flutter-dev ships the telemetry constants + provider. Commits as `feat(settlements): settlementHistoryProvider + telemetry`.
+292.  5. Flutter-dev ships the `SettlementHistoryScreen` widget. Commits as `feat(settlements): FR-SE-08 settlement history screen`.
+293.  6. Flutter-dev wires the `FriendDetailScreen` link integration + updates the settlements README. Commits as `feat(friends): wire View Settlement History link`.
+294.  7. QA runs the manual smoke matrix:
+295.     - Sign in as a fresh user; navigate to a friend with > 5 settlements; tap "View Settlement History" link; verify the screen mounts with the full list (capped at 50).
+296.     - Verify the empty-state path: navigate to a friend with zero settlements (but > 0 expenses, so the link is visible per AC-16); tap the link; verify the screen's Empty state renders.
+297.     - Verify the error-state path: enable airplane mode; tap the link; verify the Error state renders with the Retry button; disable airplane mode; tap Retry; verify the screen transitions to the Populated state.
+298.     - Verify the date format on each row matches `dd MMM yyyy`.
+299.     - Verify the amount on each row is formatted by `formatInrFromPaise()`.
+300.     - Verify the back arrow returns to the originating `FriendDetailScreen`.
+301.     - Verify the friend-detail Empty-state path: navigate to a brand-new friend with no expenses or settlements; verify the "View Settlement History" link is HIDDEN.
+302.     - Verify telemetry: emit a settlement; tap the link; verify `settlement_history_viewed` fires once with `{context_type: 'friendship', item_count: <count>}`.
+303.  8. Docs hand updates plan + roll-forward:
+304.     - `docs/sprint-zero/sprint-2-plan.md` (PR #58 row; 3 SP; cumulative 93 SP / 22 PRs).
+305.     - `docs/sprint-zero/next-three-prs.md` (PR #59 / #60 / #61 candidates — top is FR-PR-05 Contact Support `mailto:` OR `app_settings` Open Settings CTA chore OR `currentUserIdProvider` rehoming).
+306.     - `docs/audits/sprint-1/07-bucket-b-burndown.md` (PR #58 entry; closes FR-SE-08).
+307.     - Commits as `docs(plan): PR #58 shipped, prep PR #59`.
+308.  9. PR opened. Title (≤72 chars subject): `feat(settlements): FR-SE-08 settlement history screen`. Body must:
+309.     - Cite `SCR-24`, `telemetry-plan.md §1.3` lines 193-194 (the pre-declared events), the relevant SRS rows (4.6 FR-SE-08 P0 + 6.3 items 6,7 + 6.4 + 5.6 + 5.9 + 5.10).
+310.     - Confirm Invariants 1 / 2 / 3 / 4 (all N/A on this PR).
+311.     - State explicitly the deferred items: Group-context push, cursor-based pagination, primitive extractions, real-time fade-in, context-deleted snackbar, month grouping, settlement detail, share/export, entry-point telemetry.
+312.     - End with `Next PR: PR #59 — TBD per architect's call at kickoff (top candidate: FR-PR-05 Contact Support mailto flow).`
+313. 
+314. ────────────────────────────────────────
+315. PHASE 6 — DEFINITION OF DONE GATE
+316. ────────────────────────────────────────
+317. 
+318. Walk the DoD checklist. Particular emphasis:
+319. 
+320.   - DoD §2: every layer green (Flutter + ~25 new tests / Functions unchanged / Rules unchanged / format / analyze).
+321.   - DoD §3: QA sign-off with evidence for the screen render in all 4 states, the 50-item cap, the date + amount format, the accessibility labels, the telemetry contract, and the FriendDetailScreen link visibility contract.
+322.   - DoD §7: invariant compliance.
+323.     * Inv-1: N/A; defence-in-depth grep returns 0 violations in the 3 new files.
+324.     * Inv-2: N/A; defence-in-depth grep returns 0 references to `simplifiedBalances` in the 3 new files.
+325.     * Inv-3: N/A.
+326.     * Inv-4: N/A.
+327.   - DoD §8: documentation updated (story + architect notes + sprint-2-plan + next-three-prs + burndown + settlements/README).
+328.   - DoD §9: deploy verification. The Flutter client ships in the next mobile build with the new screen; the Functions side is UNCHANGED.
+329. 
+330. QA posts the explicit DoD §3 sign-off, including the negative-scope greps from AC-15 / AC-19 / AC-20.
+331. 
+332. **Pre-push CI hygiene:** run `dart format .` AND all test layers BEFORE `git push`.
+333. 
+334. ────────────────────────────────────────
+335. PHASE 7 — UPDATE THE ROLLING PLAN AND BURNDOWN
+336. ────────────────────────────────────────
+337. 
+338. PM agent updates:
+339.   - `docs/sprint-zero/sprint-2-plan.md` — PR #58 status (merged), velocity #22 (3 SP, total now 93 SP across 22 PRs).
+340.   - `docs/sprint-zero/next-three-prs.md`:
+341.       * PR #58 row marked merged; numbering note updated.
+342.       * PR #59: **TBD** per architect's call at kickoff. Top candidates (in rough priority order):
+343.           - **FR-PR-05 Contact Support `mailto:` flow** (P0; ~2 SP).
+344.           - **`app_settings` Open Settings CTA chore** (~1-2 SP).
+345.           - **`currentUserIdProvider` rehoming** (~1 SP — tracked from PR #57 review).
+346.           - **Bucket-B chore close-out** (~3 SP).
+347.           - **FR-PR-02 phone-number-change flow** (P1; ~5 SP).
+348.           - **FR-AU-09 account-deletion flow** (P1; ~5-8 SP).
+349.           - **Issue #47 rules-hardening** (chore; 2 SP).
+350.           - **`shared_preferences` adoption** (~2-3 SP).
+351.           - **FR-HD-01..04 home dashboard implementation** (~5-8 SP P0).
+352.           - **`shellNavigationControllerProvider` + FR-AC-05 deep-link tab-switching** (follow-up to PR #56; ~2 SP).
+353.           - **`OBTFloatingActionButton` spring-physics polish** (~1 SP — tracked follow-up).
+354.           - **`OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` / `OBTUserAvatar` / `OBTRupeeText` primitive extractions** (~1 SP each — wait for second use site).
+355.           - **`cloud-functions-catalogue.md §7` docs roll-up** (cosmetic chore; ~1 SP).
+356.           - **Activity-writer rename cleanup** (cosmetic chore; ~1-2 SP).
+357.           - **`go_router` migration** (Sprint 3 — ~3-5 SP).
+358.           - **Storage-rules `firestore.get()` cross-collection investigation** (~1-2 SP).
+359.           - **Screen-spec vs telemetry-plan `context_id` discrepancy fix** (~0.5 SP cosmetic docs chore).
+360.       * PR #60 / #61: TBD per PR #59 outcome.
+361.   - `docs/audits/sprint-1/07-bucket-b-burndown.md`:
+362.       * Header timestamp: PR #57 → PR #58.
+363.       * Append a PR #58 section: CLOSES FR-SE-08 P0 (dedicated settlement-history screen for the friendship axis).
+364. 
+365. Commits as `docs(plan): PR #58 shipped, prep PR #59`.
+366. 
+367. ────────────────────────────────────────
+368. GUARDRAILS
+369. ────────────────────────────────────────
+370. 
+371. If during this PR an agent proposes:
+372.   - "While we're shipping the screen, let's also wire the Group axis" → REFUSE. Sprint 3 Groups epic.
+373.   - "Let's also extract OBTSkeletonLoader / OBTEmptyState / OBTErrorState / OBTUserAvatar / OBTRupeeText since this is their first or second use site" → REFUSE per §2.3. Tracked follow-ups.
+374.   - "Let's also add cursor-based pagination since 50 is arbitrary" → REFUSE per §2.2. Defer until evidence.
+375.   - "Let's also add the real-time fade-in" → REFUSE per SCR-24 §Edge Cases item 2.
+376.   - "Let's also rehome currentUserIdProvider" → REFUSE per PR #57 review recommendation 2. Tracked separately.
+377.   - "Let's also fix the screen-spec vs telemetry-plan context_id discrepancy" → REFUSE per §2.9. Separate docs-cleanup chore.
+378.   - "Let's also add a settlement detail screen since the rows look tappable" → REFUSE per SCR-24 §Open Questions item 1.
+379.   - "Let's also add per-month section grouping since it would look nice" → REFUSE per SCR-24 §Open Questions item 3.
+380.   - "Let's also ship FR-PR-05 Contact Support since the error state mentions Contact Support" → REFUSE. Separate P0 story.
+381.   - "Let's NOT bundle the FriendDetailScreen link integration and ship it as a separate hotfix" → REFUSE. Without the link the new screen is orphaned. Bundling is MANDATORY.
+382.   - "Let's also wire FCM deep-link to land on the settlement-history screen directly" → REFUSE. Separate FR-AC-05 enhancement.
+383.   - "Let's also add the share/export action in the app bar" → REFUSE per SCR-24 §Open Questions item 2. v1.1.
+384.   - "Let's close issue #47 (rules-hardening) at the same time" → REFUSE. Separate small chore PR.
+385.   - "Let's close issue #49 (orphan-cleanup) at the same time" → REFUSE. FUTURE.
+386.   - "Let's close issue #50 (trigger no-op-recompute optimisation)" → **EXPLICITLY REFUSE** — closing it would BREAK FR-EX-07 AC-2.
+387. 
+388. If something genuinely surprises (e.g. `SettlementRepository.watchByContext` returns an `AsyncError` shape the architect did not anticipate; OR the 50-item cap interacts unexpectedly with the Firestore snapshot listener's incremental delivery; OR the `MaterialPageRoute.push` from `FriendDetailScreen` triggers a navigator-pop on a tab switch; OR the `intl` `DateFormat('dd MMM yyyy', 'en_IN')` requires explicit `initializeDateFormatting()` setup that the rest of the app does not currently call; OR the `FriendDetailScreen` link addition forces a recompose that breaks the existing `friend_detail_screen_widget_test.dart` test assertions), STOP and surface the friction. PR #58 is the first PR that (a) ships a generic-context-typed screen taking `(contextType, contextId)` navigation arguments, (b) consumes `SettlementRepository.watchByContext` from a non-timeline-composer surface, (c) emits the pre-declared `settlement_history_*` events, (d) introduces the `settlementHistoryProvider` family-keyed StreamProvider, and (e) wires the canonical settlement-history entry point on the friend detail surface — get the patterns right before shipping.
+389. 
+390. Begin with Phase 0 — verify the dependency DAG (PR #57 merge state at `6ece995`; baseline test counts; `SettlementRepository.watchByContext` API intact at `lib/features/settlements/data/settlement_repository.dart:147-156`; the existing Firestore composite index `(contextType ASC, contextId ASC, date DESC)` intact; the `FriendDetailScreen` Populated-state body intact at `lib/features/friends/presentation/friend_detail_screen.dart:99-132`; the `telemetry-plan.md §1.3 lines 193-194` pre-declared events intact; the SCR-24 spec at `docs/design/06-screen-specs/23-28-settle-activity-profile.md` lines 153-253 intact; the settle-up-flow wireframe §4 at `docs/design/04-wireframes/settle-up-flow.md` lines 326-400 intact) and re-read the four reference docs (`docs/design/06-screen-specs/23-28-settle-activity-profile.md §SCR-24` in full, `docs/design/04-wireframes/settle-up-flow.md §4 Settlement History` in full, `docs/design/07-technical/telemetry-plan.md §1.3 lines 193-194` for the pre-declared events, and the existing `lib/features/settlements/data/settlement_repository.dart` as the upstream the new provider consumes) before kickoff.

--- a/docs/sprint-zero/next-three-prs.md
+++ b/docs/sprint-zero/next-three-prs.md
@@ -1,7 +1,7 @@
 # Next Three PRs
 
 > Rolling roadmap. Updated at the end of every PR.
-> Last updated: PR #57 merged (FR-HD-04 persistent FAB + Add Expense context picker — closes FR-HD-04 P0 + bundled `currentUserIdProvider` production-wiring closure that PR #56 architect §2.1 left as the mandatory natural completion).
+> Last updated: PR #58 merged (FR-SE-08 dedicated settlement-history screen, SCR-24 — friendship axis; group axis stubbed pending the Sprint 3 Groups epic).
 
 ---
 
@@ -24,12 +24,13 @@ namespace on GitHub. The post-PR #48 sequence so far:
 | #55 | PR | FR-PR-03 + FR-AC-04 Notification Preferences UI (SCR-27) + production `cloud_functions` adapter wiring for `reminderRepositoryProvider` + `matchingRepositoryProvider` (merged 2026-06-11) |
 | #56 | PR | OBTBottomNav design-system primitive (`components.md §2`) + `AuthenticatedShell` IndexedStack host (5 primary tabs) + 2 placeholder screens + `bottom_nav_tab_selected` telemetry + PopScope snap-to-tab-0 + `lib/main.dart` wire-change + deletion of temporary `HomePlaceholderScreen` (merged 2026-06-11) |
 | #57 | PR | FR-HD-04 persistent FAB + Add Expense context picker — `OBTFloatingActionButton` design-system primitive + `AuthenticatedShell` FAB slot + context picker bottom sheet (Friend / Group target with Group path stubbed for Sprint 3) + bundled `currentUserIdProvider` production wiring in `AuthenticatedWithProfile` arm of `lib/main.dart` (closes FR #56 deferral that left `friendsListProvider` + `activityFeedProvider` throwing in production) (merged 2026-06-11) |
-| **#58** | **PR** | **Next feature/chore PR — see below** |
+| #58 | PR | FR-SE-08 dedicated settlement-history screen (SCR-24) — `SettlementHistoryScreen` at `/settle/history` + `settlementHistoryProvider` (`StreamProvider.family`, 50-item cap) + `settlement_history_telemetry.dart` (2 pre-declared events) + "View Settlement History" link on `FriendDetailScreen` (friendship axis; group axis stubbed) (merged 2026-06-12) |
+| **#59** | **PR** | **Next feature/chore PR — see below** |
 
 The "Next three PRs" below refer to the next three FEATURE/CHORE
-**pull requests** — i.e. PR #58, PR #59, PR #60. Their issue-number
+**pull requests** — i.e. PR #59, PR #60, PR #61. Their issue-number
 counterparts (when filed) will consume intermediate numbers; the
-orchestrator should not assume PR #58 = number 58 on GitHub.
+orchestrator should not assume PR #59 = number 59 on GitHub.
 
 ---
 
@@ -229,31 +230,61 @@ copy itself already conveys the required user action.
 
 ---
 
-## PR #58 — TBD
+## PR #58 — Merged
 
-**Status:** Next up. Architect picks at PR #58 kickoff per Sprint 2 velocity.
+**Status:** Merged 2026-06-12. FR-SE-08 dedicated settlement-history
+screen (SCR-24) shipped for the friendship axis.
 
-PR #57 shipped the FR-HD-04 persistent FAB + Add Expense context
-picker plus the bundled `currentUserIdProvider` production-wiring
-closure. The shell now has its canonical primary-action FAB and the
-two providers it depends on (`friendsListProvider`,
-`activityFeedProvider`) are correctly wired in production. The FAB
-is the natural seam that the FR-HD-01..04 home-dashboard work and
-the Sprint 3 Groups epic will inherit.
+PR #58 closed the FR-SE-08 P0 commitment for the dedicated
+`/settle/history` surface. The in-timeline settlement rows (PR #42 +
+PR #43) satisfied the functional commitment; PR #58 delivered the
+design-spec contract — a full reverse-chronological list reachable
+from the "View Settlement History" link on Friend Detail:
+
+- **`SettlementHistoryScreen`** (SCR-24) at
+  `lib/features/settlements/presentation/settlement_history_screen.dart`.
+  Generic over `(contextType, contextId)` — the architectural seam the
+  Sprint 3 Group Detail screen inherits. Four states (loading /
+  populated / empty / error) via inline private widgets (no OBT*
+  primitive extraction).
+- **`settlementHistoryProvider`** — a `StreamProvider.family` keyed by
+  `SettlementHistoryArgs { contextType, contextId }`, reusing the
+  PR #42 `watchByContext` read path with a 50-item cap. Zero changes
+  to the repository, rules, or indexes.
+- **`settlement_history_telemetry.dart`** — the two pre-declared
+  events (`settlement_history_viewed`, `settlement_history_error`).
+  NEITHER carries `context_id` (PII guard, ADR-0013).
+- **"View Settlement History" link** on `FriendDetailScreen` (populated
+  state only). No entry-point telemetry — the destination's
+  `settlement_history_viewed` captures the funnel arrival.
+
+Deferred (tracked follow-ups): Group-context push wiring (Sprint 3),
+cursor-based pagination beyond 50, the OBT* primitive extractions
+(`OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` /
+`OBTUserAvatar` / `OBTRupeeText`), real-time fade-in, context-deleted
+snackbar, per-month grouping, settlement-detail navigation, and the
+share/export action.
+
+**Velocity:** 3 SP (PR #58) → cumulative **93 SP across 22 PRs**.
+
+---
+
+## PR #59 — TBD
+
+**Status:** Next up. Architect picks at PR #59 kickoff per Sprint 2 velocity.
+
+The dedicated settlement-history surface is now live. The next slot is
+open; the candidate list below carries forward everything not yet
+shipped.
 
 Candidates (in rough priority order — architect's call at kickoff):
 
-- **FR-SE-08 dedicated full-history settlement screen** at
-  `/settlements/history` (P0 — PR #42's in-timeline rows satisfy
-  v1.0 functionally but the dedicated screen is still a v1.0
-  commitment). Natural pairing with the shell + FAB that PR #56 +
-  PR #57 just shipped because the shared nav surface makes the
-  "All settlements" deep-link target obvious. ~3-5 SP. **Highest-
-  priority follow-up; top candidate for PR #58.**
 - **FR-PR-05 Contact Support `mailto:` flow** (P0; depends on
   Remote Config wiring for the support email address; small
   standalone PR ~2 SP). Closes the last P0 line item on the
-  Profile screen.
+  Profile screen. The `SettlementHistoryScreen` error state's Retry
+  button is the v1.0 fallback; the "Contact Support" link in SCR-24
+  §States row 4 lands with this PR.
 - **`app_settings` / `permission_handler` dependency +
   AC-11 "Open Settings" CTA wiring (surfaced by PR #55 QA).**
   ~1-2 SP. Adds the dependency + wires the CTA on both platforms.
@@ -350,19 +381,19 @@ Candidates (in rough priority order — architect's call at kickoff):
 
 ---
 
-## PR #59 — TBD
-
-**Status:** Slot reserved. Architect picks at PR #58 kickoff.
-
-Candidates: whatever doesn't land in PR #58 from the list above.
-
----
-
 ## PR #60 — TBD
 
 **Status:** Slot reserved. Architect picks at PR #59 kickoff.
 
-Candidates: whatever doesn't land in PR #58 / PR #59 from the list above.
+Candidates: whatever doesn't land in PR #59 from the list above.
+
+---
+
+## PR #61 — TBD
+
+**Status:** Slot reserved. Architect picks at PR #60 kickoff.
+
+Candidates: whatever doesn't land in PR #59 / PR #60 from the list above.
 
 ---
 
@@ -458,14 +489,14 @@ completion of PR #56 architect §2.1 reconciliation.
 
 ---
 
-## Snapshot — Sprint 2 status at end of PR #57
+## Snapshot — Sprint 2 status at end of PR #58
 
 | Metric | Value |
 |---|---|
-| PRs merged in Sprint 2 | 21 (#31, #32, #34, #35, #36, #37, #38, #41, #42, #43, #44, #45, #46, #48, #51, #52, #53, #54, #55, #56, #57) |
-| Story points delivered | 90 |
-| Bucket-B items closed | 10 (R1, R2, R3, R5a, R7, R8, CV3, SR8, D5a, D5b). Remaining: 27 / 37. **PR #57 made zero Bucket-B progress** — the FR-HD-04 FAB + context picker work was tracked as a P0 functional requirement (closes SRS row FR-HD-04), not as a Bucket-B item; the bundled `currentUserIdProvider` production-wiring closure was tracked in `next-three-prs.md` as a PR #56 reconciliation discovery, not as a Bucket-B item. |
+| PRs merged in Sprint 2 | 22 (#31, #32, #34, #35, #36, #37, #38, #41, #42, #43, #44, #45, #46, #48, #51, #52, #53, #54, #55, #56, #57, #58) |
+| Story points delivered | 93 |
+| Bucket-B items closed | 10 (R1, R2, R3, R5a, R7, R8, CV3, SR8, D5a, D5b). Remaining: 27 / 37. **PR #58 made zero Bucket-B progress** — the FR-SE-08 settlement-history screen was tracked as a P0 functional requirement (closes SRS row FR-SE-08), not as a Bucket-B item. |
 | Critical Cross-PR Constraints | C-1 RESOLVED (chore #25 closed in PR #38) |
-| Open `sprint-2-chore` issues | 14 (issues #47, #49, #50 remain open; PR #57 did not file any new issues) |
+| Open `sprint-2-chore` issues | 14 (issues #47, #49, #50 remain open; PR #58 did not file any new issues) |
 | Outstanding deadline-bound work | **None.** |
-| Round-trip closures | **Simplified-debts WRITE round-trip closed in PR #43.** Expense lifecycle (create / edit / soft-delete) closed end-to-end on the friendship axis by PR #46. Receipt attachment surface closed by PR #48. Activity-feed WRITE-SIDE closed by PR #51; READ-SIDE closed by PR #52. FCM push-notification round-trip closed by PR #53. FR-SE-09 Send Reminder round-trip closed by PR #54. Notification preferences round-trip closed by PR #55 (server gate from PR #53 + client UI). Bottom-nav UX-foundation closed by PR #56. **FR-HD-04 persistent FAB + Add Expense context picker closed by PR #57** — the shell exposes its canonical primary-action FAB and the Add Expense funnel is reachable from any tab; the bundled `currentUserIdProvider` production-wiring closure restores `friendsListProvider` + `activityFeedProvider` to functional state in production. |
+| Round-trip closures | **Simplified-debts WRITE round-trip closed in PR #43.** Expense lifecycle (create / edit / soft-delete) closed end-to-end on the friendship axis by PR #46. Receipt attachment surface closed by PR #48. Activity-feed WRITE-SIDE closed by PR #51; READ-SIDE closed by PR #52. FCM push-notification round-trip closed by PR #53. FR-SE-09 Send Reminder round-trip closed by PR #54. Notification preferences round-trip closed by PR #55 (server gate from PR #53 + client UI). Bottom-nav UX-foundation closed by PR #56. FR-HD-04 persistent FAB + Add Expense context picker closed by PR #57. **FR-SE-08 dedicated settlement-history surface (friendship axis) closed by PR #58** — the `/settle/history` screen is reachable from the Friend Detail "View Settlement History" link; the group axis is wired by the Sprint 3 Group Detail screen. |

--- a/docs/sprint-zero/sprint-2-plan.md
+++ b/docs/sprint-zero/sprint-2-plan.md
@@ -1,6 +1,6 @@
 # Sprint 2 Plan
 
-> Last updated: PR #57 (FR-HD-04 persistent FAB + Add Expense context picker + bundled `currentUserIdProvider` production-wiring closure) — 21st merged PR.
+> Last updated: PR #58 (FR-SE-08 dedicated settlement-history screen, SCR-24 — friendship axis; group axis stubbed pending Sprint 3) — 22nd merged PR.
 
 ---
 
@@ -168,6 +168,7 @@ If ANY gate is red, file a dedicated DevOps chore PR (estimated
 | #55 | FR-PR-03 + FR-AC-04 | Notification preferences UI (SCR-27) — `/profile/notifications` route with three per-event toggles (`newExpense` / `settlement` / `reminder`) + per-toggle 500 ms debounced auto-save controller + `UserRepository.updateNotificationPrefs` Firestore dot-path partial-map writer (avoids the read-modify-write race the full-map form would inherit) + production `cloud_functions` adapter wiring for `reminderRepositoryProvider` + `matchingRepositoryProvider` (closes the throw-until-overridden gap surfaced by PR #54; FR-SE-09 Send Reminder callable now reaches its production handler from the app shell) + OS-permission banner with graceful "Open Settings" degradation per architect §2.4 (`firebase_messaging: ^16.2.0` Dart API does not expose `openAppNotificationSettings()` on either platform; CTA deferred to a future `app_settings` / `permission_handler` follow-up chore) + 3 new partial-map `users-update.test.ts` rules tests | 5 | Merged |
 | #56 | CHORE-PR56 | OBTBottomNav design-system primitive (`components.md §2`) + `AuthenticatedShell` IndexedStack host for the five primary tabs (Home / Friends / Groups / Activity / Profile) + 2 new placeholder screens (Home dashboard + Groups list) + `bottom_nav_tab_selected` telemetry event + PopScope snap-to-tab-0 on Android back + `lib/main.dart` wire-change swapping `HomePlaceholderScreen` for `AuthenticatedShell` + deletion of the temporary `HomePlaceholderScreen` (closes the long-deferred PR #52 §2.1 OBTBottomNav shell deferral) | 3 | Merged |
 | #57 | FR-HD-04 | Persistent FAB + Add Expense context picker — `OBTFloatingActionButton` design-system primitive (`components.md`) at `lib/core/widgets/nav/obt_floating_action_button.dart` (50 LOC) + `AuthenticatedShell` `Scaffold.floatingActionButton` slot + `_onFabTapped` handler (FAB hidden on Activity tab per architect §2.3) + `AddExpenseContextPickerSheet` bottom sheet (282 LOC; Friend path routes to existing Add Expense bottom sheet from PR #38; Group path stubbed with "Coming soon" snackbar pending Sprint 3 Groups epic) + 6 new `shell_telemetry.dart` constants for the FAB-tap → picker-open → friend-select / group-select-stub funnel + `friend_detail_screen.dart` FAB refactor (`heroTag: 'friendDetailFab'` to avoid Hero animation collision with the shell-owned FAB) + **bundled `currentUserIdProvider` production wiring** in the `AuthenticatedWithProfile` arm of `lib/main.dart` per-arm `ProviderScope` override (closes the FR #56 deferral that left `friendsListProvider` + `activityFeedProvider` throwing `UnimplementedError` on first read in production) + Riverpod 2.x `dependencies: [currentUserIdProvider]` 2-character addition each on those two providers (architect §2.9 reconciliation discovery — natural completion of PR #56 architect §2.1) | 3 | Merged |
+| #58 | FR-SE-08 | Dedicated settlement-history screen (SCR-24) — `SettlementHistoryScreen` at `/settle/history` (friendship axis; generic over `(contextType, contextId)` so the Sprint 3 Group Detail screen inherits the seam) with four inline states (loading / populated / empty / error; no OBT* primitive extraction per architect §2.3) + per-row layout (`dd MMM yyyy` date, payer→arrow→payee avatars, `formatInrFromPaise()` amount, optional note, 64 dp min row) + `settlementHistoryProvider` (`StreamProvider.family` keyed by `SettlementHistoryArgs`, reusing the PR #42 `watchByContext` read path with a 50-item cap) + `settlement_history_telemetry.dart` (2 pre-declared events `settlement_history_viewed` / `settlement_history_error`; NEITHER carries `context_id` per ADR-0013) + "View Settlement History" link on `FriendDetailScreen` (populated state only; no entry-point telemetry per architect §2.6). Zero changes to repository / rules / indexes / functions | 3 | Merged |
 
 ---
 
@@ -196,7 +197,8 @@ If ANY gate is red, file a dedicated DevOps chore PR (estimated
 | #55 | 5 | Merged |
 | #56 | 3 | Merged (chore — UX foundation) |
 | #57 | 3 | Merged (FR-HD-04 + bundled regression closure) |
-| **Total** | **90** | **21 PRs so far** |
+| #58 | 3 | Merged (FR-SE-08 settlement-history screen) |
+| **Total** | **93** | **22 PRs so far** |
 
 Sprint 1 reference:
 

--- a/docs/sprint-zero/stories/FR-SE-08-settlement-history.md
+++ b/docs/sprint-zero/stories/FR-SE-08-settlement-history.md
@@ -1,0 +1,513 @@
+# FR-SE-08: Settlement History screen (SCR-24)
+
+> Implementation-ready user story for the dedicated full-history
+> settlement screen. Tap a `View Settlement History` text link on the
+> Friend Detail screen → push a reverse-chronological list of every
+> settlement recorded against that friendship.
+
+---
+
+## SRS Requirement ID(s)
+
+FR-SE-08 (SRS section 4.6 — View settlement history per friend and per
+group). PR #42 + PR #43 partially delivered FR-SE-08 via the in-timeline
+settlement rows on Friend Detail (top-5). This story closes the **P0
+commitment** for the dedicated `/settle/history` surface — the friendship
+axis only. The group axis is wired by the Sprint 3 Group Detail screen
+PR (the screen TAKES a generic `contextType` argument; only the
+friendship arm is wired here).
+
+## Relevant SRS Sections
+
+- Section 4.6 — Simplify & Settle (FR-SE-08).
+- Section 5.6 — Accessibility (48x48 dp tap targets, WCAG 2.1 AA
+  contrast, dynamic font scaling, screen-reader semantics).
+- Section 5.9 — Localisation and internationalisation (`dd MMM yyyy`
+  IST date format).
+- Section 5.10 — Observability (telemetry contract).
+- Section 6.3 items 6 and 7 — Settlement history per friend / per group.
+- Section 6.4 — Loading, empty, and error states.
+- Section 7.3 — Key architectural decisions (Invariants 1 and 2 —
+  read-side only on this surface).
+- Section 13.2 — Story format (this document).
+
+## Priority
+
+**P0 — Must have**
+
+## Story Points
+
+3
+
+## User Story
+
+As a **signed-in user**,
+I want to **open a dedicated screen listing every settlement I have
+recorded with a friend in reverse-chronological order**,
+so that **I can review the full payment history beyond the most recent
+few rows shown inline on the Friend Detail timeline**.
+
+## Preconditions
+
+1. User is authenticated and a member of the friendship `friendshipId`.
+2. The top-level `settlements/{settlementId}` collection is readable by
+   members of the context per the rules shipped in PR #37
+   (`firestore.rules`). The screen is **read-only**; it never writes.
+3. `SettlementRepository.watchByContext({contextType, contextId})`
+   (PR #42 read path) returns a `Stream<List<SettlementDoc>>` filtered by
+   `contextType + contextId`, ordered by `date` descending, with
+   soft-deleted entries already excluded at the repository layer.
+4. The Firestore composite index `(contextType ASC, contextId ASC,
+   date DESC)` (PR #42) satisfies the canonical query without
+   `FAILED_PRECONDITION`. No index change is required.
+5. PR #57 has merged: `FriendDetailScreen`, `friendDetailProvider`, and
+   the `OBTFloatingActionButton` refactor all exist in production.
+6. `simplifiedBalances` is maintained exclusively by the server
+   (Invariant 2). This screen reads only `settlements/{id}` documents
+   and never references `simplifiedBalances`.
+7. The app uses the single configured Firebase project; pre-merge
+   verification runs against the Firebase Emulator Suite (Invariant 4).
+
+---
+
+## Acceptance Criteria
+
+### Screen render + state contract
+
+### AC-1 — Populated state renders settlements in date-desc order
+
+> Given `settlementHistoryProvider` returns 3 settlements with dates
+> `2025-03-25`, `2025-03-18`, `2025-02-02`
+> When the screen is mounted
+> Then 3 settlement rows are rendered in that exact order (no
+> client-side sort — the repository stream guarantees date-desc).
+
+### AC-2 — Empty state renders the canonical empty placeholder
+
+> Given `settlementHistoryProvider` returns an empty list
+> When the screen is mounted
+> Then a `Center(Column(...))` with `Icon(Icons.history)` +
+> `Text('No settlements yet')` +
+> `Text('Once you settle up, it will appear here.')` renders
+> And NO Retry button renders (per SCR-24 §States row 3: "No CTA
+> button").
+
+### AC-3 — Loading state renders a centred `CircularProgressIndicator`
+
+> Given `settlementHistoryProvider` is `AsyncLoading`
+> When the screen is mounted
+> Then a `Center(CircularProgressIndicator())` renders.
+
+### AC-4 — Error state renders the canonical error placeholder with Retry
+
+> Given `settlementHistoryProvider` is `AsyncError`
+> When the screen is mounted
+> Then a `Center(Column(...))` with `Icon(Icons.error_outline)` +
+> `Text('Something went wrong')` +
+> `Text('We could not load settlement history. Please try again.')` +
+> `FilledButton(child: Text('Retry'))` renders
+> And tapping Retry calls `ref.invalidate(settlementHistoryProvider(args))`
+> and the provider re-subscribes.
+
+### AC-5 — 50-item cap
+
+> Given `settlementHistoryProvider` is fed a 76-item upstream stream
+> When projected
+> Then the screen renders exactly 50 rows
+> And the `settlement_history_viewed` event fires with `item_count: 50`
+> (not 76).
+
+### Settlement-row layout contract (per SCR-24 §Settlement Row Layout)
+
+### AC-6 — Date format
+
+> Given a settlement with `date: DateTime(2025, 3, 25)`
+> When its row renders
+> Then the date is displayed as `'25 Mar 2025'` (per SRS section 5.9
+> `dd MMM yyyy`).
+
+### AC-7 — Amount format
+
+> Given a settlement with `amountPaise: 80000`
+> When its row renders
+> Then the amount is displayed as `'₹800.00'` via
+> `formatInrFromPaise(80000)` (Invariant 1).
+
+### AC-8 — Note rendering
+
+> Given a settlement with `note: 'GPay transfer'`
+> When its row renders
+> Then the note text is visible below the amount
+> And given `note: null`, when its row renders, then NO note text
+> widget is in the tree.
+
+### AC-9 — Avatar + arrow row
+
+> Given a settlement with `fromUserId: currentUid` + `toUserId: otherUid`
+> When its row renders
+> Then the payer avatar shows the current user's initials
+> And the payee avatar shows the friend's display-name initials
+> And a directional arrow icon is between them.
+
+### AC-10 — Row tap target
+
+> Given any settlement row
+> When measured
+> Then its rendered height is >= 64 dp (per SCR-24 §Settlement Row
+> Layout last paragraph).
+
+### Accessibility (per SCR-24 §Accessibility)
+
+### AC-11 — Screen title semantic header
+
+> Given the screen is mounted
+> When scanned for semantics
+> Then a semantic node with label `'Settlement History'` and
+> `isHeader: true` exists.
+
+### AC-12 — Settlement-row semantic label
+
+> Given a settlement row for `from=You, to=Priya, amount=₹800.00,
+> date=25 Mar 2025, note='GPay transfer'`
+> When scanned for semantics
+> Then a semantic node with label
+> `'You paid Priya rupees 800.00 on 25 Mar 2025. Note: GPay transfer.'`
+> exists
+> And given a `note: null` settlement, the label substitutes
+> `'Note: no note.'`.
+
+### Telemetry contract (both events pre-declared in telemetry-plan §1.3)
+
+### AC-13 — `settlement_history_viewed` fires exactly once on first populated frame
+
+> Given the screen mounts and transitions Loading → AsyncData([3 items])
+> When one frame has been pumped
+> Then exactly one `settlement_history_viewed` event has fired with
+> `{context_type: 'friendship', item_count: 3}`
+> And subsequent rebuilds (e.g. the provider stream emits a new value)
+> do NOT re-fire.
+
+### AC-14 — `settlement_history_error` fires on AsyncError
+
+> Given the screen mounts and the provider yields AsyncError
+> When one frame has been pumped
+> Then exactly one `settlement_history_error` event has fired with
+> `{error_code: '<mapped code>', context_type: 'friendship'}`.
+
+### AC-15 — Telemetry PII guard
+
+> Given the `settlement_history_viewed` and `settlement_history_error`
+> events fire
+> When scanned
+> Then NEITHER payload includes a `userId` / `uid` / `friendship_id` /
+> `friendship_id_hash` / `context_id` parameter
+> And the PII-leak grep test asserts the source files contain no such
+> literals.
+
+### `FriendDetailScreen` "View Settlement History" link integration
+
+### AC-16 — Link visible in Populated state
+
+> Given `friendDetailProvider` returns `FriendDetailStatePopulated`
+> When the screen is mounted
+> Then a `TextButton` with label `'View Settlement History'` is rendered
+> below the `FriendDetailTimelineWidget`.
+
+### AC-17 — Link hidden in Empty state
+
+> Given `friendDetailProvider` returns `FriendDetailStateEmpty`
+> When the screen is mounted
+> Then NO `TextButton` with label `'View Settlement History'` is in the
+> tree.
+
+### AC-18 — Link tap pushes `SettlementHistoryScreen` with correct args
+
+> Given the Populated state is mounted
+> When the user taps the "View Settlement History" link
+> Then a `MaterialPageRoute` is pushed
+> And its `builder` returns a `SettlementHistoryScreen` with
+> `contextType: 'friendship'`, `contextId: '<friendshipId>'`,
+> `currentUserUid: '<currentUid>'`, `otherUserUid: '<otherUid>'`,
+> `otherDisplayName: '<state.header.displayName>'`.
+
+### Cross-cutting and negative guards
+
+### AC-19 — Invariant 1 boundary contract
+
+> Given the PR diff
+> When scanned for `.toDouble()`, `parseFloat`, `/ 100`, `.toFixed`, or
+> `double ` declarations on the new files
+> Then ZERO violations exist anywhere in
+> `lib/features/settlements/presentation/settlement_history_screen.dart`,
+> `lib/features/settlements/application/settlement_history_provider.dart`,
+> or
+> `lib/features/settlements/application/settlement_history_telemetry.dart`.
+
+### AC-20 — Invariant 2 negative guard
+
+> Given the PR diff
+> When scanned
+> Then ZERO references to `simplifiedBalances` exist anywhere in the 3
+> new files.
+
+---
+
+## Telemetry Events
+
+Both events are **pre-declared** in
+`docs/design/07-technical/telemetry-plan.md` §1.3 lines 193-194. No
+telemetry-plan append is required.
+
+| Event | Parameters | Trigger |
+|---|---|---|
+| `settlement_history_viewed` | `context_type` (string), `item_count` (int) | First populated frame (fires exactly once) |
+| `settlement_history_error` | `error_code` (string), `context_type` (string) | AsyncError |
+
+**PII guard (ADR-0013).** NEITHER event carries `context_id`. For the
+friendship axis `contextId` is a UID-composite `{uidA}_{uidB}` that must
+not be emitted raw. The telemetry-plan deliberately omits it; the screen
+spec at SCR-24 §Telemetry Events lists `context_id` and is incorrect
+(see Architect Notes §2.9). `context_type` is a safe non-identifying
+enum token; `item_count` is a non-PII integer; `error_code` is a safe
+Firebase error-code enum.
+
+## Invariant Applicability Assessment
+
+| Invariant | Applicability | Rationale |
+|---|---|---|
+| Inv-1 (integer paise) | **N/A** (read-only) | No monetary write paths. The per-row amount renders via `formatInrFromPaise(int)`. Defence-in-depth grep returns 0 violations. |
+| Inv-2 (`simplifiedBalances` server-only) | **N/A** | The screen reads `settlements/{id}` documents via `SettlementRepository.watchByContext`; it never references `simplifiedBalances`. |
+| Inv-3 (system share sheet) | **N/A** | The share/export action is deferred (SCR-24 §Open Questions item 2). |
+| Inv-4 (single Firebase project) | **N/A** | No new Firebase SDK usage; reads through the single production project. |
+
+## Definition of Done
+
+- [ ] All 20 acceptance criteria are implemented and covered by tests.
+- [ ] `flutter analyze --fatal-infos` reports no issues.
+- [ ] `dart format --set-exit-if-changed .` reports no changes.
+- [ ] `flutter test` passes (baseline + new tests).
+- [ ] Functions suite UNCHANGED (no `functions/**` touch).
+- [ ] Rules suite UNCHANGED (no `firestore.rules` touch).
+- [ ] QA sign-off with evidence for all 4 states, the 50-item cap, the
+  date + amount format, the accessibility labels, the telemetry
+  contract, and the FriendDetailScreen link visibility contract.
+- [ ] Documentation updated (this story with Architect Notes,
+  sprint-2-plan, next-three-prs, burndown, settlements README).
+
+## Invariant Compliance
+
+All four invariants are N/A on this read-only client surface. The
+`settlement_history_pii_leak_test.dart` is the defence-in-depth
+assertion that the three new files carry no Inv-1 / Inv-2 / PII
+boundary-contract violations.
+
+## Design Artefact References
+
+- `docs/design/06-screen-specs/23-28-settle-activity-profile.md`
+  §SCR-24 (lines 153-253) — full screen spec.
+- `docs/design/04-wireframes/settle-up-flow.md` §4 (lines 326-400) —
+  Settlement History wireframe.
+- `docs/design/07-technical/telemetry-plan.md` §1.3 lines 193-194 —
+  pre-declared event contracts.
+- `docs/design/02-design-system/components.md` §5/§18/§19/§20 — the
+  OBT* primitives DEFERRED in favour of inline equivalents.
+- `docs/design/07-technical/error-and-empty-state-taxonomy.md` —
+  AsyncError → user-facing error-state mapping.
+
+## Responsible Agents
+
+| Agent | Responsibility |
+|---|---|
+| PM | This story + acceptance criteria. |
+| Architect | Architect Notes §2.1–§2.12; invariant applicability; primitive-extraction deferral; route and cap-location decisions. |
+| Flutter Developer | `SettlementHistoryScreen`, `settlementHistoryProvider`, telemetry constants, FriendDetailScreen link, tests. |
+| QA | Manual smoke matrix; DoD sign-off; negative-scope greps. |
+
+## Technical Notes
+
+- The screen is a `ConsumerStatefulWidget` (the one-shot
+  `settlement_history_viewed` post-frame callback mirrors the
+  `FriendDetailScreen._loggedView` precedent).
+- The provider is a `StreamProvider.family<List<SettlementDoc>,
+  SettlementHistoryArgs>` reusing the existing
+  `settlementRepositoryProvider` (root-scope; no `dependencies:` needed).
+- The 50-item cap is applied at the provider via `.take(50)`.
+- Date rendering uses `DateFormat('dd MMM yyyy')` with no locale
+  argument and no `initializeDateFormatting()` — matching the existing
+  `relative_timestamp_formatter.dart` precedent (which renders
+  `dd MMM yyyy` in production without locale init).
+
+## Out of scope
+
+- Group-context push wiring (Sprint 3 Groups epic).
+- Settlement edit/delete flow (FR-EX-06 parallel; separate later PR).
+- Cursor-based pagination beyond the 50-item cap (defer until evidence
+  of >50-settlement friendships).
+- `OBTSkeletonLoader` / `OBTEmptyState` / `OBTErrorState` /
+  `OBTUserAvatar` / `OBTRupeeText` primitive extractions (separate
+  chores; inline equivalents ship here).
+- Real-time fade-in animation (SCR-24 §Edge Cases item 2).
+- Context-deleted snackbar + auto-back (SCR-24 §Edge Cases item 3).
+- Per-month section-header grouping (SCR-24 §Open Questions item 3).
+- Settlement-row tap-to-detail navigation (SCR-24 §Open Questions
+  item 1; no detail screen exists).
+- Share/export action in the app bar (SCR-24 §Open Questions item 2;
+  v1.1).
+- `view_all_settlements_tapped` entry-point telemetry (over-instrumentation;
+  Architect Notes §2.6).
+- FR-PR-05 Contact Support `mailto:` flow (the error state's Retry is
+  the v1.0 fallback; the "Contact Support" link in SCR-24 §States row 4
+  is a separate P0 story).
+
+---
+
+## Architect Notes
+
+> Appended by the Solution Architect. Ratifies the technical decisions
+> the Flutter Developer must follow. Anything outside §2.10 is scope
+> creep.
+
+### 2.1 Route name
+
+RATIFY: `/settle/history` per `SCR-24 §Screen Identity` Route row. No
+`go_router` migration in this PR — the route is pushed via
+`MaterialPageRoute.push` from `FriendDetailScreen`. The `next-three-prs.md`
+shorthand `/settlements/history` is superseded by the screen-spec value.
+
+### 2.2 50-item cap location
+
+RATIFY: enforced at the **provider** layer. `settlementHistoryProvider`
+pipes `.take(50)` over the upstream `watchByContext` stream. No "Load
+more" footer for v1.0 per SCR-24 §Edge Cases item 1. The
+`item_count` telemetry parameter therefore reports the post-cap length
+(a 76-settlement context emits `item_count: 50`).
+
+### 2.3 Inline empty/loading/error widgets (NO primitive extraction)
+
+RATIFY: ship `_SettlementHistoryEmptyState`,
+`_SettlementHistoryLoadingState`, `_SettlementHistoryErrorState` as
+private widgets in the screen file (mirrors the PR #42
+`friend_detail_states.dart` precedent). DEFER `OBTSkeletonLoader` /
+`OBTEmptyState` / `OBTErrorState` / `OBTUserAvatar` / `OBTRupeeText` to
+separate chores. The loading state is a plain centred
+`CircularProgressIndicator` (not a shimmer skeleton) — `OBTSkeletonLoader`
+does not exist yet.
+
+### 2.4 Screen constructor args
+
+RATIFY: 5-arg
+`SettlementHistoryScreen({required this.contextType, required
+this.contextId, required this.currentUserUid, required this.otherUserUid,
+required this.otherDisplayName, super.key})`. Provider-agnostic — the
+screen does NOT read `currentUserIdProvider`; the `(contextType,
+contextId)` arguments fully scope the query, and `currentUserUid` is
+threaded as a constructor argument so the screen can label the payer
+avatar. This is the architectural seam for the Sprint 3 Group axis: the
+Group Detail screen will push the same screen with `contextType: 'group'`.
+
+### 2.5 `FriendDetailScreen` link visibility
+
+RATIFY: the "View Settlement History" `TextButton` is unconditionally
+visible in `FriendDetailStatePopulated`; HIDDEN in
+`FriendDetailStateEmpty`. The link sits BELOW the
+`FriendDetailTimelineWidget` inside the existing `SingleChildScrollView`.
+
+### 2.6 Entry-point telemetry OUT OF SCOPE
+
+RATIFY: do NOT emit a `view_all_settlements_tapped` event from the link
+tap. The destination's `settlement_history_viewed` captures the funnel
+arrival; an additional entry-point event would over-instrument.
+
+### 2.7 Date format + per-row inline
+
+RATIFY: `dd MMM yyyy` per SRS section 5.9, rendered INLINE above each
+row (not as a section header — per SCR-24 §Open Questions item 3 defer).
+Use `DateFormat('dd MMM yyyy')` with NO locale argument: the existing
+`relative_timestamp_formatter.dart` renders `dd MMM yyyy` in production
+without `initializeDateFormatting()`, so no new dependency or locale
+bootstrap is required. The `SettlementDoc.date` value comes from
+`Timestamp.toDate()` (device-local); the existing in-timeline
+`_SettlementRow` formats `doc.date` directly with no extra offset, and
+this screen matches that precedent.
+
+### 2.8 Error-code mapping table
+
+RATIFY:
+- `FirebaseException` with `code == 'permission-denied'` →
+  `'permission-denied'`
+- `FirebaseException` with `code == 'unavailable'` → `'unavailable'`
+- any other `FirebaseException` → its `code`
+- any non-`FirebaseException` → `'unknown'`
+
+Mirrors the existing `SettlementCreateError` mapping discipline (PR #43)
+but emits the raw Firebase code (kebab) rather than the snake-case
+`SettlementCreateErrorType` label, because the `settlement_history_error`
+contract is independent of the write-side enum.
+
+### 2.9 Telemetry-plan vs screen-spec discrepancy on `context_id`
+
+RATIFY: the telemetry-plan §1.3 lines 193-194 version is **authoritative**
+(NO `context_id` parameter on either event). The screen spec at SCR-24
+§Telemetry Events lists `context_id` and is INCORRECT (a parallel
+discrepancy exists on `settle_up_screen_viewed` at SCR-23). For the
+friendship axis `context_id` is a UID-composite `{uidA}_{uidB}` that must
+not be emitted raw per ADR-0013. The PII-leak test asserts the events
+emit no `context_id`. The screen-spec docs cleanup is a tracked
+follow-up, NOT fixed in this PR.
+
+### 2.10 Files to touch (exhaustive — anything outside this set is scope creep)
+
+**New:**
+- `docs/sprint-zero/stories/FR-SE-08-settlement-history.md` (this file).
+- `lib/features/settlements/application/settlement_history_telemetry.dart`.
+- `lib/features/settlements/application/settlement_history_provider.dart`.
+- `lib/features/settlements/presentation/settlement_history_screen.dart`.
+- `test/features/settlements/settlement_history_screen_test.dart`.
+- `test/features/settlements/settlement_history_provider_test.dart`.
+- `test/features/settlements/settlement_history_telemetry_test.dart`.
+- `test/features/settlements/settlement_history_pii_leak_test.dart`.
+
+**Extend:**
+- `lib/features/friends/presentation/friend_detail_screen.dart` (link).
+- `lib/features/settlements/README.md` (Implemented scope; remove the
+  FR-SE-08 deferral line).
+- `test/features/friends/friend_detail_screen_widget_test.dart`
+  (AC-16 / AC-17 / AC-18).
+- `docs/sprint-zero/sprint-2-plan.md`,
+  `docs/sprint-zero/next-three-prs.md`,
+  `docs/audits/sprint-1/07-bucket-b-burndown.md` (Phase 7 roll-ups).
+
+### 2.11 Files explicitly NOT to touch (negative scope guardrails)
+
+- `firestore.rules`, `firestore.indexes.json`, `storage.rules` —
+  UNCHANGED.
+- `functions/package.json`, all of `functions/src/**`, all of
+  `functions/test/**` — UNCHANGED.
+- `lib/features/settlements/data/**` (the repository is UNCHANGED).
+- `lib/features/settlements/domain/**` (the `SettlementDoc` shape is
+  UNCHANGED).
+- `lib/features/settlements/presentation/settle_up_bottom_sheet.dart` —
+  UNCHANGED.
+- `lib/features/{expenses,activity,notifications,reminders,profile,auth,shell}/**`
+  — UNCHANGED.
+- `lib/features/friends/**` except `friend_detail_screen.dart` —
+  UNCHANGED.
+- `lib/core/**` — UNCHANGED.
+- `pubspec.yaml`, `pubspec.lock`, `ios/Podfile.lock` — UNCHANGED.
+- `.github/workflows/*.yml` — UNCHANGED.
+- `docs/design/**` — read-only references; the SCR-24 vs telemetry-plan
+  `context_id` discrepancy is tracked but NOT fixed in this PR.
+
+### 2.12 Anticipated reconciliations
+
+1. `lib/features/profile/presentation/profile_placeholder_screen.dart`
+   still exists alongside the real `profile_screen.dart`. Still NOT
+   touched.
+2. The `currentUserIdProvider` rehoming follow-up from PR #57 review
+   recommendation 2 remains tracked; not addressed here.
+3. The pre-existing storage-rules receipt-test failures remain
+   pre-existing; not addressed.
+4. The screen-spec vs telemetry-plan `context_id` discrepancy is
+   documented (§2.9) but not fixed here.
+5. The 5 OBT* primitive extractions are all tracked follow-ups; not
+   addressed here.

--- a/lib/features/friends/presentation/friend_detail_screen.dart
+++ b/lib/features/friends/presentation/friend_detail_screen.dart
@@ -17,6 +17,7 @@ import 'package:onebytwo/features/reminders/application/send_reminder_controller
 import 'package:onebytwo/features/reminders/domain/reminder_send_error.dart';
 import 'package:onebytwo/features/settlements/application/settle_up_telemetry.dart';
 import 'package:onebytwo/features/settlements/presentation/settle_up_bottom_sheet.dart';
+import 'package:onebytwo/features/settlements/presentation/settlement_history_screen.dart';
 
 /// Friend Detail screen (SCR-11 / FR-FR-04).
 ///
@@ -127,6 +128,18 @@ class _FriendDetailScreenState extends ConsumerState<FriendDetailScreen> {
                       otherUserUid: widget.otherUserUid,
                       friendDisplayName: state.header.displayName,
                     ),
+                    // SCR-24 entry point: the dedicated full settlement
+                    // history surface. Shown unconditionally in the
+                    // populated state, hidden in the empty state. No
+                    // entry-point telemetry — the destination's
+                    // settlement_history_viewed captures the arrival.
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: TextButton(
+                        onPressed: () => _openSettlementHistory(context, state),
+                        child: const Text('View Settlement History'),
+                      ),
+                    ),
                   ],
                 ),
               );
@@ -195,6 +208,23 @@ class _FriendDetailScreenState extends ConsumerState<FriendDetailScreen> {
         friendshipId: widget.friendshipId,
         currentUserUid: widget.currentUserUid,
         otherUserUid: widget.otherUserUid,
+      ),
+    );
+  }
+
+  void _openSettlementHistory(
+    BuildContext context,
+    FriendDetailStatePopulated state,
+  ) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => SettlementHistoryScreen(
+          contextType: 'friendship',
+          contextId: widget.friendshipId,
+          currentUserUid: widget.currentUserUid,
+          otherUserUid: widget.otherUserUid,
+          otherDisplayName: state.header.displayName,
+        ),
       ),
     );
   }

--- a/lib/features/settlements/README.md
+++ b/lib/features/settlements/README.md
@@ -1,9 +1,9 @@
 # Settlements
 
 Feature-folder that owns the "settle up" surfaces: settlement creation
-(FR-SE-05, PR #43), settlement history (FR-FR-04 timeline read path,
-PR #42; dedicated `/settlements/history` screen deferred), and payment
-reminders (FR-SE-09, separate later PR).
+(FR-SE-05, PR #43), settlement history (FR-FR-04 in-timeline read path,
+PR #42, plus the dedicated `/settle/history` screen for the friendship
+axis, FR-SE-08 / SCR-24), and payment reminders (FR-SE-09).
 
 ## Implemented scope
 
@@ -106,6 +106,41 @@ Per Architect Notes §2.5, the **receiving direction** (friend owes
 current user) ships **without** the card in PR #43; FR-SE-09 Send
 Reminder ships that branch.
 
+### Settlement history screen (FR-SE-08 / SCR-24)
+
+PR #58 closes the FR-SE-08 P0 commitment for the dedicated full-history
+surface (friendship axis; the group axis is wired by the Sprint 3 Group
+Detail screen). The screen reuses the PR #42 read path verbatim — zero
+changes to `settlement_repository.dart`, `firestore.rules`, or
+`firestore.indexes.json`.
+
+- `application/settlement_history_telemetry.dart` — event-name +
+  parameter-key constants for the two pre-declared events
+  (`settlement_history_viewed { context_type, item_count }`,
+  `settlement_history_error { error_code, context_type }`). NEITHER
+  event carries `context_id` (PII guard, ADR-0013).
+- `application/settlement_history_provider.dart` —
+  `settlementHistoryProvider`, a `StreamProvider.family` keyed by
+  `SettlementHistoryArgs { contextType, contextId }`. Reuses
+  `SettlementRepository.watchByContext` and applies a 50-item cap
+  (`settlementHistoryItemCap`) over the projected list.
+- `presentation/settlement_history_screen.dart` — the SCR-24
+  `ConsumerStatefulWidget`. Four states (loading / populated / empty /
+  error) via inline private widgets (no OBT* primitive extraction per
+  Architect Notes §2.3). Per-row layout: inline `dd MMM yyyy` date,
+  payer avatar → arrow → payee avatar, `formatInrFromPaise()` amount,
+  optional muted note. `settlement_history_viewed` fires exactly once
+  on the first resolved frame; `settlement_history_error` fires once on
+  the first error frame. Generic over `(contextType, contextId)` so the
+  Sprint 3 Group Detail surface can push it with `contextType: 'group'`.
+
+The entry point is the **"View Settlement History"** text link on
+`FriendDetailScreen`, shown unconditionally in the populated state and
+hidden in the empty state. The tap pushes the screen via
+`MaterialPageRoute` with `contextType: 'friendship'`. No entry-point
+telemetry — the destination's `settlement_history_viewed` captures the
+funnel arrival (Architect Notes §2.6).
+
 ## Layout
 
 ```
@@ -170,8 +205,6 @@ presentation/
 
 ## Out of scope for PR #43
 
-- Dedicated full-history screen at `/settlements/history` (FR-SE-08
-  P0 — separate later PR; PR #42's in-timeline rows satisfy v1.0).
 - Home Dashboard `OBTSettleUpCard` host (FR-HD-02 — Home Dashboard
   does not exist yet).
 - Group context Settle Up (FR-GR-04 — Sprint 3 groups epic).
@@ -181,6 +214,10 @@ presentation/
 - Settlement Confirmation animation sub-screen (UX-polish later PR).
 - Two-sided card orientation when the friend owes the current user
   (§2.5 default-omit; ships with FR-SE-09).
+
+> The dedicated full-history screen (FR-SE-08 P0) was deferred from
+> PR #43 and is now shipped by PR #58 — see "Settlement history screen
+> (FR-SE-08 / SCR-24)" above.
 
 ## Firestore composite index
 

--- a/lib/features/settlements/application/settlement_history_provider.dart
+++ b/lib/features/settlements/application/settlement_history_provider.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onebytwo/features/settlements/data/settlement_repository.dart';
+import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
+
+/// Maximum number of settlement rows the history screen renders for
+/// v1.0. Enforced at the provider layer per the SCR-24 §Edge Cases
+/// item 1 fallback (no "Load more" footer). Defer cursor-based
+/// pagination until there is evidence of contexts exceeding this cap.
+const int settlementHistoryItemCap = 50;
+
+/// Family argument tuple that scopes a single settlement-history query.
+///
+/// The `(contextType, contextId)` pair fully scopes the underlying
+/// `SettlementRepository.watchByContext` read. `currentUserUid`,
+/// `otherUserUid`, and `otherDisplayName` are NOT part of the family
+/// key — they are presentation-only and threaded through the screen
+/// constructor, so two screens viewing the same context share one
+/// subscription.
+@immutable
+class SettlementHistoryArgs {
+  /// Creates a [SettlementHistoryArgs].
+  const SettlementHistoryArgs({
+    required this.contextType,
+    required this.contextId,
+  });
+
+  /// One of `'friendship'` or `'group'`.
+  final String contextType;
+
+  /// The friendship or group document ID this history is scoped to.
+  final String contextId;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SettlementHistoryArgs &&
+        other.contextType == contextType &&
+        other.contextId == contextId;
+  }
+
+  @override
+  int get hashCode => Object.hash(contextType, contextId);
+}
+
+/// Family-keyed stream of the most recent settlements for a context,
+/// ordered by `date` descending (FR-SE-08 / SCR-24).
+///
+/// Reuses the PR #42 read path `SettlementRepository.watchByContext`
+/// verbatim (soft-deleted entries are already excluded at the
+/// repository layer) and applies the [settlementHistoryItemCap] over
+/// the projected list. No `dependencies:` override is needed: the
+/// repository is a root-scope provider with no per-arm override.
+///
+/// **Invariant 2 (`simplifiedBalances` server-maintained).** This
+/// provider reads only top-level `settlements/{id}` documents; it never
+/// references `simplifiedBalances`.
+final settlementHistoryProvider =
+    StreamProvider.family<List<SettlementDoc>, SettlementHistoryArgs>((
+      ref,
+      args,
+    ) {
+      final repository = ref.watch(settlementRepositoryProvider);
+      return repository
+          .watchByContext(
+            contextType: args.contextType,
+            contextId: args.contextId,
+          )
+          .map(
+            (settlements) => settlements
+                .take(settlementHistoryItemCap)
+                .toList(growable: false),
+          );
+    });

--- a/lib/features/settlements/application/settlement_history_telemetry.dart
+++ b/lib/features/settlements/application/settlement_history_telemetry.dart
@@ -1,0 +1,52 @@
+/// Telemetry event-name and parameter-key constants for the settlement
+/// history screen (SCR-24).
+///
+/// Both events are pre-declared in
+/// `docs/design/07-technical/telemetry-plan.md` §1.3. NEITHER event
+/// carries a `context_id` parameter: for the friendship axis the
+/// `contextId` is a UID-composite (`{uidA}_{uidB}`) that must not be
+/// emitted raw per ADR-0013. `context_type` is a safe non-identifying
+/// enum token, `item_count` is a non-PII integer, and `error_code` is a
+/// safe Firebase error-code enum — so no hashing is required here.
+///
+/// Reference: `docs/design/06-screen-specs/23-28-settle-activity-profile.md`
+/// §SCR-24.
+abstract final class SettlementHistoryTelemetry {
+  // ---------------------------------------------------------------
+  // Event names.
+  // ---------------------------------------------------------------
+
+  /// Settlement history screen loaded with resolved data (fires exactly
+  /// once on the first `AsyncData` frame). Payload: `context_type`,
+  /// `item_count`.
+  static const String viewedEvent = 'settlement_history_viewed';
+
+  /// Settlement history data fetch failed (fires exactly once on the
+  /// first `AsyncError` frame). Payload: `error_code`, `context_type`.
+  static const String errorEvent = 'settlement_history_error';
+
+  // ---------------------------------------------------------------
+  // Parameter-key constants.
+  // ---------------------------------------------------------------
+
+  /// `'friendship'` for the friendship axis; `'group'` for the Sprint 3
+  /// group axis.
+  static const String paramContextType = 'context_type';
+
+  /// Number of settlement rows rendered (post 50-item cap).
+  static const String paramItemCount = 'item_count';
+
+  /// Mapped error code (`'permission-denied'` / `'unavailable'` / the
+  /// raw `FirebaseException.code` / `'unknown'`).
+  static const String paramErrorCode = 'error_code';
+
+  // ---------------------------------------------------------------
+  // Context-type enum tokens.
+  // ---------------------------------------------------------------
+
+  /// Friendship-axis context-type token.
+  static const String contextTypeFriendship = 'friendship';
+
+  /// Group-axis context-type token (Sprint 3 Groups epic).
+  static const String contextTypeGroup = 'group';
+}

--- a/lib/features/settlements/presentation/settlement_history_screen.dart
+++ b/lib/features/settlements/presentation/settlement_history_screen.dart
@@ -1,0 +1,425 @@
+import 'dart:async';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:onebytwo/core/formatters/inr_formatter.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/settlements/application/settlement_history_provider.dart';
+import 'package:onebytwo/features/settlements/application/settlement_history_telemetry.dart';
+import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
+
+/// Settlement History screen (SCR-24 / FR-SE-08).
+///
+/// Renders a reverse-chronological list of every settlement recorded
+/// against a single context (a friendship or — in a future Sprint —
+/// a group). The screen is generic over `(contextType, contextId)` so
+/// the Sprint 3 Group Detail surface can push it with
+/// `contextType: 'group'`; only the friendship arm is wired today.
+///
+/// State contract (per SCR-24 §States):
+/// - Loading: a centred `CircularProgressIndicator`.
+/// - Populated: a `ListView` of settlement rows ordered by `date`
+///   descending (the repository stream guarantees the order; no
+///   client-side sort).
+/// - Empty: "No settlements yet" placeholder, no CTA.
+/// - Error: "Something went wrong" placeholder with a Retry button.
+///
+/// Telemetry (both events pre-declared in `telemetry-plan.md` §1.3):
+/// - `settlement_history_viewed { context_type, item_count }` fires
+///   exactly once on the first resolved frame.
+/// - `settlement_history_error { error_code, context_type }` fires
+///   exactly once on the first error frame.
+///
+/// PII guard (ADR-0013): neither event carries `context_id` — for the
+/// friendship axis the `contextId` is a UID-composite that must not be
+/// emitted raw.
+///
+/// Invariant compliance:
+/// - **Invariant 1 (paise)**: the per-row amount flows through
+///   `formatInrFromPaise()`; no inline arithmetic.
+/// - **Invariant 2 (`simplifiedBalances` read-only)**: this screen reads
+///   only top-level `settlements/{id}` documents and never references
+///   `simplifiedBalances`.
+class SettlementHistoryScreen extends ConsumerStatefulWidget {
+  /// Creates a [SettlementHistoryScreen].
+  const SettlementHistoryScreen({
+    required this.contextType,
+    required this.contextId,
+    required this.currentUserUid,
+    required this.otherUserUid,
+    required this.otherDisplayName,
+    super.key,
+  });
+
+  /// One of `'friendship'` or `'group'`.
+  final String contextType;
+
+  /// The friendship or group document ID this history is scoped to.
+  final String contextId;
+
+  /// Authenticated user UID — used to label the payer/payee avatars.
+  final String currentUserUid;
+
+  /// The other party UID.
+  final String otherUserUid;
+
+  /// The other party display name — interpolated into the row labels.
+  final String otherDisplayName;
+
+  @override
+  ConsumerState<SettlementHistoryScreen> createState() =>
+      _SettlementHistoryScreenState();
+}
+
+class _SettlementHistoryScreenState
+    extends ConsumerState<SettlementHistoryScreen> {
+  bool _loggedView = false;
+  bool _loggedError = false;
+
+  SettlementHistoryArgs get _args => SettlementHistoryArgs(
+    contextType: widget.contextType,
+    contextId: widget.contextId,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final settlementsAsync = ref.watch(settlementHistoryProvider(_args));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Semantics(header: true, child: const Text('Settlement History')),
+      ),
+      body: settlementsAsync.when(
+        loading: () => const _SettlementHistoryLoadingState(),
+        error: (error, _) {
+          _logErrorOnce(error);
+          return _SettlementHistoryErrorState(
+            onRetry: () => ref.invalidate(settlementHistoryProvider(_args)),
+          );
+        },
+        data: (settlements) {
+          _logViewedOnce(settlements.length);
+          if (settlements.isEmpty) {
+            return const _SettlementHistoryEmptyState();
+          }
+          return _SettlementHistoryList(
+            settlements: settlements,
+            currentUserUid: widget.currentUserUid,
+            otherDisplayName: widget.otherDisplayName,
+          );
+        },
+      ),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Telemetry helpers
+  // -------------------------------------------------------------------------
+
+  void _logViewedOnce(int itemCount) {
+    if (_loggedView) return;
+    _loggedView = true;
+    unawaited(
+      ref
+          .read(analyticsServiceProvider)
+          .logEvent(
+            name: SettlementHistoryTelemetry.viewedEvent,
+            parameters: <String, Object>{
+              SettlementHistoryTelemetry.paramContextType: widget.contextType,
+              SettlementHistoryTelemetry.paramItemCount: itemCount,
+            },
+          ),
+    );
+  }
+
+  void _logErrorOnce(Object error) {
+    if (_loggedError) return;
+    _loggedError = true;
+    unawaited(
+      ref
+          .read(analyticsServiceProvider)
+          .logEvent(
+            name: SettlementHistoryTelemetry.errorEvent,
+            parameters: <String, Object>{
+              SettlementHistoryTelemetry.paramErrorCode: _errorCode(error),
+              SettlementHistoryTelemetry.paramContextType: widget.contextType,
+            },
+          ),
+    );
+  }
+
+  /// Maps a stream error to a safe, non-PII `error_code` token per
+  /// Architect Notes §2.8: the raw `FirebaseException.code`
+  /// (`'permission-denied'` / `'unavailable'` / other) or `'unknown'`
+  /// for any non-Firebase error.
+  String _errorCode(Object error) {
+    if (error is FirebaseException) {
+      return error.code;
+    }
+    return 'unknown';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Populated list + row
+// ---------------------------------------------------------------------------
+
+class _SettlementHistoryList extends StatelessWidget {
+  const _SettlementHistoryList({
+    required this.settlements,
+    required this.currentUserUid,
+    required this.otherDisplayName,
+  });
+
+  final List<SettlementDoc> settlements;
+  final String currentUserUid;
+  final String otherDisplayName;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: settlements.length,
+      itemBuilder: (context, index) {
+        final settlement = settlements[index];
+        return _SettlementHistoryRow(
+          key: ValueKey<String>(
+            'settlement_history_row_${settlement.settlementId}',
+          ),
+          settlement: settlement,
+          currentUserUid: currentUserUid,
+          otherDisplayName: otherDisplayName,
+        );
+      },
+    );
+  }
+}
+
+class _SettlementHistoryRow extends StatelessWidget {
+  const _SettlementHistoryRow({
+    required this.settlement,
+    required this.currentUserUid,
+    required this.otherDisplayName,
+    super.key,
+  });
+
+  final SettlementDoc settlement;
+  final String currentUserUid;
+  final String otherDisplayName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateText = DateFormat('dd MMM yyyy').format(settlement.date);
+    final amountText = formatInrFromPaise(settlement.amountPaise);
+
+    final payerLabel = settlement.fromUserId == currentUserUid
+        ? 'You'
+        : otherDisplayName;
+    final payeeLabel = settlement.toUserId == currentUserUid
+        ? 'You'
+        : otherDisplayName;
+
+    return Semantics(
+      container: true,
+      label: _semanticLabel(
+        payerLabel: payerLabel,
+        payeeLabel: payeeLabel,
+        amountText: amountText,
+        dateText: dateText,
+      ),
+      child: ExcludeSemantics(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 64),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  dateText,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    _InitialAvatar(label: payerLabel),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Icon(
+                        Icons.arrow_forward,
+                        size: 20,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    _InitialAvatar(label: payeeLabel),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            amountText,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: theme.colorScheme.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          if (settlement.note != null) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              settlement.note!,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Builds the screen-reader label per SCR-24 §Accessibility:
+  /// `<payer> paid <payee> rupees <amount> on <date>. Note: <note or
+  /// no note>.` The spoken amount strips the leading currency symbol
+  /// so the screen reader announces "rupees 800.00" rather than the
+  /// glyph.
+  String _semanticLabel({
+    required String payerLabel,
+    required String payeeLabel,
+    required String amountText,
+    required String dateText,
+  }) {
+    final spokenAmount = amountText.replaceAll('₹', '');
+    final noteClause = settlement.note ?? 'no note';
+    return '$payerLabel paid $payeeLabel rupees $spokenAmount on '
+        '$dateText. Note: $noteClause.';
+  }
+}
+
+class _InitialAvatar extends StatelessWidget {
+  const _InitialAvatar({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return CircleAvatar(
+      radius: 16,
+      backgroundColor: theme.colorScheme.surfaceContainerHighest,
+      child: Text(_initial(label), style: theme.textTheme.labelMedium),
+    );
+  }
+
+  static String _initial(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return '?';
+    return trimmed.substring(0, 1).toUpperCase();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inline state widgets (per Architect Notes §2.3 — no OBT* primitive
+// extraction; mirrors the friend_detail_states.dart precedent).
+// ---------------------------------------------------------------------------
+
+class _SettlementHistoryLoadingState extends StatelessWidget {
+  const _SettlementHistoryLoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+class _SettlementHistoryEmptyState extends StatelessWidget {
+  const _SettlementHistoryEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ExcludeSemantics(
+              child: Icon(
+                Icons.history,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No settlements yet',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Once you settle up, it will appear here.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettlementHistoryErrorState extends StatelessWidget {
+  const _SettlementHistoryErrorState({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: theme.colorScheme.error),
+            const SizedBox(height: 16),
+            Text(
+              'Something went wrong',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'We could not load settlement history. Please try again.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/friends/friend_detail_screen_widget_test.dart
+++ b/test/features/friends/friend_detail_screen_widget_test.dart
@@ -36,6 +36,7 @@ import 'package:onebytwo/features/settlements/application/settle_up_telemetry.da
 import 'package:onebytwo/features/settlements/data/settlement_repository.dart';
 import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
 import 'package:onebytwo/features/settlements/presentation/settle_up_bottom_sheet.dart';
+import 'package:onebytwo/features/settlements/presentation/settlement_history_screen.dart';
 
 import '../expenses/helpers/fake_services.dart';
 
@@ -944,6 +945,64 @@ void main() {
         find.byType(OBTFloatingActionButton),
       );
       expect(fab.heroTag, 'friendDetailFab');
+    });
+  });
+
+  group('View Settlement History link (FR-SE-08 AC-16/17/18)', () {
+    final populated = FriendDetailStatePopulated(
+      header: _header(),
+      timeline: [
+        TimelineSettlement(
+          doc: _settlement(id: 'sid-1', date: DateTime(2026, 6, 3)),
+        ),
+      ],
+    );
+
+    testWidgets('AC-16 link is visible in the Populated state', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(initialValue: AsyncData(populated), analytics: analytics),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('View Settlement History'), findsOneWidget);
+    });
+
+    testWidgets('AC-17 link is hidden in the Empty state', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          initialValue: AsyncData(FriendDetailStateEmpty(header: _header())),
+          analytics: analytics,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('View Settlement History'), findsNothing);
+    });
+
+    testWidgets('AC-18 tapping the link pushes SettlementHistoryScreen with '
+        'the correct args', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          initialValue: AsyncData(populated),
+          analytics: analytics,
+          settlementRepository: FakeSettlementRepository(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('View Settlement History'));
+      await tester.tap(find.text('View Settlement History'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      final screen = tester.widget<SettlementHistoryScreen>(
+        find.byType(SettlementHistoryScreen),
+      );
+      expect(screen.contextType, 'friendship');
+      expect(screen.contextId, 'uid-friend_uid-me');
+      expect(screen.currentUserUid, 'uid-me');
+      expect(screen.otherUserUid, 'uid-friend');
+      expect(screen.otherDisplayName, 'Bina');
     });
   });
 }

--- a/test/features/settlements/settlement_history_pii_leak_test.dart
+++ b/test/features/settlements/settlement_history_pii_leak_test.dart
@@ -1,0 +1,134 @@
+// Settlement history PII-leak + boundary-contract tests (FR-SE-08).
+//
+// Grep-based defence-in-depth over the three NEW source files, mirroring
+// the settle_up_boundary_contract pattern. Locks the invariant triad:
+//
+//   Inv-1 (paise integers): no `double` decls, no `.toDouble()`, no
+//          `.toFixed`, no `parseFloat`, no inline `/ 100` paise math.
+//   Inv-2 (simplifiedBalances client-read-only): the field is never
+//          referenced on this read-only surface.
+//   PII (ADR-0013): neither telemetry event carries a UID-derived
+//          parameter — the source contains no `'context_id'`,
+//          `'friendship_id'`, `'friendship_id_hash'`, `'uid'`, or
+//          `'userId'` string-literal parameter keys. (Variable names
+//          such as `currentUserUid` are deliberately NOT matched — only
+//          quoted parameter-key literals are forbidden.)
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const sourceFiles = [
+    'lib/features/settlements/application/settlement_history_telemetry.dart',
+    'lib/features/settlements/application/settlement_history_provider.dart',
+    'lib/features/settlements/presentation/settlement_history_screen.dart',
+  ];
+
+  group('Inv-1 (paise integers): no inline paise→rupee math', () {
+    for (final path in sourceFiles) {
+      test('$path contains no double / toDouble / toFixed / `/ 100`', () {
+        final lines = _sourceLines(path);
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          expect(
+            line.contains(' double ') || line.contains('(double '),
+            isFalse,
+            reason: 'Forbidden `double` declaration in $path:${i + 1}',
+          );
+          expect(
+            line.contains('.toDouble()'),
+            isFalse,
+            reason: 'Forbidden `.toDouble()` call in $path:${i + 1}',
+          );
+          expect(
+            line.contains('.toFixed'),
+            isFalse,
+            reason: 'Forbidden `.toFixed` call in $path:${i + 1}',
+          );
+          expect(
+            line.contains('parseFloat'),
+            isFalse,
+            reason: 'Forbidden `parseFloat` call in $path:${i + 1}',
+          );
+          expect(
+            line.contains(RegExp(r'/\s*100\b')) && !line.contains('~/'),
+            isFalse,
+            reason:
+                'Forbidden `/ 100` paise division in $path:${i + 1}; '
+                'use the shared formatInrFromPaise() instead',
+          );
+        }
+      });
+    }
+  });
+
+  group('Inv-2 (simplifiedBalances client-read-only)', () {
+    for (final path in sourceFiles) {
+      test('$path never references simplifiedBalances', () {
+        final lines = _sourceLines(path);
+        for (var i = 0; i < lines.length; i++) {
+          expect(
+            lines[i].contains('simplifiedBalances'),
+            isFalse,
+            reason:
+                'Forbidden simplifiedBalances reference in $path:${i + 1}; '
+                'this field is server-maintained (Invariant 2)',
+          );
+        }
+      });
+    }
+  });
+
+  group('PII (ADR-0013): no UID-derived telemetry parameter-key literals', () {
+    const forbiddenLiterals = <String>[
+      "'context_id'",
+      '"context_id"',
+      "'friendship_id'",
+      '"friendship_id"',
+      "'friendship_id_hash'",
+      '"friendship_id_hash"',
+      "'uid'",
+      '"uid"',
+      "'userId'",
+      '"userId"',
+    ];
+
+    for (final path in sourceFiles) {
+      test('$path contains no forbidden parameter-key literal', () {
+        final lines = _sourceLines(path);
+        for (var i = 0; i < lines.length; i++) {
+          for (final literal in forbiddenLiterals) {
+            expect(
+              lines[i].contains(literal),
+              isFalse,
+              reason:
+                  'Forbidden PII parameter-key literal $literal in '
+                  '$path:${i + 1}',
+            );
+          }
+        }
+      });
+    }
+  });
+}
+
+/// Reads a source file's non-comment lines. Fails the test if the file
+/// does not exist (the boundary contract must guard a real file).
+List<String> _sourceLines(String path) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    fail('Expected source file $path to exist for boundary grep');
+  }
+  return file
+      .readAsLinesSync()
+      .where((line) => !_isCommentLine(line))
+      .toList(growable: false);
+}
+
+bool _isCommentLine(String raw) {
+  final trimmed = raw.trim();
+  return trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*');
+}

--- a/test/features/settlements/settlement_history_provider_test.dart
+++ b/test/features/settlements/settlement_history_provider_test.dart
@@ -1,0 +1,182 @@
+// Settlement history provider tests (FR-SE-08 / SCR-24).
+//
+// Verifies that settlementHistoryProvider:
+//   - resolves to the repository's watchByContext stream;
+//   - applies the 50-item cap over the upstream list;
+//   - threads the (contextType, contextId) family key to the repo;
+//   - has a value-equality family-key contract on SettlementHistoryArgs;
+//   - drops its subscription on invalidation (re-subscribes on next read).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/settlements/application/settlement_history_provider.dart';
+import 'package:onebytwo/features/settlements/data/settlement_repository.dart';
+import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
+
+SettlementDoc _settlement(int index) {
+  return SettlementDoc(
+    settlementId: 'sid-$index',
+    fromUserId: 'uid-me',
+    toUserId: 'uid-friend',
+    amountPaise: 1000 + index,
+    contextType: 'friendship',
+    contextId: 'uid-friend_uid-me',
+    date: DateTime(2025).add(Duration(days: index)),
+    note: null,
+    method: 'manual',
+    verificationStatus: 'unverified',
+    currency: 'INR',
+    createdAt: DateTime(2025).add(Duration(days: index)),
+    deleted: false,
+  );
+}
+
+class FakeSettlementRepository implements SettlementRepository {
+  FakeSettlementRepository(this._factory);
+
+  final Stream<List<SettlementDoc>> Function() _factory;
+
+  int watchCallCount = 0;
+  String? lastContextType;
+  String? lastContextId;
+
+  @override
+  Stream<List<SettlementDoc>> watchByContext({
+    required String contextType,
+    required String contextId,
+  }) {
+    watchCallCount += 1;
+    lastContextType = contextType;
+    lastContextId = contextId;
+    return _factory();
+  }
+
+  @override
+  Future<String> createSettlement({required SettlementDoc doc}) async {
+    throw UnimplementedError('history provider never writes');
+  }
+}
+
+void main() {
+  const args = SettlementHistoryArgs(
+    contextType: 'friendship',
+    contextId: 'uid-friend_uid-me',
+  );
+
+  group('SettlementHistoryArgs family-key contract', () {
+    test('equal args are == and share a hashCode', () {
+      const a = SettlementHistoryArgs(
+        contextType: 'friendship',
+        contextId: 'uid-friend_uid-me',
+      );
+      const b = SettlementHistoryArgs(
+        contextType: 'friendship',
+        contextId: 'uid-friend_uid-me',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differing contextId or contextType breaks equality', () {
+      const base = SettlementHistoryArgs(
+        contextType: 'friendship',
+        contextId: 'uid-friend_uid-me',
+      );
+      expect(
+        base,
+        isNot(
+          equals(
+            const SettlementHistoryArgs(
+              contextType: 'friendship',
+              contextId: 'other-id',
+            ),
+          ),
+        ),
+      );
+      expect(
+        base,
+        isNot(
+          equals(
+            const SettlementHistoryArgs(
+              contextType: 'group',
+              contextId: 'uid-friend_uid-me',
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('settlementHistoryProvider', () {
+    test('resolves to the repository watchByContext stream', () async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([_settlement(0), _settlement(1)]),
+      );
+      final container = ProviderContainer(
+        overrides: [settlementRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        settlementHistoryProvider(args).future,
+      );
+
+      expect(result, hasLength(2));
+      expect(repo.lastContextType, 'friendship');
+      expect(repo.lastContextId, 'uid-friend_uid-me');
+    });
+
+    test('applies the 50-item cap over a 76-item upstream list', () async {
+      final upstream = List.generate(76, _settlement);
+      final repo = FakeSettlementRepository(() => Stream.value(upstream));
+      final container = ProviderContainer(
+        overrides: [settlementRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        settlementHistoryProvider(args).future,
+      );
+
+      expect(result, hasLength(settlementHistoryItemCap));
+      expect(result, hasLength(50));
+      // The cap keeps the FIRST 50 (the repository already orders
+      // date-desc, so these are the most recent).
+      expect(result.first.settlementId, 'sid-0');
+      expect(result.last.settlementId, 'sid-49');
+    });
+
+    test('a sub-cap list passes through unchanged', () async {
+      final upstream = List.generate(3, _settlement);
+      final repo = FakeSettlementRepository(() => Stream.value(upstream));
+      final container = ProviderContainer(
+        overrides: [settlementRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        settlementHistoryProvider(args).future,
+      );
+
+      expect(result, hasLength(3));
+    });
+
+    test('invalidation re-subscribes to the repository', () async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([_settlement(0)]),
+      );
+      final container = ProviderContainer(
+        overrides: [settlementRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(settlementHistoryProvider(args).future);
+      expect(repo.watchCallCount, 1);
+
+      container.invalidate(settlementHistoryProvider(args));
+      await container.read(settlementHistoryProvider(args).future);
+
+      expect(repo.watchCallCount, 2);
+    });
+  });
+}

--- a/test/features/settlements/settlement_history_screen_test.dart
+++ b/test/features/settlements/settlement_history_screen_test.dart
@@ -1,0 +1,577 @@
+// Settlement History screen widget tests (FR-SE-08 / SCR-24).
+//
+// Verifies the SCR-24 four-state rendering (loading / populated / empty
+// / error), the settlement-row layout contract (date / amount / note /
+// avatars / row height), the accessibility labels, the 50-item cap, and
+// the settlement_history_viewed / settlement_history_error single-fire
+// telemetry discipline (both events pre-declared in telemetry-plan §1.3).
+//
+// Tests are written BEFORE the implementation and will fail to compile
+// until the production code lands.
+
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/formatters/inr_formatter.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/settlements/application/settlement_history_telemetry.dart';
+import 'package:onebytwo/features/settlements/data/settlement_repository.dart';
+import 'package:onebytwo/features/settlements/domain/settlement_doc.dart';
+import 'package:onebytwo/features/settlements/presentation/settlement_history_screen.dart';
+
+class FakeAnalyticsService implements AnalyticsService {
+  final List<({String name, Map<String, Object>? parameters})> loggedEvents =
+      [];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object>? parameters,
+  }) async {
+    loggedEvents.add((name: name, parameters: parameters));
+  }
+
+  int countOf(String name) => loggedEvents.where((e) => e.name == name).length;
+
+  Map<String, Object>? lastParamsFor(String name) =>
+      loggedEvents.lastWhere((e) => e.name == name).parameters;
+}
+
+class FakeSettlementRepository implements SettlementRepository {
+  FakeSettlementRepository(this._factory);
+
+  final Stream<List<SettlementDoc>> Function() _factory;
+  int watchCallCount = 0;
+
+  @override
+  Stream<List<SettlementDoc>> watchByContext({
+    required String contextType,
+    required String contextId,
+  }) {
+    watchCallCount += 1;
+    return _factory();
+  }
+
+  @override
+  Future<String> createSettlement({required SettlementDoc doc}) async {
+    throw UnimplementedError('history screen never writes');
+  }
+}
+
+SettlementDoc _settlement({
+  required String id,
+  required DateTime date,
+  int amountPaise = 5000,
+  String fromUserId = 'uid-me',
+  String toUserId = 'uid-friend',
+  String? note,
+}) {
+  return SettlementDoc(
+    settlementId: id,
+    fromUserId: fromUserId,
+    toUserId: toUserId,
+    amountPaise: amountPaise,
+    contextType: 'friendship',
+    contextId: 'uid-friend_uid-me',
+    date: date,
+    note: note,
+    method: 'manual',
+    verificationStatus: 'unverified',
+    currency: 'INR',
+    createdAt: date,
+    deleted: false,
+  );
+}
+
+Widget _buildSubject({
+  required FakeSettlementRepository repo,
+  required FakeAnalyticsService analytics,
+  String otherDisplayName = 'Priya',
+}) {
+  return ProviderScope(
+    overrides: [
+      settlementRepositoryProvider.overrideWithValue(repo),
+      analyticsServiceProvider.overrideWithValue(analytics),
+    ],
+    child: MaterialApp(
+      home: SettlementHistoryScreen(
+        contextType: 'friendship',
+        contextId: 'uid-friend_uid-me',
+        currentUserUid: 'uid-me',
+        otherUserUid: 'uid-friend',
+        otherDisplayName: otherDisplayName,
+      ),
+    ),
+  );
+}
+
+Finder _rowFinder() => find.byWidgetPredicate(
+  (w) =>
+      w.key is ValueKey<String> &&
+      (w.key! as ValueKey<String>).value.startsWith('settlement_history_row_'),
+);
+
+void main() {
+  late FakeAnalyticsService analytics;
+
+  setUp(() {
+    analytics = FakeAnalyticsService();
+  });
+
+  group('Loading state (AC-3)', () {
+    testWidgets('renders a centred CircularProgressIndicator', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream<List<SettlementDoc>>.fromFuture(
+          Completer<List<SettlementDoc>>().future,
+        ),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('does NOT fire settlement_history_viewed while loading', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () => Stream<List<SettlementDoc>>.fromFuture(
+          Completer<List<SettlementDoc>>().future,
+        ),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pump();
+
+      expect(analytics.countOf(SettlementHistoryTelemetry.viewedEvent), 0);
+    });
+  });
+
+  group('Populated state (AC-1)', () {
+    List<SettlementDoc> threeDateDesc() => [
+      _settlement(id: 's-1', date: DateTime(2025, 3, 25)),
+      _settlement(id: 's-2', date: DateTime(2025, 3, 18)),
+      _settlement(id: 's-3', date: DateTime(2025, 2, 2)),
+    ];
+
+    testWidgets('renders all settlements as rows', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value(threeDateDesc()),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(_rowFinder(), findsNWidgets(3));
+    });
+
+    testWidgets('renders rows in date-descending order', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value(threeDateDesc()),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      final y25 = tester.getTopLeft(find.text('25 Mar 2025')).dy;
+      final y18 = tester.getTopLeft(find.text('18 Mar 2025')).dy;
+      final y02 = tester.getTopLeft(find.text('02 Feb 2025')).dy;
+      expect(y25, lessThan(y18));
+      expect(y18, lessThan(y02));
+    });
+  });
+
+  group('Empty state (AC-2)', () {
+    testWidgets('renders the canonical empty placeholder and NO Retry', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value(const <SettlementDoc>[]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No settlements yet'), findsOneWidget);
+      expect(
+        find.text('Once you settle up, it will appear here.'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.history), findsOneWidget);
+      expect(find.text('Retry'), findsNothing);
+      expect(find.byType(FilledButton), findsNothing);
+    });
+  });
+
+  group('Error state (AC-4)', () {
+    Stream<List<SettlementDoc>> errorStream() =>
+        Stream<List<SettlementDoc>>.error(
+          FirebaseException(plugin: 'cloud_firestore', code: 'unavailable'),
+        );
+
+    testWidgets('renders the canonical error placeholder with Retry', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(errorStream);
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(
+        find.text('We could not load settlement history. Please try again.'),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(FilledButton, 'Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping Retry re-subscribes to the provider', (tester) async {
+      final repo = FakeSettlementRepository(errorStream);
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+      expect(repo.watchCallCount, 1);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Retry'));
+      await tester.pumpAndSettle();
+
+      expect(repo.watchCallCount, 2);
+    });
+  });
+
+  group('50-item cap (AC-5)', () {
+    testWidgets('a 76-item stream renders 50 rows and logs item_count 50', (
+      tester,
+    ) async {
+      final upstream = List.generate(
+        76,
+        (i) => _settlement(
+          id: 's-$i',
+          date: DateTime(2025).add(Duration(days: i)),
+        ),
+      );
+      final repo = FakeSettlementRepository(() => Stream.value(upstream));
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      final listView = tester.widget<ListView>(find.byType(ListView));
+      final delegate = listView.childrenDelegate as SliverChildBuilderDelegate;
+      expect(delegate.childCount, 50);
+
+      expect(
+        analytics.lastParamsFor(
+          SettlementHistoryTelemetry.viewedEvent,
+        )?[SettlementHistoryTelemetry.paramItemCount],
+        50,
+      );
+    });
+  });
+
+  group('Settlement-row layout (AC-6 / AC-7 / AC-8 / AC-9 / AC-10)', () {
+    testWidgets('AC-6 date renders as dd MMM yyyy', (tester) async {
+      final repo = FakeSettlementRepository(
+        () =>
+            Stream.value([_settlement(id: 's-1', date: DateTime(2025, 3, 25))]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(find.text('25 Mar 2025'), findsOneWidget);
+    });
+
+    testWidgets('AC-7 amount renders via formatInrFromPaise', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([
+          _settlement(
+            id: 's-1',
+            date: DateTime(2025, 3, 25),
+            amountPaise: 80000,
+          ),
+        ]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(find.text(formatInrFromPaise(80000)), findsOneWidget);
+      expect(find.text('₹800.00'), findsOneWidget);
+    });
+
+    testWidgets('AC-8 note is visible when non-null', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([
+          _settlement(
+            id: 's-1',
+            date: DateTime(2025, 3, 25),
+            note: 'GPay transfer',
+          ),
+        ]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(find.text('GPay transfer'), findsOneWidget);
+    });
+
+    testWidgets('AC-8 note widget is absent when null', (tester) async {
+      final repo = FakeSettlementRepository(
+        () =>
+            Stream.value([_settlement(id: 's-1', date: DateTime(2025, 3, 25))]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      // The only text nodes are the date and the amount; no note line.
+      expect(find.text('GPay transfer'), findsNothing);
+    });
+
+    testWidgets('AC-9 two avatars with payer/payee initials + an arrow', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () =>
+            Stream.value([_settlement(id: 's-1', date: DateTime(2025, 3, 25))]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CircleAvatar), findsNWidgets(2));
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      // Payer is the current user ("You" -> "Y"); payee is the friend
+      // ("Priya" -> "P").
+      expect(find.text('Y'), findsOneWidget);
+      expect(find.text('P'), findsOneWidget);
+    });
+
+    testWidgets('AC-10 row height is at least 64 dp', (tester) async {
+      final repo = FakeSettlementRepository(
+        () =>
+            Stream.value([_settlement(id: 's-1', date: DateTime(2025, 3, 25))]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(tester.getSize(_rowFinder()).height, greaterThanOrEqualTo(64));
+    });
+  });
+
+  group('Accessibility (AC-11 / AC-12)', () {
+    testWidgets('AC-11 screen title is a semantic header', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value(const <SettlementDoc>[]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.ancestor(
+          of: find.text('Settlement History'),
+          matching: find.byWidgetPredicate(
+            (w) => w is Semantics && (w.properties.header ?? false),
+          ),
+        ),
+        findsAtLeastNWidgets(1),
+      );
+    });
+
+    testWidgets('AC-12 settlement-row semantic label (with note)', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([
+          _settlement(
+            id: 's-1',
+            date: DateTime(2025, 3, 25),
+            amountPaise: 80000,
+            note: 'GPay transfer',
+          ),
+        ]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.bySemanticsLabel(
+          'You paid Priya rupees 800.00 on 25 Mar 2025. Note: GPay transfer.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('AC-12 settlement-row semantic label (no note)', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([
+          _settlement(
+            id: 's-1',
+            date: DateTime(2025, 3, 25),
+            amountPaise: 80000,
+          ),
+        ]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.bySemanticsLabel(
+          'You paid Priya rupees 800.00 on 25 Mar 2025. Note: no note.',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('Telemetry (AC-13 / AC-14)', () {
+    testWidgets('AC-13 settlement_history_viewed fires once with params', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () => Stream.value([
+          _settlement(id: 's-1', date: DateTime(2025, 3, 25)),
+          _settlement(id: 's-2', date: DateTime(2025, 3, 18)),
+          _settlement(id: 's-3', date: DateTime(2025, 2, 2)),
+        ]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(analytics.countOf(SettlementHistoryTelemetry.viewedEvent), 1);
+      final params = analytics.lastParamsFor(
+        SettlementHistoryTelemetry.viewedEvent,
+      );
+      expect(
+        params?[SettlementHistoryTelemetry.paramContextType],
+        'friendship',
+      );
+      expect(params?[SettlementHistoryTelemetry.paramItemCount], 3);
+    });
+
+    testWidgets('AC-13 does NOT re-fire on a subsequent stream emission', (
+      tester,
+    ) async {
+      final controller = StreamController<List<SettlementDoc>>();
+      addTearDown(controller.close);
+      final repo = FakeSettlementRepository(() => controller.stream);
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+
+      controller.add([_settlement(id: 's-1', date: DateTime(2025, 3, 25))]);
+      await tester.pump();
+      controller.add([
+        _settlement(id: 's-1', date: DateTime(2025, 3, 25)),
+        _settlement(id: 's-2', date: DateTime(2025, 3, 18)),
+      ]);
+      await tester.pump();
+
+      expect(analytics.countOf(SettlementHistoryTelemetry.viewedEvent), 1);
+    });
+
+    testWidgets('AC-14 settlement_history_error fires on AsyncError', (
+      tester,
+    ) async {
+      final repo = FakeSettlementRepository(
+        () => Stream<List<SettlementDoc>>.error(
+          FirebaseException(
+            plugin: 'cloud_firestore',
+            code: 'permission-denied',
+          ),
+        ),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(analytics.countOf(SettlementHistoryTelemetry.errorEvent), 1);
+      final params = analytics.lastParamsFor(
+        SettlementHistoryTelemetry.errorEvent,
+      );
+      expect(
+        params?[SettlementHistoryTelemetry.paramErrorCode],
+        'permission-denied',
+      );
+      expect(
+        params?[SettlementHistoryTelemetry.paramContextType],
+        'friendship',
+      );
+    });
+
+    testWidgets('AC-14 non-Firebase error maps to unknown', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream<List<SettlementDoc>>.error(Exception('boom')),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      expect(
+        analytics.lastParamsFor(
+          SettlementHistoryTelemetry.errorEvent,
+        )?[SettlementHistoryTelemetry.paramErrorCode],
+        'unknown',
+      );
+    });
+  });
+
+  group('Telemetry PII guard (AC-15)', () {
+    const forbiddenKeys = <String>[
+      'context_id',
+      'friendship_id',
+      'friendship_id_hash',
+      'userId',
+      'uid',
+    ];
+    const piiValues = <String>[
+      'uid-friend_uid-me',
+      'uid-me',
+      'uid-friend',
+      'Priya',
+    ];
+
+    testWidgets('viewed event carries no PII key or value', (tester) async {
+      final repo = FakeSettlementRepository(
+        () =>
+            Stream.value([_settlement(id: 's-1', date: DateTime(2025, 3, 25))]),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      for (final event in analytics.loggedEvents) {
+        final params = event.parameters ?? const <String, Object>{};
+        for (final key in forbiddenKeys) {
+          expect(params.containsKey(key), isFalse, reason: 'leaked key $key');
+        }
+        for (final value in params.values) {
+          for (final pii in piiValues) {
+            expect(
+              value.toString().contains(pii),
+              isFalse,
+              reason: 'leaked PII value $pii',
+            );
+          }
+        }
+      }
+    });
+
+    testWidgets('error event carries no PII key or value', (tester) async {
+      final repo = FakeSettlementRepository(
+        () => Stream<List<SettlementDoc>>.error(
+          FirebaseException(plugin: 'cloud_firestore', code: 'unavailable'),
+        ),
+      );
+      await tester.pumpWidget(_buildSubject(repo: repo, analytics: analytics));
+      await tester.pumpAndSettle();
+
+      for (final event in analytics.loggedEvents) {
+        final params = event.parameters ?? const <String, Object>{};
+        for (final key in forbiddenKeys) {
+          expect(params.containsKey(key), isFalse, reason: 'leaked key $key');
+        }
+        for (final value in params.values) {
+          for (final pii in piiValues) {
+            expect(
+              value.toString().contains(pii),
+              isFalse,
+              reason: 'leaked PII value $pii',
+            );
+          }
+        }
+      }
+    });
+  });
+}

--- a/test/features/settlements/settlement_history_telemetry_test.dart
+++ b/test/features/settlements/settlement_history_telemetry_test.dart
@@ -1,0 +1,62 @@
+// Settlement history telemetry-constant tests (FR-SE-08 / SCR-24).
+//
+// Locks the two pre-declared event names and the parameter-key /
+// enum-token constants against the telemetry-plan §1.3 contract. The
+// authoritative source is `docs/design/07-technical/telemetry-plan.md`
+// §1.3:
+//   settlement_history_viewed { context_type, item_count }
+//   settlement_history_error  { error_code, context_type }
+// NEITHER event carries context_id (PII guard, ADR-0013).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/settlements/application/settlement_history_telemetry.dart';
+
+void main() {
+  group('SettlementHistoryTelemetry — event names', () {
+    test('viewedEvent matches the telemetry-plan contract', () {
+      expect(
+        SettlementHistoryTelemetry.viewedEvent,
+        'settlement_history_viewed',
+      );
+    });
+
+    test('errorEvent matches the telemetry-plan contract', () {
+      expect(SettlementHistoryTelemetry.errorEvent, 'settlement_history_error');
+    });
+  });
+
+  group('SettlementHistoryTelemetry — parameter keys', () {
+    test('paramContextType is context_type', () {
+      expect(SettlementHistoryTelemetry.paramContextType, 'context_type');
+    });
+
+    test('paramItemCount is item_count', () {
+      expect(SettlementHistoryTelemetry.paramItemCount, 'item_count');
+    });
+
+    test('paramErrorCode is error_code', () {
+      expect(SettlementHistoryTelemetry.paramErrorCode, 'error_code');
+    });
+
+    test('there is NO context_id parameter constant (PII guard)', () {
+      // Defence-in-depth: the contract deliberately omits context_id.
+      // Assert none of the declared parameter keys is 'context_id'.
+      const declaredParamKeys = <String>[
+        SettlementHistoryTelemetry.paramContextType,
+        SettlementHistoryTelemetry.paramItemCount,
+        SettlementHistoryTelemetry.paramErrorCode,
+      ];
+      expect(declaredParamKeys, isNot(contains('context_id')));
+    });
+  });
+
+  group('SettlementHistoryTelemetry — context-type tokens', () {
+    test('contextTypeFriendship is friendship', () {
+      expect(SettlementHistoryTelemetry.contextTypeFriendship, 'friendship');
+    });
+
+    test('contextTypeGroup is group', () {
+      expect(SettlementHistoryTelemetry.contextTypeGroup, 'group');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the **FR-SE-08 P0** SRS row (SRS section 4.6) for the dedicated
settlement-history surface on the **friendship axis**. PR #42 + PR #43
shipped the in-timeline settlement rows that satisfied the v1.0
functional commitment; this PR delivers the design-spec contract — the
dedicated `/settle/history` screen (**SCR-24**).

The screen is generic over `(contextType, contextId)`, so the Sprint 3
Group Detail screen inherits the architectural seam; only the friendship
arm is wired here (group axis stubbed).

### What ships

- **`SettlementHistoryScreen`** (SCR-24) — four states (loading /
  populated / empty / error) via inline private widgets (no OBT*
  primitive extraction). Per-row layout: inline `dd MMM yyyy` date,
  payer → arrow → payee avatars, `formatInrFromPaise()` amount in the
  primary colour, optional muted note, 64 dp min row height.
- **`settlementHistoryProvider`** — a `StreamProvider.family` keyed by
  `SettlementHistoryArgs { contextType, contextId }`, reusing the PR #42
  `SettlementRepository.watchByContext` read path with a 50-item cap.
- **`settlement_history_telemetry.dart`** — the two pre-declared events
  per `docs/design/07-technical/telemetry-plan.md` §1.3 lines 193-194:
  `settlement_history_viewed { context_type, item_count }` and
  `settlement_history_error { error_code, context_type }`. NEITHER
  carries `context_id` (PII guard, ADR-0013).
- **"View Settlement History" link** on `FriendDetailScreen` — shown
  unconditionally in the populated state, hidden in the empty state.
  No entry-point telemetry; the destination's `settlement_history_viewed`
  captures the funnel arrival.

### Design + SRS references

- `docs/design/06-screen-specs/23-28-settle-activity-profile.md` §SCR-24
- `docs/design/04-wireframes/settle-up-flow.md` §4
- `docs/design/07-technical/telemetry-plan.md` §1.3 lines 193-194
- SRS 4.6 (FR-SE-08 P0), 6.3 items 6 & 7, 6.4, 5.6, 5.9, 5.10

### Invariants

All four are **N/A** on this read-only client surface:
- **Inv-1 (integer paise):** no money write paths; the per-row amount
  flows through `formatInrFromPaise(int)`. Defence-in-depth grep returns
  0 violations.
- **Inv-2 (`simplifiedBalances` server-only):** the screen reads only
  top-level `settlements/{id}` documents; never references the field.
- **Inv-3 (system share sheet):** the share/export action is deferred.
- **Inv-4 (single Firebase project):** no new Firebase SDK usage.

### Out of scope (tracked follow-ups)

Group-context push wiring (Sprint 3), cursor-based pagination beyond 50,
the OBT* primitive extractions (`OBTSkeletonLoader` / `OBTEmptyState` /
`OBTErrorState` / `OBTUserAvatar` / `OBTRupeeText`), real-time fade-in,
context-deleted snackbar + auto-back, per-month section grouping,
settlement-detail navigation, share/export action, and the
`view_all_settlements_tapped` entry-point telemetry.

### Verification

- `flutter analyze --fatal-infos` — no issues.
- `dart format --set-exit-if-changed .` — clean.
- `flutter test` — 1292 pass / 30 skipped (+49 new, zero regressions).
- Zero changes to `functions/**`, `firestore.rules`,
  `firestore.indexes.json`, `storage.rules`, `pubspec.yaml`,
  `pubspec.lock`, `ios/Podfile.lock`, or the settlements
  repository/domain layers — the Functions and Rules suites are
  unchanged.

Next PR: PR #59 — TBD per architect's call at kickoff (top candidate: FR-PR-05 Contact Support mailto flow).