### PR TITLE
ci: speed up pr pipeline via caching and coverage de-duplication

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -278,12 +278,10 @@ jobs:
 
   build-ios:
     name: Build iOS (no signing)
-    # Larger Apple-silicon runner (M2 Pro, 5 vCPU) vs the standard macos-15
-    # (M1, 3 vCPU) to speed up the Xcode compile of the ~270 Firebase pods,
-    # which is the pipeline's wall-clock bottleneck. NOTE: larger runners are
-    # billed (~$0.16/min) even on public repos, where the standard macos-15
-    # runner is free — revert to `macos-15` to eliminate that cost.
-    runs-on: macos-15-xlarge
+    # Standard (free) Apple-silicon runner. Do NOT switch to a larger runner
+    # (macos-15-large / -xlarge): those are billed even on public repos, where
+    # this standard runner is free.
+    runs-on: macos-15
     env:
       # Pinned so the version-checked guard on the activation step below can
       # detect a cache hit (flutterfire_cli restored via subosito's pub cache)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,6 +72,14 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -125,8 +133,15 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Run unit tests
-        run: npm test
+      - name: Run unit tests with coverage
+        run: npx jest --coverage --coverageReporters=json-summary --coverageReporters=text --forceExit
+
+      - name: Upload Functions coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: functions-coverage
+          path: functions/coverage/
+          retention-days: 14
 
   # ── Integration tests against Firebase Emulator Suite ───────────────────────
   # Enabled in PR #7 (phone-auth feature) which added integration_test/.
@@ -153,6 +168,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: functions/package-lock.json
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
       - name: Install Flutter dependencies
         run: flutter pub get
 
@@ -167,7 +190,7 @@ jobs:
         run: cd functions && npm run build
 
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@15.20.0
 
       - name: Run Firestore Security Rules tests (no functions loaded)
         # Runs the rules-test layer in a dedicated emulator session with
@@ -231,6 +254,24 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -261,6 +302,10 @@ jobs:
     name: Build iOS (no signing)
     runs-on: macos-15
     needs: [flutter-checks]
+    env:
+      # Pinned so the activated CLI snapshot is cacheable via the pub-cache step
+      # below and the from-source compile is skipped on a warm cache.
+      FLUTTERFIRE_VERSION: 1.4.0
     steps:
       - uses: actions/checkout@v4
 
@@ -268,6 +313,15 @@ jobs:
         with:
           channel: stable
           cache: true
+
+      - name: Cache pub packages and FlutterFire CLI
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}-flutterfire-${{ env.FLUTTERFIRE_VERSION }}
+          restore-keys: |
+            pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}-
+            pub-${{ runner.os }}-
 
       - name: Install dependencies
         run: flutter pub get
@@ -283,8 +337,20 @@ jobs:
         # until FlutterFire 2.x ships full SwiftPM support.
         run: flutter config --no-enable-swift-package-manager
 
-      - name: Install FlutterFire CLI
-        run: dart pub global activate flutterfire_cli
+      - name: Install FlutterFire CLI (cached)
+        # The Xcode "upload-crashlytics-symbols" build phase invokes the
+        # `flutterfire` binary, so the CLI is required for `flutter build ios`.
+        # Activation compiles the CLI from source (slow); skip it when the
+        # pinned version has already been restored from the pub-cache step
+        # above. The version check (not a mere existence check) ensures a
+        # FLUTTERFIRE_VERSION bump still re-activates even if a restore-key
+        # fallback brought back an older snapshot.
+        run: |
+          if dart pub global list 2>/dev/null | grep -q "flutterfire_cli ${FLUTTERFIRE_VERSION}"; then
+            echo "flutterfire_cli ${FLUTTERFIRE_VERSION} restored from cache; skipping activation."
+          else
+            dart pub global activate flutterfire_cli "$FLUTTERFIRE_VERSION"
+          fi
 
       - name: Restore GoogleService-Info.plist
         # ── Firebase config secret restoration ──
@@ -305,6 +371,16 @@ jobs:
           fi
           printf '%s' "${GOOGLE_SERVICE_INFO_PLIST_BASE64}" | base64 -D > ios/Runner/GoogleService-Info.plist
 
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            pods-${{ runner.os }}-
+
       - name: Build iOS (no codesign)
         run: flutter build ios --no-codesign
 
@@ -317,36 +393,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [flutter-checks, functions-checks]
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: subosito/flutter-action@v2
+      # Coverage data is produced once upstream — flutter-checks emits
+      # coverage/lcov.info and functions-checks emits
+      # functions/coverage/coverage-summary.json — and uploaded as artifacts.
+      # This job downloads them and enforces the SRS 5.7 thresholds without
+      # re-running any tests.
+      - name: Download Flutter coverage
+        uses: actions/download-artifact@v4
         with:
-          channel: stable
-          cache: true
+          name: flutter-coverage
+          path: coverage
 
-      - uses: actions/setup-node@v4
+      - name: Download Functions coverage
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: functions/package-lock.json
-
-      - name: Install Flutter dependencies
-        run: flutter pub get
-
-      - name: Install Functions dependencies
-        run: cd functions && npm ci
-
-      - name: Run Flutter tests with coverage
-        run: flutter test --coverage
-
-      - name: Run Functions tests with coverage
-        run: cd functions && npx jest --coverage --coverageReporters=json-summary --coverageReporters=text
-
-      - name: Install lcov
-        run: |
-          if ! command -v lcov >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y lcov
-          fi
+          name: functions-coverage
+          path: functions/coverage
 
       - name: Enforce coverage thresholds
         run: |
@@ -501,19 +563,3 @@ jobs:
               print("")
               print("Coverage gate PASSED. All thresholds met.")
           COVERAGE_SCRIPT
-
-      - name: Upload Flutter coverage
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: flutter-coverage-report
-          path: coverage/lcov.info
-          retention-days: 14
-
-      - name: Upload Functions coverage
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: functions-coverage-report
-          path: functions/coverage/
-          retention-days: 14

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,15 +70,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # subosito/flutter-action already caches ~/.pub-cache keyed on
+          # pubspec.lock, so no separate pub cache step is needed.
           cache: true
-
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
 
       - name: Install dependencies
         run: flutter pub get
@@ -168,14 +162,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: functions/package-lock.json
 
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
-
       - name: Install Flutter dependencies
         run: flutter pub get
 
@@ -254,24 +240,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
-
       - name: Install dependencies
         run: flutter pub get
 
@@ -303,8 +271,9 @@ jobs:
     runs-on: macos-15
     needs: [flutter-checks]
     env:
-      # Pinned so the activated CLI snapshot is cacheable via the pub-cache step
-      # below and the from-source compile is skipped on a warm cache.
+      # Pinned so the version-checked guard on the activation step below can
+      # detect a cache hit (flutterfire_cli restored via subosito's pub cache)
+      # and skip the slow from-source compile on a warm cache.
       FLUTTERFIRE_VERSION: 1.4.0
     steps:
       - uses: actions/checkout@v4
@@ -312,16 +281,10 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # subosito/flutter-action caches ~/.pub-cache (keyed on pubspec.lock),
+          # which also preserves the globally-activated flutterfire_cli snapshot,
+          # so the activation step below is skipped on a warm cache.
           cache: true
-
-      - name: Cache pub packages and FlutterFire CLI
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}-flutterfire-${{ env.FLUTTERFIRE_VERSION }}
-          restore-keys: |
-            pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}-
-            pub-${{ runner.os }}-
 
       - name: Install dependencies
         run: flutter pub get
@@ -340,11 +303,11 @@ jobs:
       - name: Install FlutterFire CLI (cached)
         # The Xcode "upload-crashlytics-symbols" build phase invokes the
         # `flutterfire` binary, so the CLI is required for `flutter build ios`.
-        # Activation compiles the CLI from source (slow); skip it when the
-        # pinned version has already been restored from the pub-cache step
-        # above. The version check (not a mere existence check) ensures a
-        # FLUTTERFIRE_VERSION bump still re-activates even if a restore-key
-        # fallback brought back an older snapshot.
+        # Activation compiles the CLI from source (slow, ~2-4 min); skip it when
+        # the globally-activated snapshot has already been restored via the
+        # subosito/flutter-action pub cache above (common case: unchanged
+        # pubspec.lock). The version check (not a mere existence check) ensures a
+        # FLUTTERFIRE_VERSION bump still triggers re-activation.
         run: |
           if dart pub global list 2>/dev/null | grep -q "flutterfire_cli ${FLUTTERFIRE_VERSION}"; then
             echo "flutterfire_cli ${FLUTTERFIRE_VERSION} restored from cache; skipping activation."
@@ -382,14 +345,7 @@ jobs:
             pods-${{ runner.os }}-
 
       - name: Build iOS (no codesign)
-        # Debug build (not release): the PR pipeline only needs to "catch build
-        # errors early" (SRS 9.2.1), and a debug build does that while skipping
-        # Dart AOT compilation and building the ~270 Firebase/gRPC/BoringSSL pods
-        # unoptimised, which is markedly faster than a release build. This mirrors
-        # the Android PR job (flutter build apk --debug). The release pipeline
-        # (release.yml) still performs the full signed release build before
-        # shipping, so release-only build errors are caught pre-ship.
-        run: flutter build ios --debug --no-codesign
+        run: flutter build ios --no-codesign
 
   # ── Coverage Gate — authoritative SRS 5.7 enforcement ────────────────────
   # Runs after test jobs complete. Checks per-feature/per-module thresholds

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,15 +88,21 @@ jobs:
 
       - name: Check coverage threshold
         run: |
-          if ! command -v lcov >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y lcov
-          fi
-          TOTAL=$(lcov --summary coverage/lcov.info 2>&1 | grep 'lines' | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
-          echo "Total coverage: ${TOTAL}%"
-          if [ "$(echo "$TOTAL < 50.0" | bc -l)" -eq 1 ]; then
-            echo "::error::Overall coverage ${TOTAL}% is below the 50% threshold (SRS section 5.7)."
-            exit 1
-          fi
+          python3 - <<'PY'
+          import sys
+          lh = lf = 0
+          with open("coverage/lcov.info") as f:
+              for line in f:
+                  if line.startswith("LH:"):
+                      lh += int(line.split(":")[1])
+                  elif line.startswith("LF:"):
+                      lf += int(line.split(":")[1])
+          pct = (lh * 100.0 / lf) if lf else 0.0
+          print(f"Total coverage: {pct:.1f}%")
+          if pct < 50.0:
+              print(f"::error::Overall coverage {pct:.1f}% is below the 50% threshold (SRS section 5.7).")
+              sys.exit(1)
+          PY
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -223,10 +229,14 @@ jobs:
           fi
 
   # ── Build (unsigned) — catch build errors early ─────────────────────────────
+  # The build jobs intentionally do NOT depend on flutter-checks: they run in
+  # parallel with lint/test from the start of the pipeline to minimise
+  # wall-clock time. The trade-off is that a build may run even when
+  # flutter-checks fails; concurrency.cancel-in-progress cancels superseded runs
+  # when a new commit is pushed.
   build-android:
     name: Build Android (debug)
     runs-on: ubuntu-latest
-    needs: [flutter-checks]
     steps:
       - uses: actions/checkout@v4
 
@@ -268,8 +278,12 @@ jobs:
 
   build-ios:
     name: Build iOS (no signing)
-    runs-on: macos-15
-    needs: [flutter-checks]
+    # Larger Apple-silicon runner (M2 Pro, 5 vCPU) vs the standard macos-15
+    # (M1, 3 vCPU) to speed up the Xcode compile of the ~270 Firebase pods,
+    # which is the pipeline's wall-clock bottleneck. NOTE: larger runners are
+    # billed (~$0.16/min) even on public repos, where the standard macos-15
+    # runner is free — revert to `macos-15` to eliminate that cost.
+    runs-on: macos-15-xlarge
     env:
       # Pinned so the version-checked guard on the activation step below can
       # detect a cache hit (flutterfire_cli restored via subosito's pub cache)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -382,7 +382,14 @@ jobs:
             pods-${{ runner.os }}-
 
       - name: Build iOS (no codesign)
-        run: flutter build ios --no-codesign
+        # Debug build (not release): the PR pipeline only needs to "catch build
+        # errors early" (SRS 9.2.1), and a debug build does that while skipping
+        # Dart AOT compilation and building the ~270 Firebase/gRPC/BoringSSL pods
+        # unoptimised, which is markedly faster than a release build. This mirrors
+        # the Android PR job (flutter build apk --debug). The release pipeline
+        # (release.yml) still performs the full signed release build before
+        # shipping, so release-only build errors are caught pre-ship.
+        run: flutter build ios --debug --no-codesign
 
   # ── Coverage Gate — authoritative SRS 5.7 enforcement ────────────────────
   # Runs after test jobs complete. Checks per-feature/per-module thresholds


### PR DESCRIPTION
## Summary

Speeds up and cleans up the PR pipeline (`.github/workflows/pr.yml`), backed by
step-level measurements from real CI runs. All runners remain **free**
(standard `ubuntu-latest` / `macos-15`).

## What changed

1. **Parallelise the build jobs** - `build-ios` and `build-android` no longer
   `needs: [flutter-checks]`, so they start at t=0 instead of after the ~3 min
   check job. Deterministically removes ~3 min from the critical path. The
   artifact-consuming jobs (`coverage-gate`, `integration-tests`) keep their
   gates. `concurrency.cancel-in-progress` cancels superseded runs on re-push.
2. **Cache CocoaPods** (`ios/Pods` + CocoaPods cache, keyed on `Podfile.lock`) -
   cuts `pod install` from ~280 s to ~42 s on the iOS critical path.
3. **Guard the `flutterfire_cli` activation** - skips its ~2-4 min from-source
   compile on a warm pub cache (subosito/flutter-action caches `~/.pub-cache`,
   including the activated CLI). The CLI is required by the Xcode
   `upload-crashlytics-symbols` build phase, so it is cached, not removed.
3. **De-duplicate `coverage-gate`** - it re-ran the full Flutter + Functions
   suites already run by `flutter-checks` / `functions-checks`. It now downloads
   their coverage artifacts and runs only the SRS 5.7 enforcement script. Same
   thresholds; 3m19s -> ~5 s. (Off the critical path, so this saves billable
   compute and a runner, not wall-clock.)
4. **Drop `apt-get install lcov`** from `flutter-checks` - the overall-coverage
   threshold check now parses `lcov.info` inline with Python (~12 s + an apt
   dependency removed from the critical path).
5. **Pin `firebase-tools`** for reproducibility.

Tried and reverted: `--debug` iOS build (no speedup - Firebase pods compile the
same) and a larger macOS runner (billed; would not start on this account, and
we keep runners free).

## Result

Baseline **27m37s** -> **~14-17 min** wall-clock (run to run), all jobs green.
Deterministic critical-path savings: parallelisation (~3 min) + CocoaPods cache
(~4 min) + skipped flutterfire compile (~2-4 min). iOS runner time varies (Xcode
compile of ~270 Firebase pods ranged 710-853 s across runs), so wall-clock
fluctuates around the iOS build time.

## Remaining floor (not pursued)

~12-14 min is Xcode compiling the ~270 Firebase pods. Caching `ios/Pods` cannot
reduce the *compile* (only `pod install`). Breaking it further would need Xcode
DerivedData caching, a (billed) larger runner, or fewer Firebase SDKs - none
pursued here (kept free + low-risk).

## Validation

`actionlint` clean; warm runs confirm CocoaPods restored + flutterfire activation
skipped + `pod install` ~42 s; builds confirmed starting in parallel at t=0; all
jobs green. No job names change, so required status checks on `main` are
unaffected.
