### PR TITLE
fix(validation): Sprint 1-2 Pass 1 emulator defects (D1-D14)

### DIFF
--- a/docs/copilot_prompts/manual-validation-sprint-1-2.md
+++ b/docs/copilot_prompts/manual-validation-sprint-1-2.md
@@ -1,0 +1,226 @@
+# Pre-Sprint-3 Manual Validation — Sprint 1 + Sprint 2 (Emulator + Production, Device + Simulator)
+
+> Paste this prompt into a fresh OneByTwo orchestrator session to run an interactive,
+> agent-guided manual validation pass over **everything shipped in Sprint 1 and Sprint 2**,
+> before the Sprint 3 Groups epic begins. It is the human-in-the-loop counterpart to the
+> automated suite: a step-by-step walkthrough of every scenario, validated on **both the
+> app UI and the Firebase backend**, across **both the Firebase Emulator Suite and
+> production**, on **both a real device and a simulator**.
+
+---
+
+You are the **OneByTwo orchestrator** running an **interactive, human-in-the-loop manual
+validation** session. **QA leads**; **flutter-dev**, **functions-dev**, and **devops**
+consult. The tester (the user) executes each step on real hardware; you guide them.
+
+This is **validation, not feature work**. No new code ships except fixes the tester
+explicitly approves for a blocking defect. **Refuse any attempt to start the Sprint 3
+Groups epic, the `go_router` migration, or any feature work.** Quote the SRS/invariant
+and propose a compliant alternative (file a defect/issue).
+
+Read before starting: `.github/copilot-instructions.md`, `.github/shared/invariants.md`,
+`docs/OneByTwo_Requirements_Spec.md`, `docs/design/06-screen-specs/`,
+`docs/design/07-technical/{firestore-schema.md,cloud-functions-catalogue.md,telemetry-plan.md,test-design.md}`,
+`docs/sprint-zero/sprint-3-kickoff-readiness.md`, and the skills
+`.github/skills/{setup-emulator-suite,triage-bug,write-integration-test}/SKILL.md`.
+
+────────────────────────────────────────
+HOW YOU GUIDE (binding interaction contract)
+────────────────────────────────────────
+
+- **Drive with `ask_user`, one step at a time.** For each scenario: (1) state the exact
+  tester action(s), on which target; (2) state the **expected app behaviour**; (3) state
+  the **expected Firebase-side artefact** and **exactly how to inspect it** (Emulator UI
+  / Firebase Console path / Functions log / Storage object / Auth record / Analytics
+  DebugView); (4) **wait** for the tester to report what they saw on **both** sides;
+  (5) record pass/fail in the ledger; (6) only then proceed.
+- **Never batch scenarios and never assume a result.** Every scenario must be confirmed
+  on the **app side AND the Firebase side**.
+- **Two-party flows** (friends, expenses, settlements, notifications, real-time sync)
+  must be exercised across **both users at once** — User A on the device, User B on the
+  simulator — and the cross-effect verified on the other user's screen.
+- Keep a running **validation ledger** (use the session DB). At the end produce the
+  report and the defect list (below).
+- If a step blocks (build won't run, emulator won't reach the device, a missing
+  permission), stop and help the tester resolve it before continuing.
+
+────────────────────────────────────────
+TEST MATRIX (read first)
+────────────────────────────────────────
+
+**Two users (run together):**
+- **DEVICE** = a real phone (iOS or Android) = **User A**, a real `+91` number (#1).
+- **SIMULATOR/EMULATOR** = iOS Simulator or Android Emulator = **User B**, a second `+91`
+  number (#2).
+- Expense-sharing is inherently two-party; most scenarios need both signed in at once.
+
+**Two backends, two passes (do Pass 1 fully, then Pass 2):**
+- **PASS 1 — Firebase Emulator Suite.** Fast, safe, fully inspectable. **No real SMS**
+  (Auth-emulator test numbers with fixed codes), **no FCM push** (FCM is not part of the
+  Emulator Suite — `lib/main.dart` notes this). Inspect everything in the **Emulator UI
+  at http://localhost:4000** (Firestore, Auth, Storage, Functions logs).
+- **PASS 2 — Production (`onebytwo-avtanshgupta`).** Real `+91` SMS OTP, real
+  `asia-south1` Cloud Functions, real Storage, and **real FCM push on the real device**.
+  Inspect in the **Firebase Console** (Firestore Data, Functions > Logs [region
+  `asia-south1`], Storage, Authentication, Crashlytics, Analytics > DebugView).
+
+**The four invariants are validated explicitly in Phase 9** and spot-checked throughout:
+(1) money is integer paise; (2) `simplifiedBalances` is server-written / client-read-only;
+(3) system share sheet only; (4) single Firebase project.
+
+────────────────────────────────────────
+PHASE 0 — ENVIRONMENT SETUP (devops + QA)
+────────────────────────────────────────
+
+Guide the tester through, and confirm each is up before any scenario:
+
+1. **Build Functions:** `cd functions && npm run build`.
+2. **Start the Emulator Suite** (JDK 21+ required for firebase-tools — e.g.
+   `export PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"`):
+   `firebase emulators:start --only auth,firestore,functions,storage`.
+   Ports: **auth 9099, firestore 8181, functions 5001, storage 9199, UI 4000**
+   (`singleProjectMode`). Confirm the UI loads at http://localhost:4000.
+3. **Run the app against the emulator** (Pass 1):
+   `fvm flutter run --dart-define=USE_EMULATOR=true --dart-define=EMULATOR_HOST=<host>`.
+   The **host** differs per target:
+   - iOS Simulator → `127.0.0.1` (or omit for the default).
+   - Android Emulator → `10.0.2.2`.
+   - **Real device on the emulator** → the **dev machine's LAN IP** (phone on the same
+     Wi-Fi); confirm the device can reach `http://<LAN-IP>:4000`.
+4. **Auth-emulator test numbers:** add fixed test `+91` numbers with known OTP codes in
+   the Auth emulator (or use the emulator's deterministic code) so Pass 1 needs no SMS.
+5. **Run the app against production** (Pass 2): `fvm flutter run` (no `USE_EMULATOR`).
+   Confirm `lib/firebase_options.dart` / `.firebaserc` resolve to
+   **`onebytwo-avtanshgupta`** only (Invariant 4).
+6. **Analytics DebugView** (Pass 2, to validate telemetry & PII): enable debug mode
+   (`adb shell setprop debug.firebase.analytics.app <pkg>` on Android; the
+   `-FIRDebugEnabled` launch arg on iOS) and open **Console > Analytics > DebugView**.
+
+Commit the framing in writing: targets, the two passes, the inspection tools, and that
+push/SMS testing happens only in Pass 2 on the real device.
+
+────────────────────────────────────────
+PHASES 1–10 — THE SCENARIO SCRIPTS
+────────────────────────────────────────
+
+For **every** scenario, confirm: app behaviour ✔, Firebase artefact ✔, on the stated
+target(s) and pass(es). The screen IDs (SCR-nn) and FR IDs are the source of truth in
+the SRS and screen specs.
+
+**Phase 1 — Auth & Profile (Sprint 1; FR-AU-01..08; SCR-01/03/04/05).** Splash; phone
+entry (`+91` validation, reject non-`+91`/short); OTP send → countdown → **resend** →
+**wrong code** error → success; **Android auto-retrieval** (real Android device only);
+profile setup (display name, character counter, **avatar upload**). Session persistence
+(kill + relaunch → stays signed in). Sign out. **Firebase:** `users/{uid}` doc shape
+(phoneNumber `+91`, displayName, photoUrl, fcmTokens, locale `en-IN`); **Auth record**
+exists; **Storage `avatars/{uid}`** object (≤5 MB, jpeg/png). Run on **both** device and
+simulator (each becomes a distinct signed-in user).
+
+**Phase 2 — Friends (FR-FR-01..04; SCR-09/10/11).** Add friend via **device contacts**
+(grant + the permission-denied + "Open Settings" path), via **manual `+91` entry**, and
+the **match-and-invite** branch: existing user (User B is registered) → friendship
+created; non-user number → **invite via the system share sheet**. Self-add and duplicate
+blocks. Friends list (empty + populated). Friend detail. **Firebase:** `friendships/{id}`
+(`memberIds`, `createdBy`, **no `simplifiedBalances` at create**); `lookupUserByPhoneNumber`
+function log + the per-user lookup **rate limit** (`_rateLimits/...`). **INVARIANT 3**
+(share sheet, never a WhatsApp-specific target). **Re-verify S6 explicitly:** the
+add-friend flow was unreachable before PR #91 — confirm it now completes end-to-end and a
+friendship document actually appears for both users.
+
+**Phase 3 — Expenses (FR-EX-01..07, friendship context; SCR-19/20/21/22).** Add expense:
+amount in ₹ (verify it stores **integer paise**), description (≤100 chars), date; **equal
+split** and **custom split** (shares must sum exactly to the total). **Receipt attach**
+(camera on the real device, gallery on both). **Edit** and **delete** — confirm
+**creator-only** (the non-creator cannot edit/delete; #72). **Firebase:** the
+`friendships/{id}/expenses/{id}` doc (`amountPaise`, `splits` summing exactly,
+`source`/`currency`, `createdBy`); the **`onExpenseWriteFriendship` trigger** fires →
+**`simplifiedBalances` recomputed** on the friendship doc (watch it change); an
+**`activity`** entry is written; a **receipt** lands in **Storage** with the size/MIME
+constraint. **INVARIANT 1** (paise, no float drift) **and 2** (only the trigger writes
+`simplifiedBalances`). In Pass 2, User B receives an **FCM push**.
+
+**Phase 4 — Settlements (FR-SE-03..09; SCR-23/24).** Settle up (full and partial,
+pre-filled amount/direction); settlement history (per friend); **Send Reminder** (and the
+**24-hour rate limit** second attempt is blocked). **Firebase:** `settlements/{id}` carries
+the extension-point locks **`method:'manual'`, `currency:'INR'`, `verificationStatus:'unverified'`**;
+**`onSettlementWrite`** → **recompute** `simplifiedBalances` (balance moves toward zero);
+an `activity` entry; `sendReminderNotification` runs (the rate-limit doc + the reminder
+**push** in Pass 2). **INVARIANT 1/2.**
+
+**Phase 5 — Home Dashboard (FR-HD-01..04; SCR-06/08).** Overall **net balance**; **top
+balances**; **monthly spend-breakdown chart** (donut + legend + empty/error states); the
+**persistent FAB + context picker**. **Real-time sync:** add an expense on the **Device**
+and confirm the **Simulator's** balance/dashboard updates **live**. Verify money renders
+as ₹ with two decimals and **Indian numbering** (e.g. ₹1,23,456.78), the sole paise→INR
+boundary.
+
+**Phase 6 — Activity Feed (FR-AC-01; SCR-25).** Chronological list with **relative
+timestamps in IST**; empty/error states; **deep-link** from an activity item to the
+relevant screen (expense/settlement/friend).
+
+**Phase 7 — Notifications (FR-AC-03/05; PASS 2, real device only).** FCM **token
+registration** (`users/{uid}.fcmTokens`); **push received** for an expense, a settlement,
+and a reminder; **notification tap deep-link** in **cold start**, **background**, and
+**foreground**; **notification preferences** toggle OFF → the corresponding push **stops**.
+(Note: the Emulator Suite cannot push and iOS Simulator has no push — this phase is
+production + the real device.)
+
+**Phase 8 — Profile & Account (FR-PR-01..05, FR-SH-03/04, FR-AU-09; SCR-26/27/28).**
+View/edit profile (name + avatar re-upload); **change phone (FR-PR-02)** via OTP reverify
+→ confirm `users/{uid}.phoneNumber` **and** the **Auth record** update; **Contact Support**
+(`mailto:` + the copy/share fallback); notification preferences. **DELETE ACCOUNT
+(FR-AU-09):** run the **`deleteUserAccount`** cascade and verify the user's
+`users` doc, `friendships`, `expenses`, `settlements`, `activity`, **Storage**
+avatar/receipts, **and the Auth record** are **all removed**, and the other user's view
+reconciles. (Use a disposable test user for the destructive delete.)
+
+**Phase 9 — Invariants & Security (explicit).**
+- **INV1 (paise):** enter several awkward amounts (e.g. ₹100.005, ₹0.01, large values),
+  confirm exact paise in the docs and exact split sums — no rounding/float drift.
+- **INV2 (`simplifiedBalances`):** attempt a **direct client write** to `simplifiedBalances`
+  on a friendship (e.g. from the Emulator UI acting as the client, or a temporary debug
+  write) → **rejected by Security Rules**; confirm only the function writes it.
+- **INV3 (share sheet):** every invite/share opens the **OS share sheet** with no
+  app-specific target.
+- **INV4 (single project):** confirm `.firebaserc` / `firebase_options.dart` reference
+  only `onebytwo-avtanshgupta`.
+- **Security rules:** as User A, attempt to read/write a friendship you are **not** a
+  member of, or another user's expense/profile → **denied**.
+
+**Phase 10 — Cross-cutting.** Offline (airplane mode → queued writes, graceful error
+states, recovery on reconnect); permission **denials** (contacts, notifications) + the
+**Open Settings** CTA; **accessibility** (VoiceOver/TalkBack on the key screens, dynamic
+type at 1.5×/2×, dark mode, ≥48 dp targets); empty/error states across screens; cold-start
+performance (target < 3 s); **Crashlytics** shows no crashes; **Analytics DebugView**
+shows the expected events firing with **bucketed `amount_range` (never raw `amount_paise`)**
+and **no phone-derived or raw-id PII** (re-verifies the T1/T2/T3 fixes from PR #91).
+
+────────────────────────────────────────
+DEFECT HANDLING
+────────────────────────────────────────
+
+The moment a scenario deviates, log it before moving on: a precise **repro**, the
+**target** (device/sim) and **pass** (emulator/production), **expected vs actual on both
+the app and Firebase sides**, and a **severity** via the `triage-bug` skill (S1–S4).
+Classify each as **blocking** (must fix before Sprint 3) or **backlog**, and file it as a
+**GitHub issue on the owning milestone** (per `.github/shared/milestone-tracking.md`).
+
+────────────────────────────────────────
+OUTPUT & SIGN-OFF
+────────────────────────────────────────
+
+Produce **`docs/qa/manual-validation-sprint-1-2.md`**: a per-scenario **pass/fail matrix**
+across **(emulator | production) × (device | simulator)**, each row noting the
+Firebase-side evidence; a **defect list** with severities and filed issue numbers; and a
+**QA sign-off** stating whether the shipped Sprint-1 + Sprint-2 surface is validated and
+free of **blocking** defects — the green light (or hold) for Sprint 3.
+
+────────────────────────────────────────
+EXECUTION PROTOCOL
+────────────────────────────────────────
+
+Interactive and **step-by-step via `ask_user`**: present a step, wait for the tester's
+observation on **both** sides, validate, record, proceed. Complete **Pass 1 (emulator)**
+fully, then **Pass 2 (production)**. Keep the ledger current. Stop after each **phase**
+and summarise pass/fail before the next. **Refuse** all Sprint-3 / feature work — this
+session only validates and logs defects.

--- a/docs/qa/manual-validation-sprint-1-2.md
+++ b/docs/qa/manual-validation-sprint-1-2.md
@@ -4,35 +4,44 @@
 > run against the **Firebase Emulator Suite (Pass 1)** before the Sprint-3 Groups epic.
 > Orchestrated by QA with flutter-dev / functions-dev / devops consulting.
 
-**Date:** 2026-06-24 · **Tester:** @avtanshgupta · **Backend:** emulator (Pass 1) ·
-**Targets:** iPhone 16 sim (iOS 18.6, User One `+91 98765 43210`) + iPhone 17 Pro sim
-(iOS 26.0, User Two `+91 99887 76655`).
+**Date:** 2026-06-24 / 2026-06-25 (full re-run) · **Tester:** @avtanshgupta ·
+**Backend:** Firebase Emulator Suite (Pass 1) · **Targets:** iPhone 16 sim (User One,
+`+91 98765 43210` → changed to `+91 98765 00000` in FR-PR-02 testing) + iPhone 17 Pro sim
+(User Two `+91 99887 76655`; plus a disposable User Three `+91 98765 11111` for the
+delete-account cascade).
 
-> **Scope note.** This pass covered Phase 0 (environment), Phase 1 (Auth & Profile),
-> Phase 2 (Friends), and the core of Phase 3 (Expenses: INV1/INV2). **Pass 2 (production)
-> and Phases 4–10 were not reached** — the session uncovered and fixed several blocking
-> defects first. See "Not yet validated" and "Verdict" below.
+> **Scope.** Pass 1 (emulator) is **complete**: Phases 0–6, 8, 9, and 10 were all
+> validated two-party against both the app UI and the Firebase backend, after a full
+> clean-build / clean-emulator re-run. **14 defects (D1–D14) were found and all 14 are
+> fixed, regression-tested, and pushed** on branch `fix/sprint-1-2-validation-defects`.
+> Phase 7 (FCM push), offline queue/sync, Crashlytics, Analytics DebugView, and real SMS
+> remain **Pass 2 (production + real device)** items by nature. See the matrix, defect
+> list, and verdict below.
 
 ---
 
 ## Headline
 
-Manual validation found that **four core flows were each broken end-to-end** by defects
-that the unit/widget tests miss (they use **fake stores / global test scopes** and never
-exercise the real security rules, provider scopes, or app lifecycle). All four — and every
-other defect found this session — are now fixed and verified (D8 also device-verified).
+Manual validation against the **real** Firebase emulator (real security rules, real
+provider scopes, real app lifecycle, real Cloud Function triggers) found **14 defects** the
+unit/widget suite missed — it uses fake stores and global test scopes. Several broke core
+flows end-to-end (launch, add-friend, friend-detail, add-expense, delete-account display).
+**All 14 are now fixed with regression tests; `flutter analyze` clean, 1609 tests pass,
+formatter clean**, and each fix was re-verified on-device against the emulator.
 
 | Core flow | Defect | Result |
 |---|---|---|
 | App launch (iOS) | D1 (S1) | **Fixed + verified** (#95) |
-| Add friend | D4 (S1) | **Fixed + verified** (#98) |
+| Add friend — duplicate-check hang/latency | D4→D9 (S1) | **Fixed + verified** (#98, #106) |
 | Friend Detail | D7 (S2) | **Fixed + verified** (#101) |
-| Add expense (FAB picker) | D8 (S1) | **Fixed + verified** (#102) |
+| Add-expense FAB picker | D8 (S1) | **Fixed + verified** (#102) |
+| Add-expense save (analytics crash) | D11 (S2) | **Fixed + verified** (#105) |
+| Delete-account display (tombstone) | D13 (S3) | **Fixed + verified** (#108) |
 
-> **Update — all 8 defects fixed.** Following the validation, every open defect (D2, D3,
-> D5, D6, D8) was fixed with regression tests. Whole repo: `flutter analyze` clean,
-> **1601 tests pass**, formatter clean; D8 also re-verified on device (the picker lists all
-> friends, including ones with no expense). Changes are in the working tree pending PR(s).
+> **All 14 defects fixed.** D1–D14 each carry a GitHub issue (#95–#102, #104–#109) on the
+> **Sprint 2** milestone, plus enhancement #103. Branch `fix/sprint-1-2-validation-defects`
+> holds 6 commits (`0f891ba`, `2cba3cc`, `23460ef`, `c24fbec`, `51c83f4`, `80762d0`).
+> A key environment caveat (FlutterFire #10449) is documented under "Environment notes".
 
 ---
 
@@ -81,29 +90,119 @@ Legend: ✅ pass · ⚠️ partial (works with a logged deviation) · ⛔ blocke
 | User B full sign-up | ✅ | 2 users docs |
 | Android OTP auto-retrieval | N/A | iOS only |
 
-### Phase 2 — Friends — **PASS** (core), with open UX defects
+### Phase 2 — Friends — **PASS** (all scenarios, re-run)
 | Scenario | Result | Firebase evidence |
 |---|---|---|
 | Empty friends list | ✅ | — |
-| **S6** add friend (manual) → match → friendship created (two-party) | ⚠️ **D4 fixed; D5/D6 open** | `friendships/{sorted}`: sorted memberIds, createdBy, **no simplifiedBalances** (INV2); `lookupUserByPhoneNumber` matched (246 ms) |
-| Duplicate block ("You are already friends") | ✅ | existing-friendship read allowed → true |
+| **S6** add friend (manual) → match → friendship created (two-party) | ✅ | `friendships/{sorted}`: sorted memberIds, createdBy, **no simplifiedBalances** (INV2); `lookupUserByPhoneNumber` matched |
+| Add-friend duplicate-check latency | ✅ **D9 fixed** | membership query via `.snapshots().first`: 90 s → 2.2 ms |
+| Add-friend completion feedback + name | ✅ **D5/D6** | `MatchAndInviteAdded` → snackbar + `userProfileProvider` invalidate |
+| Duplicate block ("You are already friends") | ✅ | fast membership-query true path |
 | Self-add block | ✅ | short-circuits before callable |
 | Non-user → **invite via system share sheet (INV3)** | ✅ | generic iOS share sheet, no app-specific target |
 | Contacts permission: no auto-prompt → Grant → list | ✅ | D1 fix (`permissions.check/request`) |
-| Contacts permission denied → Open Settings | ✅ | D1 `deniedPermanently` mapping |
-| Friend Detail (SCR-11) loads | ✅ | after **D7 fix** (settlements list query 200) |
+| Contacts permission denied → PermissionDeniedView → Open Settings | ✅ | opened iOS Settings; D1 `_mapPermissionStatus` |
+| Friends list two-party (resolved names) | ✅ | both see each other after fix |
+| Friend Detail (SCR-11) loads | ✅ | **D7 fix** (settlements list query → `isContextMember`, 200) |
+| Per-user lookup rate-limit counter | ✅ | `_rateLimits/{uid}/lookups/counter` written per-user (limit 100/h) |
 
-### Phase 3 — Expenses — **core PASS** (INV1 + INV2)
+### Phase 3 — Expenses — **PASS** (INV1 + INV2 + #72)
 | Scenario | Result | Firebase evidence |
 |---|---|---|
-| Add equal-split expense → trigger recompute | ✅ | `amountPaise=50000`, splits 25000+25000=**exactly 50000**, source=manual, currency=INR; `onExpenseWriteFriendship` fired (259 ms) → `simplifiedBalances {B:{A:25000}}` (**INV2 trigger-only**) |
-| Two-party balance display (INV1 ₹ boundary) | ✅ | ₹250.00 — A owed / B owes, real-time both sides, Indian numbering |
+| Add-expense FAB context picker lists friends | ✅ **D8 fixed** | scope hoisted into `MaterialApp.builder` |
+| Add equal-split expense → trigger recompute | ✅ | `amountPaise=50000`, splits 25000+25000=**50000**, source=manual, currency=INR; `onExpenseWriteFriendship` → `simplifiedBalances {B:{A:25000}}` (**INV2 trigger-only**) |
+| Custom split (awkward amount, INV1) | ✅ | `amountPaise=10001` (₹100.01); splits 5000+5001=**10001** exact, no float drift |
+| Two-party balance display (INV1 ₹ boundary) | ✅ | ₹250.00 both sides, real-time, Indian numbering |
 | Activity entry (FR-EX-07) | ✅ | `expense_added` for both users |
-| Custom split / receipt attach / creator-only edit-delete | **not validated** | — |
+| Receipt upload (gallery) | ✅ | `receipts/friendships/{fid}/{eid}` 1.07 MB image/jpeg (≤5 MB); expense `receiptUrl` set |
+| Expense **edit** → trigger recompute (FR-EX-06) | ✅ | Lunch 30000→40000, `updatedAt` fresh; `simplifiedBalances` recomputed |
+| Creator-only edit/delete (#72) | ✅ | non-creator (User Two) blocked; creator (User One) edits/deletes |
+| Expense delete → recompute | ✅ | `deleted=true`, trigger recomputed balance |
+| Post-delete navigation | ✅ **D10 fixed** | returns to Friend Detail (`softDelete()` returns bool) |
+| Add-expense analytics (no crash) | ✅ **D11 fixed** | bool params coerced to String; save fast |
+
+### Phase 4 — Settlements — **PASS** (reminder push → Pass 2)
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| Full settle-up → recompute to zero (INV1/INV2 + locks) | ✅ | `settlements/{id}` amountPaise=25000, from=B to=A, **method=manual, currency=INR, verificationStatus=unverified**; `onSettlementWrite` → `simplifiedBalances={}` |
+| Settlement history per friend (SCR-24) | ✅ | shows ₹250 settlement + date (dd MMM yyyy IST) |
+| Send Reminder — guard when recipient has no push | ✅ | `sendReminderNotification` ran then short-circuited (no fcmTokens); toast shown |
+| Reminder push + 24 h rate-limit | ⛔ Pass 2 | needs real FCM |
+
+### Phase 5 — Home Dashboard — **PASS**
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| Net balance + top balances (populated) | ✅ | User Two owes ₹400 after Groceries |
+| Monthly spend-breakdown chart (FR-HD-03) | ✅ | donut+legend, **own share**: Food ₹250 + Groceries ₹400 = ₹650 (never full amount) |
+| Settled-up empty state (zero balance) | ✅ by-spec | hides spend card per spec 06-08:113 — enhancement #103 (Sprint 2) |
+| Real-time two-party sync | ✅ | User One adds expense → User Two balance updates **live** |
+
+### Phase 6 — Activity Feed — **PASS**
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| Chronological list + relative IST timestamps | ✅ | expenses + settlement |
+| Deep-link from item → expense detail | ✅ | navigates to SCR-21 |
+| Expense detail shows friend name | ✅ **D12 fixed** | `userProfileProvider` resolves name (was "Friend") |
+
+### Phase 8 — Profile & Account — **PASS**
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| View profile | ✅ | name/avatar/phone |
+| Edit profile (name + avatar re-upload) | ✅ | `displayName` updated; avatar overwritten at same path |
+| Notification preferences toggle | ✅ | `users/{uid}.notificationPrefs.reminder=false` persisted |
+| Contact Support (mailto → copy fallback) | ✅ | no Mail account → copy-address dialog |
+| **Change phone (FR-PR-02)** | ✅ | `users/{uid}.phoneNumber` **AND Auth record** both → +919876500000 (same uid) |
+| **Delete account (FR-AU-09)** | ✅ by-design | re-auth + type-Delete gates; **deleted** activity/_rateLimits/avatar/Auth; **tombstoned** `users/{uid}={displayName:"Deleted User", deletedAt}`; **preserved** shared friendship/expense/simplifiedBalances (ADR-0016, INV2) |
+| Surviving user reconciliation | ✅ **D13 fixed** | shows "Deleted User" (tombstone parses) |
+
+### Phase 9 — Invariants & Security — **PASS**
+| Scenario | Result | Evidence |
+|---|---|---|
+| **INV1** integer paise (equal, custom, odd amounts) | ✅ | exact split sums; ₹100.01 = 10001 paise |
+| **INV2** client write to `simplifiedBalances` rejected | ✅ | PATCH as member → **HTTP 403**; control `lastActivityAt` → 200; trigger-only writes |
+| **INV3** invite → system share sheet | ✅ | no app-specific target |
+| **INV4** single Firebase project | ✅ | only `onebytwo-avtanshgupta` in `.firebaserc`/options/plist/google-services |
+| Non-member read/write friendship+expense | ✅ | **403** (member control 200) |
+| Stranger reads another profile | ✅ | **403** (friend control 200) |
+| Unauthenticated read | ✅ | **403** |
+| Friendship enumeration (list all) | ✅ | **403** (no social-graph enumeration) |
+
+### Phase 10 — Cross-cutting — **PASS** (offline → Pass 2)
+| Scenario | Result | Evidence |
+|---|---|---|
+| Dark mode | ✅ | readable, adequate contrast |
+| Dynamic type / large text | ✅ **D14 fixed** | OTP screen scrolls + responsive cells (was overflow) |
+| VoiceOver | ✅ | balance, rows, buttons, headings announced |
+| Tap targets ≥48 dp | ✅ | comfortable |
+| Empty/error states | ✅ | friendly messages + CTAs |
+| Cold-start performance | ✅ | < ~3 s to usable screen (debug/emulator) |
+| Offline queue/sync | ⛔ Pass 2 | no per-sim airplane mode; localhost loopback |
+
+### Phase 7 — Notifications — **Pass 2 only**
+FCM token registration, push (expense/settlement/reminder), notification-tap deep-link
+(cold/background/foreground), pref-OFF suppression — all require real FCM on a real device
+(the Emulator Suite has no FCM; iOS Simulator has no push). Deferred to Pass 2.
+
+---
+
+## Environment notes (carry into Pass 2)
+
+- **FlutterFire #10449 (iOS-sim + emulator slow one-shot `.get()`).** Against the Firestore
+  emulator on the iOS Simulator, a one-shot server `.get()` (doc or query) stalls ~90 s,
+  while `.snapshots()` cache reads are ~2 ms. This is **not a production bug** (REST/server
+  reads are instant) but it makes read-heavy paths feel slow on the emulator (profile
+  resolution, the dashboard spend-card read, opening an expense). D9's fix uses
+  `.snapshots().first` to dodge it; other `.get()` paths remain emulator-slow only.
+  Verify latency on production in Pass 2.
+- **Disabling Firestore persistence makes it worse**, not better (it removes the cache that
+  `.snapshots().first` reads) — do not add `persistenceEnabled: false`.
 
 ---
 
 ## Defect list
+
+All 14 defects are **fixed, regression-tested, and pushed** on
+`fix/sprint-1-2-validation-defects`. Each has a GitHub issue on the **Sprint 2** milestone.
 
 | ID | Sev | Issue | Status | Summary |
 |---|---|---|---|---|
@@ -115,6 +214,17 @@ Legend: ✅ pass · ⚠️ partial (works with a logged deviation) · ⛔ blocke
 | D6 | S3 | [#100](https://github.com/avtansh-code/OneByTwo/issues/100) | **Fixed + verified** | Newly-added friend shows "Unknown" until relaunch → on `Added`, `ref.invalidate(userProfileProvider(otherUserId))` refreshes the cached null |
 | D7 | S2 | [#101](https://github.com/avtansh-code/OneByTwo/issues/101) | **Fixed + verified** | Friend Detail broken — settlements `watchByContext` list query denied by from/to read rule → changed to `isContextMember` |
 | D8 | S1 | [#102](https://github.com/avtansh-code/OneByTwo/issues/102) | **Fixed + verified** | Add-expense FAB context picker can't load friends — modal on the root Navigator sat outside the per-arm `ProviderScope` → hoisted the scope overrides into `MaterialApp.builder` (above the root Navigator); device-verified |
+| D9 | S1 | [#106](https://github.com/avtansh-code/OneByTwo/issues/106) | **Fixed + verified** | Add-friend duplicate-check stalls ~90 s (supersedes D4) — mobile SDK slow to surface a denied/one-shot `get()` on iOS-sim+emulator (#10449) → `existsForMember` membership query via `.snapshots().first` (90 s → 2.2 ms) |
+| D10 | S3 | [#104](https://github.com/avtansh-code/OneByTwo/issues/104) | **Fixed + verified** | After deleting an expense the screen stayed on the stale view — gated `maybePop()` on re-reading an autoDispose provider → `softDelete()` returns `bool`; navigate on the return value |
+| D11 | S2 | [#105](https://github.com/avtansh-code/OneByTwo/issues/105) | **Fixed + verified** | Adding an expense threw Firebase Analytics assertions (bool params) + slow save → coerce `bool`→`"true"/"false"` centrally in `FirebaseAnalyticsService` |
+| D12 | S3 | [#107](https://github.com/avtansh-code/OneByTwo/issues/107) | **Fixed + verified** | Expense detail showed "Friend"/"You" instead of the friend's name → resolve `userProfileProvider(otherUserUid)` (cache-warm), fallback "Friend" |
+| D13 | S3 | [#108](https://github.com/avtansh-code/OneByTwo/issues/108) | **Fixed + verified** | Deleted account renders "Unknown" not "Deleted User" — PII-free tombstone failed the non-nullable `phoneNumber` cast → `UserModel.fromFirestore` tolerates it (`String? ?? ''`) |
+| D14 | S3 | [#109](https://github.com/avtansh-code/OneByTwo/issues/109) | **Fixed + verified** | OTP screen overflows at large Dynamic Type (vertical) and on small phones (horizontal) → `SingleChildScrollView` + `LayoutBuilder` responsive cells; 320 dp regression test |
+
+> **Enhancement filed:** [#103](https://github.com/avtansh-code/OneByTwo/issues/103)
+> (Sprint 2) — surface the spend-breakdown chart + a "no pending balances" indicator in the
+> dashboard settled/empty state (FR-HD-03 follow-up; user pulled into Sprint 2). To be
+> implemented after Pass 1 + Pass 2 complete.
 
 **Common root cause / test gap:** unit & widget tests use fake repositories and a global
 test `ProviderScope`, so they never exercise the **real Firestore security rules**, the
@@ -123,57 +233,60 @@ emulator-rules / integration / root-Navigator test.
 
 ---
 
-## In-session code changes (working tree — need PR + review)
+## Commits (branch `fix/sprint-1-2-validation-defects`)
 
-| File | Defect |
-|---|---|
-| `pubspec.yaml`, `pubspec.lock`, `ios/Podfile.lock` | D1 (flutter_contacts `^2.2.2`) |
-| `lib/features/friends/data/contact_service.dart` | D1 (2.x API migration) |
-| `lib/features/friends/data/friendship_repository.dart` | D4 (permission-denied → not-exists) |
-| `firestore.rules` | D7 (settlements read → `isContextMember`) |
-| `lib/features/notifications/presentation/notifications_lifecycle_host.dart` | D2 (`mounted` guards) |
-| `lib/features/auth/presentation/widgets/otp_input.dart`, `otp_entry_screen.dart` | D3 (controller-owned digits + clear on reset) |
-| `lib/features/friends/application/match_and_invite_controller.dart`, `presentation/match_and_invite_screen.dart` | D5 + D6 (`Added` state → pop + snackbar + profile invalidate) |
-| `lib/main.dart` | D8 (scope overrides hoisted into `MaterialApp.builder`) |
-| `test/features/auth/otp_input_test.dart`, `test/features/friends/match_and_invite_controller_test.dart`, `test/features/shell/root_navigator_scope_test.dart` | D3 / D5 / D8 regression tests |
+| Commit | Defects | Summary |
+|---|---|---|
+| `0f891ba` | D1–D8 | initial validation fixes (contacts 2.x, mounted guards, OTP clear, dup-check, add-friend feedback, settlements rule, FAB scope) |
+| `2cba3cc` | D9 | add-friend duplicate-check via membership query `.snapshots().first` |
+| `23460ef` | D10, D11 | post-delete navigation + analytics bool coercion |
+| `c24fbec` | D12 | expense detail shows friend name |
+| `51c83f4` | D13 | deleted account renders "Deleted User" |
+| `80762d0` | D14 | OTP screen overflow (scroll + responsive cells) |
 
-All eight fixes verified end-to-end against the emulator; `flutter analyze` clean; whole
-suite **1601 tests pass**; formatter clean; D8 additionally re-verified on device.
+All fixes verified end-to-end against the emulator; `flutter analyze` clean; whole suite
+**1609 tests pass**; formatter clean; each fix re-verified on-device.
 
 ---
 
-## Not yet validated (out of this session)
+## Not yet validated — **Pass 2 (production + real device)**
 
-- **Pass 2 — production**: real `+91` SMS OTP, real `asia-south1` functions, real FCM push,
-  Crashlytics, Analytics DebugView (incl. telemetry PII / bucketed `amount_range`).
-- **Phase 3 remainder**: custom split (INV1 exact sum), receipt attach (Storage), creator-only
-  edit/delete (#72).
-- **Phase 4** Settlements, **Phase 5** Home dashboard chart + cross-device sync, **Phase 6**
-  Activity feed deep-links, **Phase 7** Notifications (prod), **Phase 8** Profile + delete-account
-  cascade, **Phase 9** explicit invariant + security-rule probes, **Phase 10** offline / a11y /
-  perf / Crashlytics.
+- Real `+91` SMS OTP; real `asia-south1` Cloud Functions latency (confirm #10449 is
+  emulator-only).
+- **Phase 7 Notifications**: FCM token registration, push (expense/settlement/reminder),
+  notification-tap deep-link (cold/background/foreground), pref-OFF suppression.
+- Reminder push + 24 h rate-limit (Phase 4 remainder).
+- **Offline** queue/sync + recovery (Phase 10 remainder).
+- **Crashlytics** (no crashes) and **Analytics DebugView** (events fire; bucketed
+  `amount_range`, never raw `amount_paise`; no phone-derived/raw-id PII).
 
 ---
 
 ## QA sign-off
 
-**Verdict: all eight validation defects (D1–D8) are fixed and verified. Cleared for Sprint 3
-once the fixes land as reviewed PRs — full Pass-2 / Phase-4–10 validation remains outstanding.**
+**Verdict: Pass 1 (emulator) is COMPLETE and GREEN. All 14 defects (D1–D14) found during
+validation are fixed, regression-tested, and pushed. Clearance for Sprint 3 is gated only
+on (1) merging the fix branch as reviewed PR(s) and (2) running Pass 2 on production.**
 
-- ✅ Validated: the integer-paise money model and the server-only `simplifiedBalances`
-  recompute (**INV1 + INV2**), the system-share-sheet invariant (**INV3**), and the single
-  Firebase project (**INV4**) all hold; Auth/Profile is solid; the Friends and add-expense
-  surfaces work end-to-end after fixes.
-- ✅ All eight defects (D1–D8, incl. the four S1 blockers — launch, add-friend, Friend Detail,
-  add-expense) are fixed with regression tests; `flutter analyze` clean, **1601 tests pass**,
-  formatter clean, D8 device-verified.
-- ⛔ Before Sprint 3 can be declared green:
-  1. Land the eight fixes as **reviewed PR(s)** (they are currently in the working tree) —
-     ideally with the missing **real-rules / integration / lifecycle** coverage so these
-     fake-store/test-scope regressions can't recur.
-  2. Resume the validation from **Phase 3 remainder** (custom split, receipt, creator-only
-     edit/delete) through **Phase 10**, and run **Pass 2 on production**.
+- ✅ **Invariants all hold:** INV1 (integer paise, exact splits incl. ₹100.01), INV2
+  (`simplifiedBalances` server-only; client write → 403), INV3 (system share sheet), INV4
+  (single project) — verified directly, including the security-rule probes (non-member,
+  stranger, unauthenticated, enumeration all denied).
+- ✅ **Full surface validated two-party** across Phases 0–6, 8, 9, 10: auth/profile,
+  friends, expenses (equal+custom split, receipt, edit, creator-only #72), settlements
+  (both triggers + extension-point locks), dashboard (populated + spend chart + real-time
+  sync), activity feed + deep-link, profile + change-phone (dual-write) +
+  delete-account cascade (ADR-0016 tombstone), accessibility.
+- ✅ **14/14 defects fixed** with regression tests; `flutter analyze` clean, **1609 tests
+  pass**, formatter clean; every fix device-verified.
+- ⛔ **Before Sprint 3 is declared green:**
+  1. Merge `fix/sprint-1-2-validation-defects` as reviewed PR(s) (closes #95–#102, #104–#109).
+  2. Run **Pass 2 on production** (Phase 7 push, offline, Crashlytics, DebugView, real SMS).
+  3. Implement enhancement #103 (settled-state dashboard) — user-assigned to Sprint 2.
 
-**Recommendation:** the recurring fake-store/test-scope gap is itself the highest-leverage
-fix — add an emulator-backed integration lane (real rules + real provider scopes) to CI so
-these classes of defect surface automatically.
+**Highest-leverage follow-up:** the recurring theme is that fake-store/global-scope unit
+tests never exercise the real security rules, modal provider scopes, app lifecycle, or
+device layout — which is exactly where all 14 defects lived. Add an **emulator-backed
+integration lane** (real rules + real provider scopes + a small-viewport widget pass) to CI
+so these classes of defect surface automatically.
+

--- a/docs/qa/manual-validation-sprint-1-2.md
+++ b/docs/qa/manual-validation-sprint-1-2.md
@@ -1,0 +1,179 @@
+# Pre-Sprint-3 Manual Validation — Sprint 1 + Sprint 2
+
+> Human-in-the-loop manual validation of the shipped Sprint-1 + Sprint-2 surface,
+> run against the **Firebase Emulator Suite (Pass 1)** before the Sprint-3 Groups epic.
+> Orchestrated by QA with flutter-dev / functions-dev / devops consulting.
+
+**Date:** 2026-06-24 · **Tester:** @avtanshgupta · **Backend:** emulator (Pass 1) ·
+**Targets:** iPhone 16 sim (iOS 18.6, User One `+91 98765 43210`) + iPhone 17 Pro sim
+(iOS 26.0, User Two `+91 99887 76655`).
+
+> **Scope note.** This pass covered Phase 0 (environment), Phase 1 (Auth & Profile),
+> Phase 2 (Friends), and the core of Phase 3 (Expenses: INV1/INV2). **Pass 2 (production)
+> and Phases 4–10 were not reached** — the session uncovered and fixed several blocking
+> defects first. See "Not yet validated" and "Verdict" below.
+
+---
+
+## Headline
+
+Manual validation found that **four core flows were each broken end-to-end** by defects
+that the unit/widget tests miss (they use **fake stores / global test scopes** and never
+exercise the real security rules, provider scopes, or app lifecycle). All four — and every
+other defect found this session — are now fixed and verified (D8 also device-verified).
+
+| Core flow | Defect | Result |
+|---|---|---|
+| App launch (iOS) | D1 (S1) | **Fixed + verified** (#95) |
+| Add friend | D4 (S1) | **Fixed + verified** (#98) |
+| Friend Detail | D7 (S2) | **Fixed + verified** (#101) |
+| Add expense (FAB picker) | D8 (S1) | **Fixed + verified** (#102) |
+
+> **Update — all 8 defects fixed.** Following the validation, every open defect (D2, D3,
+> D5, D6, D8) was fixed with regression tests. Whole repo: `flutter analyze` clean,
+> **1601 tests pass**, formatter clean; D8 also re-verified on device (the picker lists all
+> friends, including ones with no expense). Changes are in the working tree pending PR(s).
+
+---
+
+## Environment (Phase 0) — fixes required before any scenario
+
+The local toolchain was behind the project/CI and blocked all runtime testing:
+
+- **Xcode 26.5 iOS platform missing** → `xcodebuild` listed zero simulator destinations.
+  Fixed with `xcodebuild -downloadPlatform iOS` (installed the iOS 26.5 runtime).
+- **Swift Package Manager** (default-on in Flutter 3.44.x) breaks the iOS build →
+  `flutter config --no-enable-swift-package-manager`.
+- **firebase-tools 13.35.1 + Node 18** crashed every callable Cloud Function under the
+  emulator (`functions.config()` removed in firebase-functions v7). Installed **Node 22**
+  and upgraded to **firebase-tools 15.20.0** (matches CI); restarted the emulators under
+  Node 22 with `firebase-export` import to preserve data.
+
+All seven functions load in `asia-south1`; emulator UI at `localhost:4000`.
+
+---
+
+## Pass / Fail matrix (Pass 1 · emulator)
+
+Legend: ✅ pass · ⚠️ partial (works with a logged deviation) · ⛔ blocked.
+
+### Phase 0 — Environment
+| Scenario | Result | Evidence |
+|---|---|---|
+| Emulator Suite boots (auth/firestore/functions/storage + UI) | ✅ | All emulators ready; UI :4000 |
+| All 7 Cloud Functions load in `asia-south1` | ✅ | boot log roster |
+| Emulator UI reachable, Firestore empty (clean start) | ✅ | tester-confirmed |
+| iOS app builds & launches on Simulator | ✅ | after D1 fix |
+
+### Phase 1 — Auth & Profile — **PASS**
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| Splash → Phone Entry (no session) | ✅ | — |
+| Phone validation (reject prefix, soft-gate <10) | ✅ | client-side |
+| OTP send → countdown → resend → success | ✅ | Auth emulator codes; new Auth user |
+| OTP invalid code → error + retry | ⚠️ **D3** | rejected; cells don't auto-clear |
+| New user → Profile Setup; display name + soft counter (>40) + 50 cap | ✅ | — |
+| Avatar pick (gallery) | ✅ | — |
+| Save profile → Home; `users/{uid}` + Storage avatar | ✅ | doc shape clean (phone +91, locale en-IN, notifPrefs, fcmTokens [], no extra); avatar image/jpeg 246 KB (<5 MB) |
+| Session persistence (kill→relaunch→Home) | ✅ | — |
+| Sign out → Phone Entry | ✅ | users doc + Auth record persist |
+| Existing-user login → Home (not Profile Setup) | ✅ | — |
+| User B full sign-up | ✅ | 2 users docs |
+| Android OTP auto-retrieval | N/A | iOS only |
+
+### Phase 2 — Friends — **PASS** (core), with open UX defects
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| Empty friends list | ✅ | — |
+| **S6** add friend (manual) → match → friendship created (two-party) | ⚠️ **D4 fixed; D5/D6 open** | `friendships/{sorted}`: sorted memberIds, createdBy, **no simplifiedBalances** (INV2); `lookupUserByPhoneNumber` matched (246 ms) |
+| Duplicate block ("You are already friends") | ✅ | existing-friendship read allowed → true |
+| Self-add block | ✅ | short-circuits before callable |
+| Non-user → **invite via system share sheet (INV3)** | ✅ | generic iOS share sheet, no app-specific target |
+| Contacts permission: no auto-prompt → Grant → list | ✅ | D1 fix (`permissions.check/request`) |
+| Contacts permission denied → Open Settings | ✅ | D1 `deniedPermanently` mapping |
+| Friend Detail (SCR-11) loads | ✅ | after **D7 fix** (settlements list query 200) |
+
+### Phase 3 — Expenses — **core PASS** (INV1 + INV2)
+| Scenario | Result | Firebase evidence |
+|---|---|---|
+| Add equal-split expense → trigger recompute | ✅ | `amountPaise=50000`, splits 25000+25000=**exactly 50000**, source=manual, currency=INR; `onExpenseWriteFriendship` fired (259 ms) → `simplifiedBalances {B:{A:25000}}` (**INV2 trigger-only**) |
+| Two-party balance display (INV1 ₹ boundary) | ✅ | ₹250.00 — A owed / B owes, real-time both sides, Indian numbering |
+| Activity entry (FR-EX-07) | ✅ | `expense_added` for both users |
+| Custom split / receipt attach / creator-only edit-delete | **not validated** | — |
+
+---
+
+## Defect list
+
+| ID | Sev | Issue | Status | Summary |
+|---|---|---|---|---|
+| D1 | S1 | [#95](https://github.com/avtansh-code/OneByTwo/issues/95) | **Fixed + verified** | iOS launch crash — flutter_contacts 1.1.9+2 nil-unwraps `AppDelegate.window` under UISceneDelegate → bumped to `^2.2.2` + migrated `contact_service` to the 2.x API |
+| D2 | S2 | [#96](https://github.com/avtansh-code/OneByTwo/issues/96) | **Fixed + verified** | Cold-start notification deep-link never runs — `ref.read` after dispose in `NotificationsLifecycleHost` → added `mounted` guards around the post-frame callback and after the await |
+| D3 | S3 | [#97](https://github.com/avtansh-code/OneByTwo/issues/97) | **Fixed + verified** | OTP cells don't auto-clear after an invalid code (SCR-04) → `OtpInput` takes the controller-owned `digits` and clears the cells on reset via `didUpdateWidget` |
+| D4 | S1 | [#98](https://github.com/avtansh-code/OneByTwo/issues/98) | **Fixed + verified** | Add-friend hang — duplicate-check `get` on a non-existent friendship denied by rules (null error); client now treats `permission-denied` as not-exists |
+| D5 | S2 | [#99](https://github.com/avtansh-code/OneByTwo/issues/99) | **Fixed + verified** | Add-friend: no feedback/navigation after "Add as friend" → new `MatchAndInviteAdded` state; the screen pops with a confirmation snackbar |
+| D6 | S3 | [#100](https://github.com/avtansh-code/OneByTwo/issues/100) | **Fixed + verified** | Newly-added friend shows "Unknown" until relaunch → on `Added`, `ref.invalidate(userProfileProvider(otherUserId))` refreshes the cached null |
+| D7 | S2 | [#101](https://github.com/avtansh-code/OneByTwo/issues/101) | **Fixed + verified** | Friend Detail broken — settlements `watchByContext` list query denied by from/to read rule → changed to `isContextMember` |
+| D8 | S1 | [#102](https://github.com/avtansh-code/OneByTwo/issues/102) | **Fixed + verified** | Add-expense FAB context picker can't load friends — modal on the root Navigator sat outside the per-arm `ProviderScope` → hoisted the scope overrides into `MaterialApp.builder` (above the root Navigator); device-verified |
+
+**Common root cause / test gap:** unit & widget tests use fake repositories and a global
+test `ProviderScope`, so they never exercise the **real Firestore security rules**, the
+**modal provider scope**, or the **app lifecycle**. Each fix should land with a real
+emulator-rules / integration / root-Navigator test.
+
+---
+
+## In-session code changes (working tree — need PR + review)
+
+| File | Defect |
+|---|---|
+| `pubspec.yaml`, `pubspec.lock`, `ios/Podfile.lock` | D1 (flutter_contacts `^2.2.2`) |
+| `lib/features/friends/data/contact_service.dart` | D1 (2.x API migration) |
+| `lib/features/friends/data/friendship_repository.dart` | D4 (permission-denied → not-exists) |
+| `firestore.rules` | D7 (settlements read → `isContextMember`) |
+| `lib/features/notifications/presentation/notifications_lifecycle_host.dart` | D2 (`mounted` guards) |
+| `lib/features/auth/presentation/widgets/otp_input.dart`, `otp_entry_screen.dart` | D3 (controller-owned digits + clear on reset) |
+| `lib/features/friends/application/match_and_invite_controller.dart`, `presentation/match_and_invite_screen.dart` | D5 + D6 (`Added` state → pop + snackbar + profile invalidate) |
+| `lib/main.dart` | D8 (scope overrides hoisted into `MaterialApp.builder`) |
+| `test/features/auth/otp_input_test.dart`, `test/features/friends/match_and_invite_controller_test.dart`, `test/features/shell/root_navigator_scope_test.dart` | D3 / D5 / D8 regression tests |
+
+All eight fixes verified end-to-end against the emulator; `flutter analyze` clean; whole
+suite **1601 tests pass**; formatter clean; D8 additionally re-verified on device.
+
+---
+
+## Not yet validated (out of this session)
+
+- **Pass 2 — production**: real `+91` SMS OTP, real `asia-south1` functions, real FCM push,
+  Crashlytics, Analytics DebugView (incl. telemetry PII / bucketed `amount_range`).
+- **Phase 3 remainder**: custom split (INV1 exact sum), receipt attach (Storage), creator-only
+  edit/delete (#72).
+- **Phase 4** Settlements, **Phase 5** Home dashboard chart + cross-device sync, **Phase 6**
+  Activity feed deep-links, **Phase 7** Notifications (prod), **Phase 8** Profile + delete-account
+  cascade, **Phase 9** explicit invariant + security-rule probes, **Phase 10** offline / a11y /
+  perf / Crashlytics.
+
+---
+
+## QA sign-off
+
+**Verdict: all eight validation defects (D1–D8) are fixed and verified. Cleared for Sprint 3
+once the fixes land as reviewed PRs — full Pass-2 / Phase-4–10 validation remains outstanding.**
+
+- ✅ Validated: the integer-paise money model and the server-only `simplifiedBalances`
+  recompute (**INV1 + INV2**), the system-share-sheet invariant (**INV3**), and the single
+  Firebase project (**INV4**) all hold; Auth/Profile is solid; the Friends and add-expense
+  surfaces work end-to-end after fixes.
+- ✅ All eight defects (D1–D8, incl. the four S1 blockers — launch, add-friend, Friend Detail,
+  add-expense) are fixed with regression tests; `flutter analyze` clean, **1601 tests pass**,
+  formatter clean, D8 device-verified.
+- ⛔ Before Sprint 3 can be declared green:
+  1. Land the eight fixes as **reviewed PR(s)** (they are currently in the working tree) —
+     ideally with the missing **real-rules / integration / lifecycle** coverage so these
+     fake-store/test-scope regressions can't recur.
+  2. Resume the validation from **Phase 3 remainder** (custom split, receipt, creator-only
+     edit/delete) through **Phase 10**, and run **Pass 2 on production**.
+
+**Recommendation:** the recurring fake-store/test-scope gap is itself the highest-leverage
+fix — add an emulator-backed integration lane (real rules + real provider scopes) to CI so
+these classes of defect surface automatically.

--- a/firestore.rules
+++ b/firestore.rules
@@ -487,10 +487,18 @@ service cloud.firestore {
           && prev.deleted == false;
       }
 
-      // Read: either party may read.
+      // Read: any member of the parent context (friendship/group) may read.
+      // For a friendship the two context members are exactly fromUserId and
+      // toUserId, so this preserves the prior "either party" semantics while
+      // also authorising the contextId-filtered list query (watchByContext,
+      // SCR-11 Friend Detail). Per-doc and list reads both resolve through
+      // the contextType/contextId equality filters.
       allow read: if request.auth != null
-        && (request.auth.uid == resource.data.fromUserId
-            || request.auth.uid == resource.data.toUserId);
+        && isContextMember(
+          resource.data.contextType,
+          resource.data.contextId,
+          request.auth.uid
+        );
 
       // Create: caller MUST be the fromUserId (Invariant per SRS 7.5).
       allow create: if request.auth != null

--- a/functions/test/firestore-rules/settlements.test.ts
+++ b/functions/test/firestore-rules/settlements.test.ts
@@ -22,18 +22,24 @@ import {
   assertFails,
   assertSucceeds,
   initializeTestEnvironment,
+  type RulesTestContext,
   type RulesTestEnvironment,
 } from "@firebase/rules-unit-testing";
 import {readFileSync} from "fs";
 import {resolve} from "path";
 import {
+  collection,
   doc,
   setDoc,
   updateDoc,
   deleteDoc,
   getDoc,
+  getDocs,
+  orderBy,
+  query,
   serverTimestamp,
   setLogLevel,
+  where,
 } from "firebase/firestore";
 
 const PROJECT_ID = "demo-onebytwo";
@@ -233,6 +239,70 @@ describe("settlements/{sid} — read rules (AC-2)", () => {
     await assertFails(
       getDoc(doc(ctx.firestore(), `settlements/${SETTLEMENT_ID}`)),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2 — READ tests: contextId LIST query (D7 regression guard)
+//
+// SettlementRepository.watchByContext (lib/features/settlements/data/
+// settlement_repository.dart; SCR-11 Friend Detail) lists settlements with
+// `where(contextType ==) + where(contextId ==) + orderBy(date)`. The D7 fix
+// moved the read rule from `uid == fromUserId || uid == toUserId` to
+// `isContextMember(...)`, which is what authorises that contextId-filtered
+// LIST query for context members.
+//
+// The read rule references BOTH `resource.data.contextType` and
+// `resource.data.contextId`, so a list query must constrain BOTH with
+// equality filters for the rule to resolve — exactly what watchByContext
+// does. These tests exercise that list path; the single-doc getDoc tests
+// above pass unchanged even if the list-read path regresses, so without
+// these a green rules job would NOT lock in the D7 fix.
+// ---------------------------------------------------------------------------
+
+describe("settlements/{sid} — contextId list-read rules (D7)", () => {
+  /** Mirrors SettlementRepository.watchByContext for the friendship FID. */
+  function listSettlementsByContext(
+    firestore: ReturnType<RulesTestContext["firestore"]>,
+  ) {
+    return getDocs(
+      query(
+        collection(firestore, "settlements"),
+        where("contextType", "==", "friendship"),
+        where("contextId", "==", FID),
+        orderBy("date", "desc"),
+      ),
+    );
+  }
+
+  beforeEach(async () => {
+    await seedFriendship(testEnv);
+    await seedSettlement(testEnv);
+    await seedSettlement(testEnv, `${SETTLEMENT_ID}-2`);
+  });
+
+  it("allows a context member to list settlements by contextId", async () => {
+    const ctx = testEnv.authenticatedContext(memberA);
+    const snap = await assertSucceeds(
+      listSettlementsByContext(ctx.firestore()),
+    );
+    expect(snap.size).toBe(2);
+  });
+
+  it("allows the other context member to list settlements by "
+    + "contextId", async () => {
+    const ctx = testEnv.authenticatedContext(memberB);
+    await assertSucceeds(listSettlementsByContext(ctx.firestore()));
+  });
+
+  it("rejects a non-member's identical contextId list query", async () => {
+    const ctx = testEnv.authenticatedContext(outsider);
+    await assertFails(listSettlementsByContext(ctx.firestore()));
+  });
+
+  it("rejects an unauthenticated contextId list query", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    await assertFails(listSettlementsByContext(ctx.firestore()));
   });
 });
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1716,7 +1716,7 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 7c659ebf23afdc1e60a05df72a07ad7349f5758f
   FirebaseStorage: 84d86cc0c0451e56e30f235fce26a264f1de13dc
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_contacts: 5383945387e7ca37cf963d4be57c21f2fc15ca9f
+  flutter_contacts: 2ec1d6b62ca2869c3bbb3871bd74d4e3ef157135
   GoogleAdsOnDeviceConversion: 80ce443fa1b4b5750913d53a04ecda644ff57744
   GoogleAppMeasurement: 1987ffa55055dfb22c52e363c31aa50c1e11d349
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7

--- a/lib/features/auth/application/analytics_provider.dart
+++ b/lib/features/auth/application/analytics_provider.dart
@@ -12,6 +12,22 @@ abstract class AnalyticsService {
   });
 }
 
+/// Coerces analytics parameter values into Firebase-acceptable types.
+///
+/// Firebase Analytics only accepts `String` or `num` parameter values; a
+/// `bool` throws an assertion in debug builds (breaking the calling flow)
+/// and is rejected in release. This coerces any `bool` to its `String`
+/// form so semantic boolean params (e.g. `payer_is_self`, `has_receipt`)
+/// are recorded as `"true"`/`"false"` rather than crashing the caller
+/// (defect D11). All other values pass through unchanged.
+Map<String, Object>? sanitiseAnalyticsParameters(
+  Map<String, Object>? parameters,
+) {
+  return parameters?.map(
+    (key, value) => MapEntry(key, value is bool ? value.toString() : value),
+  );
+}
+
 /// Production implementation that delegates to [FirebaseAnalytics].
 class FirebaseAnalyticsService implements AnalyticsService {
   /// Creates a [FirebaseAnalyticsService] backed by the given instance.
@@ -24,7 +40,10 @@ class FirebaseAnalyticsService implements AnalyticsService {
     required String name,
     Map<String, Object>? parameters,
   }) {
-    return _analytics.logEvent(name: name, parameters: parameters);
+    return _analytics.logEvent(
+      name: name,
+      parameters: sanitiseAnalyticsParameters(parameters),
+    );
   }
 }
 

--- a/lib/features/auth/domain/user_model.dart
+++ b/lib/features/auth/domain/user_model.dart
@@ -27,11 +27,16 @@ class UserModel {
     return UserModel(
       // FR-AU-09 (D13): the account-deletion tombstone replaces the doc
       // with a PII-free shell ({displayName: "Deleted User", deletedAt}),
-      // so phoneNumber is absent. Tolerate it (default to '') instead of
-      // a hard cast that throws and makes the friend render as "Unknown"
-      // rather than the intended "Deleted User".
+      // so only `phoneNumber` is absent. Tolerate that single field
+      // (default to '') instead of a hard cast that throws and makes the
+      // friend render as "Unknown" rather than the intended "Deleted User".
+      //
+      // `displayName` keeps the non-nullable cast: both document creation
+      // (toCreateMap) and the tombstone always set it, so a doc missing it
+      // is genuinely malformed and should fail loudly rather than silently
+      // render as a blank name.
       phoneNumber: data['phoneNumber'] as String? ?? '',
-      displayName: data['displayName'] as String? ?? '',
+      displayName: data['displayName'] as String,
       photoUrl: data['photoUrl'] as String?,
       fcmTokens: List<String>.from(data['fcmTokens'] as List? ?? []),
       createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),

--- a/lib/features/auth/domain/user_model.dart
+++ b/lib/features/auth/domain/user_model.dart
@@ -25,8 +25,13 @@ class UserModel {
   factory UserModel.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
     return UserModel(
-      phoneNumber: data['phoneNumber'] as String,
-      displayName: data['displayName'] as String,
+      // FR-AU-09 (D13): the account-deletion tombstone replaces the doc
+      // with a PII-free shell ({displayName: "Deleted User", deletedAt}),
+      // so phoneNumber is absent. Tolerate it (default to '') instead of
+      // a hard cast that throws and makes the friend render as "Unknown"
+      // rather than the intended "Deleted User".
+      phoneNumber: data['phoneNumber'] as String? ?? '',
+      displayName: data['displayName'] as String? ?? '',
       photoUrl: data['photoUrl'] as String?,
       fcmTokens: List<String>.from(data['fcmTokens'] as List? ?? []),
       createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),

--- a/lib/features/auth/presentation/otp_entry_screen.dart
+++ b/lib/features/auth/presentation/otp_entry_screen.dart
@@ -75,7 +75,7 @@ class OtpEntryScreen extends ConsumerWidget {
         ),
       ),
       body: SafeArea(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 24),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/auth/presentation/otp_entry_screen.dart
+++ b/lib/features/auth/presentation/otp_entry_screen.dart
@@ -107,6 +107,7 @@ class OtpEntryScreen extends ConsumerWidget {
               ),
               const SizedBox(height: 32),
               OtpInput(
+                digits: state.digits,
                 onDigitEntered: controller.setDigit,
                 onCompleted: (_) => controller.submit(),
                 onBackspace: controller.clearDigit,

--- a/lib/features/auth/presentation/widgets/otp_input.dart
+++ b/lib/features/auth/presentation/widgets/otp_input.dart
@@ -167,37 +167,64 @@ class _OtpInputState extends State<OtpInput> {
     final theme = Theme.of(context);
     return Semantics(
       label: 'Enter 6-digit verification code',
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: List.generate(_cellCount, (index) {
-          return Padding(
-            padding: EdgeInsets.only(right: index < _cellCount - 1 ? 12 : 0),
-            child: SizedBox(
-              width: 48,
-              height: 48,
-              child: Semantics(
-                label: 'Digit ${index + 1} of $_cellCount',
-                child: TextField(
-                  controller: _controllers[index],
-                  focusNode: _focusNodes[index],
-                  keyboardType: TextInputType.number,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.titleLarge,
-                  decoration: InputDecoration(
-                    contentPadding: EdgeInsets.zero,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8),
-                      borderSide: BorderSide(color: theme.colorScheme.outline),
-                    ),
-                    counterText: '',
-                  ),
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  onChanged: (value) => _onChanged(index, value),
-                ),
-              ),
-            ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          // Responsive cell sizing: keep the 48 dp cell on phones that
+          // have room, but shrink to the available width on smaller
+          // devices (e.g. iPhone SE) so the six-cell row never overflows
+          // horizontally. The gap shrinks proportionally with the cell.
+          const maxCell = 48.0;
+          const maxGap = 12.0;
+          final available = constraints.maxWidth.isFinite
+              ? constraints.maxWidth
+              : maxCell * _cellCount + maxGap * (_cellCount - 1);
+          final gap =
+              (maxGap *
+                      (available /
+                          (maxCell * _cellCount + maxGap * (_cellCount - 1))))
+                  .clamp(4.0, maxGap);
+          final totalGap = gap * (_cellCount - 1);
+          final cell = ((available - totalGap) / _cellCount).clamp(
+            0.0,
+            maxCell,
           );
-        }),
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: List.generate(_cellCount, (index) {
+              return Padding(
+                padding: EdgeInsets.only(
+                  right: index < _cellCount - 1 ? gap : 0,
+                ),
+                child: SizedBox(
+                  width: cell,
+                  height: maxCell,
+                  child: Semantics(
+                    label: 'Digit ${index + 1} of $_cellCount',
+                    child: TextField(
+                      controller: _controllers[index],
+                      focusNode: _focusNodes[index],
+                      keyboardType: TextInputType.number,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.titleLarge,
+                      decoration: InputDecoration(
+                        contentPadding: EdgeInsets.zero,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: theme.colorScheme.outline,
+                          ),
+                        ),
+                        counterText: '',
+                      ),
+                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                      onChanged: (value) => _onChanged(index, value),
+                    ),
+                  ),
+                ),
+              );
+            }),
+          );
+        },
       ),
     );
   }

--- a/lib/features/auth/presentation/widgets/otp_input.dart
+++ b/lib/features/auth/presentation/widgets/otp_input.dart
@@ -13,8 +13,16 @@ class OtpInput extends StatefulWidget {
     required this.onDigitEntered,
     required this.onCompleted,
     required this.onBackspace,
+    this.digits,
     super.key,
   });
+
+  /// The authoritative digit values from the controller, when the caller
+  /// tracks them. When supplied and they become all-empty (e.g. the
+  /// controller resets them after an invalid code), the widget clears its own
+  /// cells so the user can retype (SCR-04). When `null`, the widget is fully
+  /// self-managed (callers that only need `onCompleted`).
+  final List<String>? digits;
 
   /// Called when a digit is entered at the given index.
   final void Function(int index, String digit) onDigitEntered;
@@ -57,6 +65,27 @@ class _OtpInputState extends State<OtpInput> {
       n.dispose();
     }
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(OtpInput oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // SCR-04 (D3): when the caller tracks digits and the controller resets
+    // every one to empty — e.g. after an invalid code — clear the visual
+    // cells and refocus the first one so the user can retype. Programmatic
+    // controller edits do not fire `onChanged`, so there is no feedback loop.
+    final tracked = widget.digits;
+    final controllerCleared =
+        tracked != null && tracked.every((d) => d.isEmpty);
+    final cellsHaveContent = _controllers.any((c) => c.text.isNotEmpty);
+    if (controllerCleared && cellsHaveContent) {
+      for (final c in _controllers) {
+        c.clear();
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _focusNodes.first.requestFocus();
+      });
+    }
   }
 
   void _onChanged(int index, String value) {

--- a/lib/features/expenses/application/add_expense_controller.dart
+++ b/lib/features/expenses/application/add_expense_controller.dart
@@ -927,36 +927,48 @@ class AddExpenseController extends StateNotifier<AddExpenseState> {
   ///
   /// No-op in create mode (the absence of an
   /// [initialExpenseId] means there is nothing to soft-delete).
-  Future<void> softDelete() async {
-    if (!isEditMode || initialExpenseId == null) return;
+  /// Soft-deletes the expense. Returns `true` when the delete succeeded
+  /// (the repository write completed), `false` on a delete error.
+  ///
+  /// The success/error [state] transition is best-effort: this is an
+  /// autoDispose+family controller, so if it is disposed during the
+  /// repository await the state is not updated — but the return value
+  /// still reflects the outcome, so the caller can navigate reliably
+  /// instead of re-reading a possibly-recreated provider state (D10).
+  Future<bool> softDelete() async {
+    if (!isEditMode || initialExpenseId == null) return false;
     final draft = _currentDraft();
-    if (draft == null) return;
+    if (draft == null) return false;
     state = Saving(draft: draft);
     try {
       await _repository.softDeleteExpense(
         friendshipId: friendshipId,
         expenseId: initialExpenseId!,
       );
-      if (!mounted) return;
+    } on ExpenseDeleteError catch (err) {
+      if (mounted) {
+        _emitDeleteFailed(err.type);
+        state = AddExpenseError(
+          draft: draft,
+          // Reuse the existing ExpenseCreateErrorType.unknown for the
+          // state-machine variant — the host widget displays the
+          // dedicated delete-failure message verbatim. The typed
+          // ExpenseDeleteErrorType already drove the telemetry payload
+          // above.
+          errorType: ExpenseCreateErrorType.unknown,
+          message: _kMsgDeleteFailure,
+        );
+      }
+      return false;
+    }
+    if (mounted) {
       _emitDeleteConfirmed(draft: draft);
       state = Success(
         expenseId: initialExpenseId!,
         action: SuccessAction.deleted,
       );
-    } on ExpenseDeleteError catch (err) {
-      if (!mounted) return;
-      _emitDeleteFailed(err.type);
-      state = AddExpenseError(
-        draft: draft,
-        // Reuse the existing ExpenseCreateErrorType.unknown for the
-        // state-machine variant — the host widget displays the
-        // dedicated delete-failure message verbatim. The typed
-        // ExpenseDeleteErrorType already drove the telemetry payload
-        // above.
-        errorType: ExpenseCreateErrorType.unknown,
-        message: _kMsgDeleteFailure,
-      );
     }
+    return true;
   }
 
   /// Returns the current draft from any non-terminal state, or null.

--- a/lib/features/expenses/presentation/expense_detail_screen.dart
+++ b/lib/features/expenses/presentation/expense_detail_screen.dart
@@ -17,6 +17,7 @@ import 'package:onebytwo/features/expenses/domain/expense_doc.dart';
 import 'package:onebytwo/features/expenses/domain/split_method.dart';
 import 'package:onebytwo/features/expenses/presentation/add_expense_bottom_sheet.dart';
 import 'package:onebytwo/features/expenses/presentation/widgets/receipt_fullscreen_viewer.dart';
+import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
 
 /// Read-only detail screen for a single expense (SCR-22).
 ///
@@ -272,7 +273,17 @@ class _ExpenseDetailBody extends ConsumerWidget {
     final dateFmt = DateFormat.yMMMd();
     final amount = formatInrFromPaise(doc.amountPaise);
     final isMyExpense = doc.payerId == currentUserUid;
-    final payerLabel = isMyExpense ? 'You' : 'Friend';
+    // Resolve the other participant's display name; the friends-list
+    // listener keeps userProfileProvider warm so this is an instant
+    // cache read in practice. Falls back to "Friend" while loading or if
+    // the profile cannot be resolved (e.g. deleted account).
+    final friendName = ref
+        .watch(userProfileProvider(otherUserUid))
+        .maybeWhen(
+          data: (profile) => profile?.displayName ?? 'Friend',
+          orElse: () => 'Friend',
+        );
+    final payerLabel = isMyExpense ? 'You' : friendName;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -316,7 +327,7 @@ class _ExpenseDetailBody extends ConsumerWidget {
           const SizedBox(height: 8),
           for (final split in doc.splits)
             _DetailRow(
-              label: split.userId == currentUserUid ? 'You' : 'Friend',
+              label: split.userId == currentUserUid ? 'You' : friendName,
               value: formatInrFromPaise(split.sharePaise),
             ),
           // FR-EX-05: receipt thumbnail when present.

--- a/lib/features/expenses/presentation/expense_detail_screen.dart
+++ b/lib/features/expenses/presentation/expense_detail_screen.dart
@@ -192,17 +192,19 @@ class _ExpenseDetailScreenState extends ConsumerState<ExpenseDetailScreen> {
       initialExpenseId: widget.expenseId,
     );
     final controller = ref.read(addExpenseControllerProvider(args).notifier);
-    await controller.softDelete();
+    final deleted = await controller.softDelete();
     if (!mounted) return;
-    final state = ref.read(addExpenseControllerProvider(args));
     final messenger = ScaffoldMessenger.maybeOf(context);
-    if (state is Success && state.action == SuccessAction.deleted) {
+    if (deleted) {
       messenger?.showSnackBar(
         const SnackBar(content: Text('Expense deleted.')),
       );
       await Navigator.of(context).maybePop();
-    } else if (state is AddExpenseError) {
-      messenger?.showSnackBar(SnackBar(content: Text(state.message)));
+    } else {
+      final state = ref.read(addExpenseControllerProvider(args));
+      if (state is AddExpenseError) {
+        messenger?.showSnackBar(SnackBar(content: Text(state.message)));
+      }
     }
   }
 }

--- a/lib/features/friends/application/match_and_invite_controller.dart
+++ b/lib/features/friends/application/match_and_invite_controller.dart
@@ -85,6 +85,26 @@ class MatchAndInviteDuplicateFriendship extends MatchAndInviteState {
   final String existingFriendshipId;
 }
 
+/// The friendship was created successfully (D5: drives confirmation +
+/// navigation; D6: drives the friend-profile cache refresh).
+class MatchAndInviteAdded extends MatchAndInviteState {
+  /// Creates a [MatchAndInviteAdded].
+  const MatchAndInviteAdded({
+    required this.friendshipId,
+    required this.otherUserId,
+    required this.displayName,
+  });
+
+  /// The created friendship's deterministic ID.
+  final String friendshipId;
+
+  /// The added friend's UID.
+  final String otherUserId;
+
+  /// The added friend's display name (for the confirmation message).
+  final String displayName;
+}
+
 // ---------------------------------------------------------------------------
 // Controller
 // ---------------------------------------------------------------------------
@@ -198,10 +218,12 @@ class MatchAndInviteController extends StateNotifier<MatchAndInviteState> {
     if (currentState is! MatchAndInviteMatchFound) return;
 
     try {
-      await _friendshipRepository.createFriendship(
-        _currentUserId,
-        currentState.otherUserId,
-      );
+      final friendshipId =
+          await _friendshipRepository.createFriendship(
+                _currentUserId,
+                currentState.otherUserId,
+              )
+              as String;
       // T4: segment the acquisition funnel by entry path. The method
       // rides on the contact captured during performLookup; it is a
       // non-identifying enum token, never PII.
@@ -209,6 +231,13 @@ class MatchAndInviteController extends StateNotifier<MatchAndInviteState> {
       await _analyticsService.logEvent(
         name: 'friend_added',
         parameters: {'method': method.wireName},
+      );
+      // D5: emit a success state so the screen can confirm + navigate
+      // (previously the state stayed MatchFound and the UI did nothing).
+      state = MatchAndInviteAdded(
+        friendshipId: friendshipId,
+        otherUserId: currentState.otherUserId,
+        displayName: currentState.displayName,
       );
     } on Exception {
       state = const MatchAndInviteError(message: 'Something went wrong');

--- a/lib/features/friends/data/contact_service.dart
+++ b/lib/features/friends/data/contact_service.dart
@@ -55,27 +55,29 @@ class FlutterContactService implements ContactService {
 
   @override
   Future<ContactPermissionState> checkPermission() async {
-    final granted = await fc.FlutterContacts.requestPermission();
-    return granted
-        ? ContactPermissionState.granted
-        : ContactPermissionState.denied;
+    final status = await fc.FlutterContacts.permissions.check(
+      fc.PermissionType.read,
+    );
+    return _mapPermissionStatus(status);
   }
 
   @override
   Future<ContactPermissionState> requestPermission() async {
-    final granted = await fc.FlutterContacts.requestPermission();
-    return granted
-        ? ContactPermissionState.granted
-        : ContactPermissionState.denied;
+    final status = await fc.FlutterContacts.permissions.request(
+      fc.PermissionType.read,
+    );
+    return _mapPermissionStatus(status);
   }
 
   @override
   Future<List<DeviceContact>> getContacts() async {
-    final contacts = await fc.FlutterContacts.getContacts(withProperties: true);
+    final contacts = await fc.FlutterContacts.getAll(
+      properties: fc.ContactProperties.allProperties,
+    );
     return contacts
         .map(
           (c) => DeviceContact(
-            displayName: c.displayName,
+            displayName: c.displayName ?? '',
             phoneNumbers: c.phones.map((p) => p.number).toList(),
           ),
         )
@@ -84,6 +86,26 @@ class FlutterContactService implements ContactService {
 
   @override
   Future<void> openSettings() => _appSettings.openAppSettings();
+}
+
+/// Maps the `flutter_contacts` 2.x [fc.PermissionStatus] to the app's
+/// [ContactPermissionState].
+///
+/// `limited` (iOS 18+ partial access) counts as granted; `permanentlyDenied`
+/// and `restricted` drive the SCR-10 "Open Settings" CTA.
+ContactPermissionState _mapPermissionStatus(fc.PermissionStatus status) {
+  switch (status) {
+    case fc.PermissionStatus.granted:
+    case fc.PermissionStatus.limited:
+      return ContactPermissionState.granted;
+    case fc.PermissionStatus.denied:
+      return ContactPermissionState.denied;
+    case fc.PermissionStatus.permanentlyDenied:
+    case fc.PermissionStatus.restricted:
+      return ContactPermissionState.deniedPermanently;
+    case fc.PermissionStatus.notDetermined:
+      return ContactPermissionState.notDetermined;
+  }
 }
 
 /// Provides a [ContactService] instance.

--- a/lib/features/friends/data/friendship_repository.dart
+++ b/lib/features/friends/data/friendship_repository.dart
@@ -15,8 +15,23 @@ abstract class FriendshipStore {
   /// Writes [data] to the document at [path].
   Future<void> set(String path, Map<String, dynamic> data);
 
-  /// Returns whether a document exists at [path].
-  Future<bool> exists(String path);
+  /// Returns whether a friendship document [friendshipId] exists and
+  /// includes [memberId] in its `memberIds`. [memberId] must be the
+  /// authenticated caller's UID.
+  ///
+  /// Implemented as a membership query (`memberIds array-contains
+  /// memberId`) resolved from the locally-cached snapshot, never a `get`
+  /// of [friendshipId]. A `get` of the deterministic document is the
+  /// wrong tool here for two reasons (defect D9):
+  ///  - For a non-existent friendship the rules deny the `get` (Null
+  ///    value error on `resource.data.memberIds`); the mobile SDK does
+  ///    not fail-fast on that denial.
+  ///  - Against the Firestore emulator on the iOS simulator a one-shot
+  ///    server `get` stalls ~90s, whereas the cached membership query
+  ///    resolves in ~2ms.
+  /// The membership query is always allowed for the caller's own
+  /// friendships and returns an accurate empty result when none exists.
+  Future<bool> existsForMember(String memberId, String friendshipId);
 
   /// Returns the document data at [path], or null if it does not exist.
   Future<Map<String, dynamic>?> get(String path);
@@ -95,22 +110,22 @@ class FirestoreFriendshipStore implements FriendshipStore {
   }
 
   @override
-  Future<bool> exists(String path) async {
-    try {
-      final snapshot = await _collection.doc(path).get();
-      return snapshot.exists;
-    } on FirebaseException catch (e) {
-      // The friendships read rule checks `request.auth.uid in
-      // resource.data.memberIds`, which raises a Null value error for a
-      // document that does not exist, so the rules deny a `get` of a
-      // non-existent friendship. A member can always read an existing
-      // friendship, so a permission-denied here means the friendship does
-      // not exist yet — treat it as not-a-duplicate. This keeps the read
-      // rule strict (no social-graph enumeration) while unblocking the
-      // add-friend duplicate check.
-      if (e.code == 'permission-denied') return false;
-      rethrow;
-    }
+  Future<bool> existsForMember(String memberId, String friendshipId) async {
+    // Membership query over the caller's own friendships — always allowed
+    // by the rules. Resolved via a one-shot listener (`.snapshots().first`)
+    // rather than `.get()`:
+    //  - The local cache is kept fresh by the always-on friends-list
+    //    listener (`watchByMember`), so the first snapshot is an accurate,
+    //    instant read of the caller's current friendships (and is
+    //    offline-resilient).
+    //  - It avoids a redundant server `.get()` round-trip, which against
+    //    the Firestore emulator on the iOS simulator stalls ~90s for a
+    //    one-shot server fetch (defect D9), versus ~2ms for the listener.
+    final snapshot = await _collection
+        .where('memberIds', arrayContains: memberId)
+        .snapshots()
+        .first;
+    return snapshot.docs.any((doc) => doc.id == friendshipId);
   }
 
   @override
@@ -189,10 +204,16 @@ class FriendshipRepository {
   }
 
   /// Returns whether a friendship exists between the two users.
+  ///
+  /// [userId1] must be the authenticated caller's UID: existence is
+  /// resolved via a membership query over the caller's own friendships
+  /// (see [FriendshipStore.existsForMember]), never a `get` of the
+  /// deterministic document (which the rules deny for a non-existent
+  /// friendship, hanging the mobile SDK for ~2 minutes — defect D9).
   Future<bool> friendshipExists(String userId1, String userId2) async {
     final sorted = [userId1, userId2]..sort();
     final friendshipId = '${sorted[0]}_${sorted[1]}';
-    return _store.exists(friendshipId);
+    return _store.existsForMember(userId1, friendshipId);
   }
 
   /// Watches all friendships the given user is a member of, ordered

--- a/lib/features/friends/data/friendship_repository.dart
+++ b/lib/features/friends/data/friendship_repository.dart
@@ -96,8 +96,21 @@ class FirestoreFriendshipStore implements FriendshipStore {
 
   @override
   Future<bool> exists(String path) async {
-    final snapshot = await _collection.doc(path).get();
-    return snapshot.exists;
+    try {
+      final snapshot = await _collection.doc(path).get();
+      return snapshot.exists;
+    } on FirebaseException catch (e) {
+      // The friendships read rule checks `request.auth.uid in
+      // resource.data.memberIds`, which raises a Null value error for a
+      // document that does not exist, so the rules deny a `get` of a
+      // non-existent friendship. A member can always read an existing
+      // friendship, so a permission-denied here means the friendship does
+      // not exist yet — treat it as not-a-duplicate. This keeps the read
+      // rule strict (no social-graph enumeration) while unblocking the
+      // add-friend duplicate check.
+      if (e.code == 'permission-denied') return false;
+      rethrow;
+    }
   }
 
   @override

--- a/lib/features/friends/presentation/match_and_invite_screen.dart
+++ b/lib/features/friends/presentation/match_and_invite_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:onebytwo/features/friends/application/match_and_invite_controller.dart';
+import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
 
 /// Screen that displays the match-and-invite flow after a contact
 /// has been selected from the device picker.
@@ -13,6 +14,25 @@ class MatchAndInviteScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(matchAndInviteControllerProvider);
     final controller = ref.read(matchAndInviteControllerProvider.notifier);
+
+    ref.listen<MatchAndInviteState>(matchAndInviteControllerProvider, (
+      previous,
+      next,
+    ) {
+      if (next is MatchAndInviteAdded) {
+        // D6: refresh the just-added friend's cached profile so the friends
+        // list resolves their display name immediately (no relaunch).
+        ref.invalidate(userProfileProvider(next.otherUserId));
+        // D5: confirm the add and return to the previous screen (the friends
+        // list / caller), where the new friend now appears.
+        final messenger = ScaffoldMessenger.of(context);
+        final name = next.displayName;
+        Navigator.of(context).pop();
+        messenger.showSnackBar(
+          SnackBar(content: Text('$name added as a friend')),
+        );
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(title: const Text('Add Friend')),
@@ -29,6 +49,9 @@ class MatchAndInviteScreen extends ConsumerWidget {
               photoUrl: photoUrl,
               onAddFriend: controller.addFriend,
             ),
+          MatchAndInviteAdded() => const Center(
+            child: CircularProgressIndicator(),
+          ),
           MatchAndInviteNoMatch(:final contactDisplayName) => _NoMatchCard(
             contactDisplayName: contactDisplayName,
             onSendInvite: controller.openInviteShareSheet,

--- a/lib/features/notifications/presentation/notifications_lifecycle_host.dart
+++ b/lib/features/notifications/presentation/notifications_lifecycle_host.dart
@@ -63,6 +63,10 @@ class _NotificationsLifecycleHostState
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      // D2: this host is recreated when the MaterialApp key changes on an
+      // auth-state transition, so the disposed instance's callback must not
+      // touch `ref`. The freshly-mounted instance runs cold-start handling.
+      if (!mounted) return;
       _subscribeFcmStreams();
       _handleColdStart();
     });
@@ -91,6 +95,7 @@ class _NotificationsLifecycleHostState
     try {
       final messaging = ref.read(firebaseMessagingProvider);
       final initial = await messaging.getInitialMessage();
+      if (!mounted) return;
       if (initial == null) return;
       final payload = NotificationPayload.fromFcmDataMap(initial.data);
       if (payload == null) return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -166,23 +166,32 @@ class OneBytwoApp extends ConsumerWidget {
         AuthUnauthenticated() => const PhoneEntryScreen(),
         AuthenticatedNoProfile(:final uid, :final phoneNumber) =>
           ProfileSetupScreen(uid: uid, phoneNumber: phoneNumber ?? ''),
-        // Per-arm ProviderScope binds `currentUserIdProvider` and
-        // `currentUserPhoneProvider` to the signed-in identity for the
-        // lifetime of the AuthenticatedShell subtree. The overrides are
-        // dropped automatically on sign-out when the auth state
-        // transitions away from `AuthenticatedWithProfile`. See
-        // `docs/sprint-zero/stories/FR-HD-04-persistent-fab-and-context-picker.md`
-        // Architect Notes §2.1.
-        AuthenticatedWithProfile(:final uid, :final user) => ProviderScope(
-          overrides: [
-            currentUserIdProvider.overrideWithValue(uid),
-            currentUserPhoneProvider.overrideWithValue(user.phoneNumber),
-          ],
-          child: const AuthenticatedShell(),
-        ),
+        // The per-arm currentUserId / currentUserPhone overrides are applied
+        // in MaterialApp.builder (ABOVE the root Navigator), not here, so that
+        // root-Navigator modals (e.g. the add-expense context picker) inherit
+        // the scope (D8 / FR-HD-04). See `scopeOverrides` below.
+        AuthenticatedWithProfile() => const AuthenticatedShell(),
       },
       loading: () => const SplashScreen(),
       error: (_, __) => const SplashScreen(),
+    );
+
+    // D8 / FR-HD-04: bind `currentUserIdProvider` and `currentUserPhoneProvider`
+    // for the authenticated session ABOVE the root Navigator (applied in the
+    // builder below), so root-Navigator modals — notably the add-expense
+    // context picker — inherit the scope rather than reading the unscoped
+    // providers (which throw). The overrides are dropped automatically on
+    // sign-out when the auth state leaves `AuthenticatedWithProfile`.
+    final scopeOverrides = authState.maybeWhen<List<Override>>(
+      data: (state) => state is AuthenticatedWithProfile
+          ? [
+              currentUserIdProvider.overrideWithValue(state.uid),
+              currentUserPhoneProvider.overrideWithValue(
+                state.user.phoneNumber,
+              ),
+            ]
+          : const [],
+      orElse: () => const [],
     );
 
     return MaterialApp(
@@ -193,9 +202,11 @@ class OneBytwoApp extends ConsumerWidget {
       darkTheme: AppTheme.dark,
       home: home,
       builder: (context, child) {
-        return NotificationsLifecycleHost(
-          child: child ?? const SizedBox.shrink(),
-        );
+        final content = child ?? const SizedBox.shrink();
+        final scoped = scopeOverrides.isEmpty
+            ? content
+            : ProviderScope(overrides: scopeOverrides, child: content);
+        return NotificationsLifecycleHost(child: scoped);
       },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,10 +618,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      sha256: c2591314166678adab23ef02a0ab3b4d4da71071dc03519de3dc059982dcfef2
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.9+2"
+    version: "2.2.2"
   flutter_localizations:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   fl_chart: ^1.2.0 # Donut chart for the FR-HD-03 monthly category breakdown (pure-Dart; no native pod)
   flutter:
     sdk: flutter
-  flutter_contacts: ^1.1.9+2 # Device contacts for add-friend flow (ADR-0013)
+  flutter_contacts: ^2.2.2 # Device contacts for add-friend flow (ADR-0013); 2.2.x targets Flutter 3.44+/UISceneDelegate
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.6.1 # State management (ADR-0004)

--- a/test/features/auth/application/analytics_provider_test.dart
+++ b/test/features/auth/application/analytics_provider_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+
+void main() {
+  group('sanitiseAnalyticsParameters (D11)', () {
+    test('coerces bool values to "true"/"false" strings', () {
+      final result = sanitiseAnalyticsParameters(<String, Object>{
+        'payer_is_self': true,
+        'has_receipt': false,
+        'has_notes': false,
+        'is_offline': false,
+      });
+
+      expect(result, <String, Object>{
+        'payer_is_self': 'true',
+        'has_receipt': 'false',
+        'has_notes': 'false',
+        'is_offline': 'false',
+      });
+    });
+
+    test('passes String and num values through unchanged', () {
+      final result = sanitiseAnalyticsParameters(<String, Object>{
+        'amount_range': '500_5000',
+        'participant_count': 2,
+        'receipt_size_bytes': 12345,
+      });
+
+      expect(result, <String, Object>{
+        'amount_range': '500_5000',
+        'participant_count': 2,
+        'receipt_size_bytes': 12345,
+      });
+    });
+
+    test('handles a mixed map without throwing (no String||num assertion)', () {
+      final result = sanitiseAnalyticsParameters(<String, Object>{
+        'context_type': 'friend',
+        'payer_is_self': true,
+        'participant_count': 2,
+      });
+
+      // Every value must now be String or num — the contract Firebase
+      // Analytics asserts on.
+      for (final value in result!.values) {
+        expect(value is String || value is num, isTrue);
+      }
+    });
+
+    test('returns null for null input', () {
+      expect(sanitiseAnalyticsParameters(null), isNull);
+    });
+  });
+}

--- a/test/features/auth/domain/user_model_test.dart
+++ b/test/features/auth/domain/user_model_test.dart
@@ -1,0 +1,68 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/features/auth/domain/user_model.dart';
+
+// ignore_for_file: subtype_of_sealed_class
+
+/// Minimal fake [DocumentSnapshot] that returns a fixed data map, so
+/// [UserModel.fromFirestore] can be exercised without Firebase.
+class _FakeDocumentSnapshot implements DocumentSnapshot<Map<String, dynamic>> {
+  _FakeDocumentSnapshot(this._data);
+
+  final Map<String, dynamic> _data;
+
+  @override
+  Map<String, dynamic>? data() => _data;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('UserModel.fromFirestore', () {
+    test('parses a full user document', () {
+      final snapshot = _FakeDocumentSnapshot(<String, dynamic>{
+        'phoneNumber': '+919876543210',
+        'displayName': 'User One',
+        'photoUrl': 'https://example.com/a.jpg',
+        'fcmTokens': <String>['tok'],
+        'createdAt': Timestamp.fromDate(DateTime.utc(2026)),
+        'updatedAt': Timestamp.fromDate(DateTime.utc(2026)),
+        'notificationPrefs': <String, dynamic>{
+          'newExpense': true,
+          'settlement': true,
+          'reminder': false,
+        },
+        'locale': 'en-IN',
+      });
+
+      final model = UserModel.fromFirestore(snapshot);
+
+      expect(model.phoneNumber, '+919876543210');
+      expect(model.displayName, 'User One');
+      expect(model.photoUrl, 'https://example.com/a.jpg');
+      expect(model.locale, 'en-IN');
+    });
+
+    test('D13: tolerates the PII-free account-deletion tombstone '
+        '(no phoneNumber) and surfaces "Deleted User"', () {
+      // FR-AU-09 tombstone shape: users/{uid} replaced with only
+      // {displayName: "Deleted User", deletedAt}. The non-nullable
+      // phoneNumber cast previously threw, making the friend render as
+      // "Unknown" instead of "Deleted User".
+      final snapshot = _FakeDocumentSnapshot(<String, dynamic>{
+        'displayName': 'Deleted User',
+        'deletedAt': Timestamp.fromDate(DateTime.utc(2026)),
+      });
+
+      final model = UserModel.fromFirestore(snapshot);
+
+      expect(model.displayName, 'Deleted User');
+      expect(model.phoneNumber, '');
+      expect(model.photoUrl, isNull);
+      // Defaults still apply for the stripped fields.
+      expect(model.locale, 'en-IN');
+      expect(model.fcmTokens, isEmpty);
+    });
+  });
+}

--- a/test/features/auth/otp_input_test.dart
+++ b/test/features/auth/otp_input_test.dart
@@ -13,10 +13,11 @@ void main() {
       onCompletedCalled = false;
     });
 
-    Widget buildSubject() {
+    Widget buildSubject({List<String>? digits}) {
       return MaterialApp(
         home: Scaffold(
           body: OtpInput(
+            digits: digits,
             onDigitEntered: (index, digit) {
               capturedDigits[index] = digit;
             },
@@ -114,6 +115,25 @@ void main() {
       for (var i = 0; i < 6; i++) {
         expect(find.bySemanticsLabel('Digit ${i + 1} of 6'), findsOneWidget);
       }
+    });
+
+    testWidgets('clears its cells when the controller resets digits to empty '
+        '(SCR-04 invalid-code retry)', (tester) async {
+      // Cells populated; the controller mirrors a filled state.
+      await tester.pumpWidget(buildSubject(digits: ['1', '', '', '', '', '']));
+      final textFields = find.byType(TextField);
+      await tester.enterText(textFields.at(0), '1');
+      await tester.pump();
+      expect(tester.widget<TextField>(textFields.at(0)).controller!.text, '1');
+
+      // Invalid code -> the controller resets all digits to empty -> the
+      // widget must clear its visual cells so the user can retype.
+      await tester.pumpWidget(buildSubject(digits: List.filled(6, '')));
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(textFields.at(0)).controller!.text,
+        isEmpty,
+      );
     });
 
     testWidgets('OTP input group has correct semantic label', (tester) async {

--- a/test/features/auth/otp_input_test.dart
+++ b/test/features/auth/otp_input_test.dart
@@ -40,6 +40,37 @@ void main() {
       expect(textFields, findsNWidgets(6));
     });
 
+    testWidgets('does not overflow horizontally on a small (320 dp) viewport', (
+      tester,
+    ) async {
+      // iPhone SE-class width: the six fixed 48 dp cells + gaps would
+      // exceed the screen, so the row must shrink responsively (no
+      // RenderFlex overflow). Regression for the Phase-10 a11y finding.
+      tester.view.physicalSize = const Size(320, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Padding(
+              // Mirror the OTP screen's horizontal padding.
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: OtpInput(
+                onDigitEntered: (_, _) {},
+                onCompleted: (_) {},
+                onBackspace: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(TextField), findsNWidgets(6));
+    });
+
     testWidgets('typing a digit moves focus to the next cell', (tester) async {
       await tester.pumpWidget(buildSubject());
 

--- a/test/features/expenses/add_expense_controller_test.dart
+++ b/test/features/expenses/add_expense_controller_test.dart
@@ -1036,7 +1036,10 @@ void main() {
     test('softDelete() calls ExpenseRepository.softDeleteExpense and '
         'transitions to Success(action: deleted)', () async {
       final controller = buildEditController();
-      await controller.softDelete();
+      final deleted = await controller.softDelete();
+      // D10: the return value drives the caller's navigation, independent
+      // of the (autoDispose) state.
+      expect(deleted, isTrue);
       expect(repo.deleteCalled, isTrue);
       expect(repo.deletedFriendshipId, _friendshipId);
       expect(repo.deletedExpenseId, initialId);
@@ -1065,7 +1068,8 @@ void main() {
         type: ExpenseDeleteErrorType.permissionDenied,
       );
       final controller = buildEditController();
-      await controller.softDelete();
+      final deleted = await controller.softDelete();
+      expect(deleted, isFalse); // D10: error returns false
       final s = controller.state;
       expect(s, isA<AddExpenseError>());
       expect(analytics.hasEvent(ExpenseTelemetry.deleteFailed), isTrue);
@@ -1078,7 +1082,8 @@ void main() {
       'softDelete() is a no-op in create mode (no initialExpenseId)',
       () async {
         final controller = buildController(repo: repo, analytics: analytics);
-        await controller.softDelete();
+        final deleted = await controller.softDelete();
+        expect(deleted, isFalse); // D10: no-op returns false
         expect(repo.deleteCalled, isFalse);
         controller.dispose();
       },

--- a/test/features/expenses/expense_detail_screen_widget_test.dart
+++ b/test/features/expenses/expense_detail_screen_widget_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:onebytwo/core/services/image_picker_service.dart';
 import 'package:onebytwo/core/widgets/dialogs/obt_confirmation_dialog.dart';
 import 'package:onebytwo/features/auth/application/analytics_provider.dart';
+import 'package:onebytwo/features/auth/domain/user_model.dart';
 import 'package:onebytwo/features/expenses/application/expense_detail_provider.dart';
 import 'package:onebytwo/features/expenses/application/expense_telemetry.dart';
 import 'package:onebytwo/features/expenses/data/expense_repository.dart';
@@ -27,6 +28,7 @@ import 'package:onebytwo/features/expenses/domain/expense_category.dart';
 import 'package:onebytwo/features/expenses/domain/expense_doc.dart';
 import 'package:onebytwo/features/expenses/domain/split_method.dart';
 import 'package:onebytwo/features/expenses/presentation/expense_detail_screen.dart';
+import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
 
 import 'helpers/fake_services.dart';
 
@@ -150,6 +152,7 @@ Widget _buildHost({
   required FakeExpenseRepository repo,
   required FakeAnalyticsService analytics,
   required Override detailOverride,
+  List<Override> extraOverrides = const [],
 }) {
   return ProviderScope(
     overrides: [
@@ -160,6 +163,7 @@ Widget _buildHost({
       ),
       imagePickerServiceProvider.overrideWithValue(FakeImagePickerService()),
       detailOverride,
+      ...extraOverrides,
     ],
     child: const MaterialApp(
       home: ExpenseDetailScreen(
@@ -254,6 +258,37 @@ void main() {
       expect(find.text('Group dinner'), findsOneWidget);
       expect(find.text('₹500.00'), findsOneWidget);
     });
+
+    testWidgets(
+      'resolves the friend display name (not "Friend") in paid-by/split rows',
+      (tester) async {
+        final friend = UserModel(
+          phoneNumber: '+919988776655',
+          displayName: 'Bob',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        );
+        await tester.pumpWidget(
+          _buildHost(
+            repo: repo,
+            analytics: analytics,
+            detailOverride: expenseDetailProvider.overrideWith(
+              (ref, args) async => _buildExpense(),
+            ),
+            extraOverrides: [
+              userProfileProvider(
+                _friendUid,
+              ).overrideWith((ref) async => friend),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+        // The friend's split row shows the resolved name, never the
+        // generic "Friend" placeholder.
+        expect(find.text('Bob'), findsWidgets);
+        expect(find.text('Friend'), findsNothing);
+      },
+    );
   });
 
   group('ExpenseDetailScreen — AppBar actions visibility', () {

--- a/test/features/friends/add_friend_flow_e2e_test.dart
+++ b/test/features/friends/add_friend_flow_e2e_test.dart
@@ -74,7 +74,12 @@ class RecordingFriendshipStore implements FriendshipStore {
   }
 
   @override
-  Future<bool> exists(String path) async => false;
+  Future<bool> existsForMember(String memberId, String friendshipId) async {
+    final data = documents[friendshipId];
+    if (data == null) return false;
+    final members = (data['memberIds'] as List?)?.cast<String>() ?? const [];
+    return members.contains(memberId);
+  }
 
   @override
   Future<Map<String, dynamic>?> get(String path) async => documents[path];

--- a/test/features/friends/friend_detail_provider_test.dart
+++ b/test/features/friends/friend_detail_provider_test.dart
@@ -48,7 +48,12 @@ class FakeFriendshipStore implements FriendshipStore {
   }
 
   @override
-  Future<bool> exists(String path) async => documents.containsKey(path);
+  Future<bool> existsForMember(String memberId, String friendshipId) async {
+    final data = documents[friendshipId];
+    if (data == null) return false;
+    final members = (data['memberIds'] as List?)?.cast<String>() ?? const [];
+    return members.contains(memberId);
+  }
 
   @override
   Future<Map<String, dynamic>?> get(String path) async => documents[path];

--- a/test/features/friends/friendship_repository_test.dart
+++ b/test/features/friends/friendship_repository_test.dart
@@ -34,8 +34,11 @@ class FakeFriendshipStore implements FriendshipStore {
   }
 
   @override
-  Future<bool> exists(String path) async {
-    return documents.containsKey(path);
+  Future<bool> existsForMember(String memberId, String friendshipId) async {
+    final data = documents[friendshipId];
+    if (data == null) return false;
+    final members = (data['memberIds'] as List?)?.cast<String>() ?? const [];
+    return members.contains(memberId);
   }
 
   @override

--- a/test/features/friends/friendship_repository_watch_test.dart
+++ b/test/features/friends/friendship_repository_watch_test.dart
@@ -39,7 +39,12 @@ class FakeFriendshipStore implements FriendshipStore {
   }
 
   @override
-  Future<bool> exists(String path) async => documents.containsKey(path);
+  Future<bool> existsForMember(String memberId, String friendshipId) async {
+    final data = documents[friendshipId];
+    if (data == null) return false;
+    final members = (data['memberIds'] as List?)?.cast<String>() ?? const [];
+    return members.contains(memberId);
+  }
 
   @override
   Future<Map<String, dynamic>?> get(String path) async => documents[path];

--- a/test/features/friends/match_and_invite_boundary_contract_test.dart
+++ b/test/features/friends/match_and_invite_boundary_contract_test.dart
@@ -41,7 +41,8 @@ class BoundaryCapturingStore implements FriendshipStore {
   }
 
   @override
-  Future<bool> exists(String path) async => false;
+  Future<bool> existsForMember(String memberId, String friendshipId) async =>
+      false;
 
   @override
   Future<Map<String, dynamic>?> get(String path) async => null;

--- a/test/features/friends/match_and_invite_controller_test.dart
+++ b/test/features/friends/match_and_invite_controller_test.dart
@@ -362,6 +362,24 @@ void main() {
 
       expect(controller.state, isA<MatchAndInviteError>());
     });
+
+    test('emits Added with the friend identity on success (D5)', () async {
+      fakeMatchingRepo.lookupResult = const Matched(
+        displayName: 'Priya Sharma',
+        photoUrl: null,
+        otherUserId: 'uid-xyz',
+      );
+
+      await controller.performLookup(_testContact);
+      await controller.addFriend();
+
+      final added = controller.state;
+      expect(added, isA<MatchAndInviteAdded>());
+      added as MatchAndInviteAdded;
+      expect(added.otherUserId, 'uid-xyz');
+      expect(added.displayName, 'Priya Sharma');
+      expect(added.friendshipId, isNotEmpty);
+    });
   });
 
   group('MatchAndInviteController.openInviteShareSheet', () {

--- a/test/features/friends/match_and_invite_screen_test.dart
+++ b/test/features/friends/match_and_invite_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:onebytwo/features/friends/application/match_and_invite_controller.dart';
+import 'package:onebytwo/features/friends/application/user_profile_provider.dart';
 import 'package:onebytwo/features/friends/presentation/match_and_invite_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -244,5 +245,95 @@ void main() {
 
       expect(controller.performLookupCalled, isTrue);
     });
+
+    testWidgets(
+      'Added state pops the route, shows the confirmation snackbar, and '
+      'invalidates the added friend profile cache (D5/D6)',
+      (tester) async {
+        final controller = FakeMatchAndInviteController(
+          const MatchAndInviteMatchFound(
+            displayName: 'Priya Sharma',
+            photoUrl: null,
+            otherUserId: 'uid-xyz',
+          ),
+        );
+
+        // Counts how many times the added friend's profile is resolved.
+        // The screen's `ref.invalidate(userProfileProvider('uid-xyz'))`
+        // disposes the cached value; the persistent Home consumer below
+        // re-watches it, so a successful invalidation produces a second
+        // resolve (D6).
+        var profileResolveCount = 0;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              matchAndInviteControllerProvider.overrideWith((_) => controller),
+              userProfileProvider('uid-xyz').overrideWith((ref) async {
+                profileResolveCount++;
+                return null;
+              }),
+            ],
+            child: MaterialApp(
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Text('Home'),
+                      // Keeps userProfileProvider('uid-xyz') alive so an
+                      // invalidate triggers an observable refetch.
+                      Consumer(
+                        builder: (context, ref, _) {
+                          ref.watch(userProfileProvider('uid-xyz'));
+                          return const SizedBox.shrink();
+                        },
+                      ),
+                      ElevatedButton(
+                        onPressed: () => Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) => const MatchAndInviteScreen(),
+                          ),
+                        ),
+                        child: const Text('Open'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        // The match-and-invite screen is on top of Home.
+        expect(find.text('Add Friend'), findsOneWidget);
+
+        final resolvesBeforeAdd = profileResolveCount;
+
+        // Drive the success transition the screen listens for.
+        controller.setState(
+          const MatchAndInviteAdded(
+            friendshipId: 'uid-aaa_uid-xyz',
+            otherUserId: 'uid-xyz',
+            displayName: 'Priya Sharma',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // D5: the route popped back to Home.
+        expect(find.text('Add Friend'), findsNothing);
+        expect(find.text('Home'), findsOneWidget);
+
+        // D5: a confirmation snackbar names the new friend.
+        expect(find.text('Priya Sharma added as a friend'), findsOneWidget);
+
+        // D6: the added friend's cached profile was invalidated, forcing a
+        // fresh resolve so the friends list shows their name immediately.
+        expect(profileResolveCount, greaterThan(resolvesBeforeAdd));
+      },
+    );
   });
 }

--- a/test/features/shell/root_navigator_scope_test.dart
+++ b/test/features/shell/root_navigator_scope_test.dart
@@ -1,0 +1,81 @@
+// D8 regression: a `ProviderScope` applied via `MaterialApp.builder` (which
+// wraps the root Navigator) must be inherited by modals pushed on the root
+// Navigator — e.g. the add-expense context picker.
+//
+// Before the fix the per-arm scope lived inside `MaterialApp.home`, below the
+// root Navigator, so a root-Navigator modal could not see it and
+// `currentUserIdProvider` threw `UnimplementedError`, surfacing as
+// "Something went wrong loading your friends" in the picker (issue #102).
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:onebytwo/features/friends/application/friends_list_provider.dart';
+
+void main() {
+  testWidgets(
+    'a modal on the root Navigator inherits a builder-applied ProviderScope '
+    'override of currentUserIdProvider (D8)',
+    (tester) async {
+      late BuildContext navContext;
+
+      await tester.pumpWidget(
+        // The root scope intentionally does NOT override
+        // `currentUserIdProvider` — mirroring the production root
+        // `ProviderScope`, where the unscoped provider throws.
+        ProviderScope(
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) {
+                navContext = context;
+                return const Scaffold();
+              },
+            ),
+            // Production structure (lib/main.dart): the per-arm override is
+            // applied here, wrapping the root Navigator — NOT inside `home`.
+            builder: (context, child) => ProviderScope(
+              overrides: [
+                currentUserIdProvider.overrideWithValue('uid-under-test'),
+              ],
+              child: child!,
+            ),
+          ),
+        ),
+      );
+
+      // Push a modal on the root Navigator (the default for
+      // `showModalBottomSheet`) that reads the scoped provider.
+      String? readUid;
+      Object? thrown;
+      unawaited(
+        showModalBottomSheet<void>(
+          context: navContext,
+          builder: (_) => Consumer(
+            builder: (context, ref, _) {
+              try {
+                readUid = ref.watch(currentUserIdProvider);
+              } on Object catch (e) {
+                thrown = e;
+              }
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        thrown,
+        isNull,
+        reason:
+            'currentUserIdProvider must resolve inside a root-Navigator modal '
+            'via the builder-applied scope (regressed if the scope moves back '
+            'into MaterialApp.home).',
+      );
+      expect(readUid, 'uid-under-test');
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Human-in-the-loop **manual validation of everything shipped in Sprint 1 + Sprint 2**, run end-to-end against the **Firebase Emulator Suite** across two real targets (iPhone 16 + iPhone 17 Pro simulators, two distinct signed-in users), as the pre-Sprint-3 readiness gate.

Every scenario was confirmed on **both** the app UI **and** the Firebase side (Firestore, Auth, Storage, Functions logs in the Emulator UI). The pass surfaced **14 defects (D1–D14)**, all fixed, regression-tested, and re-verified in a second clean run.

**Verdict: Pass 1 GREEN** — the shipped Sprint-1 + Sprint-2 surface is validated and free of blocking defects on the emulator.

## Defects fixed

| ID | Sev | Phase | Issue | Summary |
|----|-----|-------|-------|---------|
| D1 | S1 | 0 Build | #95 | iOS simulator build failure blocked launch |
| D2 | S2 | 7 Notif | #96 | Cold-start notification handler crash on null initial message |
| D3 | S3 | 1 Auth | #97 | OTP cells did not clear after a wrong code |
| D4 | S1 | 2 Friends | #98 | Add-friend match branch never created the friendship (S6) |
| D5 | S2 | 2 Friends | #99 | No navigation/confirmation after friendship create |
| D6 | S3 | 2 Friends | #100 | Newly-added friend showed blank display name |
| D7 | S2 | 2 Friends | #101 | Friend Detail context-member read denied by rules |
| D8 | S1 | 3 Expenses | #102 | Context picker empty — could not add an expense |
| D9 | S1 | 2 Friends | #106 | Add-friend duplicate-check stalled ~90s (FlutterFire #10449) |
| D10 | S3 | 3 Expenses | #104 | Post-delete navigation stayed on a stale screen |
| D11 | S2 | 3 Expenses | #105 | Analytics threw on bool params, slowing expense save |
| D12 | S3 | 6 Activity | #107 | Expense detail showed "Friend"/"You", not names |
| D13 | S3 | 8 Profile | #108 | Deleted account rendered as "Unknown", not "Deleted User" |
| D14 | S3 | 10 X-cut | #109 | OTP screen overflowed at large text and on small phones |

Severity via the `triage-bug` skill. None remain blocking.

## Commits

| Commit | Scope |
|--------|-------|
| `0f891ba` | D1–D8 (#95–102) |
| `2cba3cc` | D9 add-friend stall (#106) |
| `23460ef` | D10 nav + D11 analytics bool (#104, #105) |
| `c24fbec` | D12 expense-detail names (#107) |
| `51c83f4` | D13 deleted-user label (#108) |
| `80762d0` | D14 OTP overflow (#109) |
| `3651e69` | Final QA report |

## Deliverable

`docs/qa/manual-validation-sprint-1-2.md` — per-scenario pass/fail matrix for Phases 0–10, defect list with issue links, FlutterFire #10449 environment notes, and the Pass 1 sign-off.

## Invariants

All four spot-checked and explicitly validated in Phase 9: INV1 integer paise (exact split sums, no float drift), INV2 `simplifiedBalances` server-only (direct client write rejected by rules), INV3 system share sheet, INV4 single Firebase project. Security rules verified: non-member / stranger / unauthenticated / enumeration all denied.

## Verification

- `fvm flutter test` — full suite green (1609 tests)
- `fvm flutter analyze lib test` — no issues
- `dart format .` — clean

## Scope note

This PR is **Pass 1 (emulator) only**. Pass 2 (production + real device) is **deferred** — its findings (D15 backend deploy, D16 iOS push capability, D17/D18 App Check) are tracked separately and are **not** part of this PR. No production-only or Pass-2 code changes are included here.

Closes #95
Closes #96
Closes #97
Closes #98
Closes #99
Closes #100
Closes #101
Closes #102
Closes #104
Closes #105
Closes #106
Closes #107
Closes #108
Closes #109

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
