### PR TITLE
docs(sprint-3): scope Onboarding into DC-04 and Friend-history into DC-06

### DIFF
--- a/docs/audits/design-conversion/01-coverage-gap.md
+++ b/docs/audits/design-conversion/01-coverage-gap.md
@@ -36,15 +36,17 @@ governing FR only.
 ## B. Coverage matrix (30 Haldi screens)
 
 Status values: **covered** (a matching built screen exists) · **designed-not-yet-built**
-(Haldi designs it; the app screen is not built) · **mismatch** (built screen and Haldi
-screen diverge in scope/behaviour). A fourth value, **built-not-yet-designed** (a built
-surface the 30-screen handoff does not cover), cannot apply to a Haldi-screen row by
-definition; those surfaces are captured in the addendum table below the main matrix and in §C.
+(Haldi designs it; the app screen is not built) · **building (DC-NN)** (designed, no built
+screen yet, but scheduled as a net-new Haldi build in this sprint's named story) ·
+**mismatch** (built screen and Haldi screen diverge in scope/behaviour). A further value,
+**built-not-yet-designed** (a built surface the 30-screen handoff does not cover), cannot
+apply to a Haldi-screen row by definition; those surfaces are captured in the addendum
+table below the main matrix and in §C.
 
 | Haldi screen № | app screen / FR | status |
 |---|---|---|
 | 1 — Splash | `auth/presentation/splash_screen.dart` (SCR-01) | covered |
-| 2 — Onboarding (3 slides) | *(no built screen)* — SRS §6.3 #1 | designed-not-yet-built |
+| 2 — Onboarding (3 slides) | *(net-new build in DC-04)* — SRS §6 / §10; `Phase3a` design | **building (DC-04)** ⁵ |
 | 3 — Phone entry (+91 locked) | `auth/presentation/phone_entry_screen.dart` (FR-AU-01, FR-AU-02) | covered |
 | 4 — OTP (6-box) | `auth/presentation/otp_entry_screen.dart` (FR-AU-03, FR-AU-04, FR-AU-05) | covered |
 | 5 — Profile setup | `auth/presentation/profile_setup_screen.dart` (FR-AU-06) | covered |
@@ -54,7 +56,7 @@ definition; those surfaces are captured in the addendum table below the main mat
 | 9 — Friends list | `friends/presentation/friends_list_screen.dart` (FR-FR-03) | covered |
 | 10 — Add friend (lookup branches) | `friends/presentation/add_friend_screen.dart` + `add_friend_flow.dart` + `match_and_invite_screen.dart` (FR-FR-01, FR-FR-02) | covered |
 | 11 — Friend detail | `friends/presentation/friend_detail_screen.dart` (FR-FR-04) | covered |
-| 12 — Friend history | `friends/presentation/friend_detail_screen.dart` (top-5 inline only) — FR-FR-04 | designed-not-yet-built ² |
+| 12 — Friend history | *(net-new build in DC-06)* — `friend_history_screen.dart`; FR-FR-04 | **building (DC-06)** ² |
 | 13 — Remove friend | *(no presentation UI; removal logic only in `friends/data/friendship_repository.dart`)* — FR-FR-05 | designed-not-yet-built |
 | 14 — Groups list | `shell/presentation/groups_list_placeholder.dart` (placeholder only) — FR-GR-04 | designed-not-yet-built |
 | 15 — Create group | *(not built)* — FR-GR-01 | designed-not-yet-built |
@@ -80,12 +82,13 @@ definition; those surfaces are captured in the addendum table below the main mat
    Groups section is an intentional "Coming soon" stub row that lights up only when the
    Groups epic ships (the in-code "Sprint 3" label predates the renumber → now **Sprint 4**).
    No new design needed; the Groups branch reuses Haldi 14/16 when those are built.
-2. **Haldi 12 (designed-not-yet-built).** FR-FR-04's full reverse-chron per-friend log is
-   currently met only by the **top-5 inline timeline** on Friend detail (Haldi 11) plus the
-   **settlements-only** Settlement History (Haldi 24). The dedicated full
+2. **Haldi 12 (building — DC-06).** FR-FR-04's full reverse-chron per-friend log was
+   previously met only by the **top-5 inline timeline** on Friend detail (Haldi 11) plus
+   the **settlements-only** Settlement History (Haldi 24). The dedicated full
    expense+settlement, month-grouped, signed-amount log that Haldi screen 12 specifies is
-   not built as a distinct screen. Build it (in Haldi) when the friends history surface is
-   completed; the Haldi design already exists.
+   **now being built as a distinct Haldi screen** (`friend_history_screen.dart`) within
+   **DC-06** (PM decision 2026-06-26; the Friends feature dev is complete), superseding the
+   top-5 inline preview. The Haldi design already exists.
 3. **Haldi 24 (covered, with a flagged divergence).** The Settlement History list itself is
    built and maps cleanly. The **reminder** element diverges: it is implemented as a
    one-tap "Remind" affordance on **Friend detail** (`friend_detail_screen.dart` →
@@ -95,6 +98,11 @@ definition; those surfaces are captured in the addendum table below the main mat
 4. **Haldi 26 (covered).** The OS lock-screen banner is system-rendered and not an app
    surface to design; the designable surfaces — the foreground in-app banner, the
    "Stay in the loop" pre-permission dialog, and the deep-link host — are all built.
+5. **Haldi 2 (building — DC-04).** Onboarding has no built screen today; it is being
+   **built fresh in Haldi within DC-04** (PM decision 2026-06-26) per the `Phase3a - Auth`
+   design + the mockup `docs/design/05-mockups/01-splash-and-onboarding.html`, and the
+   SRS §6 first-time journey / §10 (Terms/Privacy linked from onboarding). It has **no
+   dedicated FR id** — the FR formalisation is folded into the PM's `update-srs` proposal.
 
 ### Addendum — built surfaces NOT among the 30 Haldi screens
 
@@ -157,11 +165,13 @@ vs **reuse existing Haldi screen N** vs **internal — no design needed**.
    Haldi screen 24/11**, but flag the placement/scope divergence to the PM for reconciliation.
    Not a new commission.
 
-7. **Designed-not-yet-built Haldi screens** — Onboarding (2), Search (7), Friend history (12),
-   Remove friend (13), Groups (14–20). *Why listed:* these are required but unbuilt; however
-   the Haldi handoff **already designs** each one. → **Reuse existing Haldi screen N** (build
-   them directly in Haldi in the later feature sprints — Groups in Sprint 4, the rest in
-   Sprint 5/6). **No new design needed.**
+7. **Designed-not-yet-built Haldi screens** — Search (7), Remove friend (13),
+   Groups (14–20). *Why listed:* these are required but unbuilt; however the Haldi handoff
+   **already designs** each one. → **Reuse existing Haldi screen N** (build them directly in
+   Haldi in the later feature sprints — Groups in **Sprint 4**, Search + Remove-friend in
+   **Sprint 6**). **No new design needed.** **(Updated 2026-06-26: Onboarding (2) and Friend
+   history (12) were promoted IN-scope as net-new Sprint 3 builds — DC-04 and DC-06
+   respectively — so they are no longer designed-not-yet-built.)**
 
 **Net result (updated 2026-06-25):** **zero** surfaces now need a newly-commissioned Haldi
 design — the single gap, the **change-phone OTP re-verification flow (FR-PR-02)**, has been
@@ -186,9 +196,13 @@ on exactly one item:
 - **Not blocked (delete, do not convert):** `authenticated_screen.dart`,
   `profile_placeholder_screen.dart`, `groups_list_placeholder.dart` — handled by the Phase 2
   conversion checklist as deletions; no design dependency.
-- **Not a Sprint 3 dependency:** the designed-not-yet-built Haldi screens (2, 7, 12, 13,
+- **Net-new Sprint 3 builds (updated 2026-06-26):** Onboarding (2) and Friend history (12)
+  are now **built fresh in Haldi within Sprint 3** — DC-04 and DC-06 respectively (PM
+  decision). They carry no *conversion* dependency (no built screen to reskin) but are
+  in-scope as builds.
+- **Not a Sprint 3 dependency:** the remaining designed-not-yet-built Haldi screens (7, 13,
   14–20) carry **no conversion dependency** because there is no built screen to convert — they
-  are built fresh in Haldi in Sprint 4/5/6.
+  are built fresh in Haldi in Sprint 4 (Groups) / Sprint 6 (Search, Remove-friend).
 - **Flag (not a blocker):** the reminder placement/scope divergence (§C item 6) is a
   reconcile item for the PM, not a conversion blocker.
 

--- a/docs/audits/design-conversion/02-conversion-checklist.md
+++ b/docs/audits/design-conversion/02-conversion-checklist.md
@@ -68,6 +68,7 @@ rebuild or hero light+dark bespoke work (multi-day). Hero screens marked ★.
 | file | Haldi № | class | key changes | states to add | effort |
 |---|---|---|---|---|---|
 | `auth/presentation/splash_screen.dart` | 1 ★ | **rebuild** | Replace placeholder `Icons.vertical_split_rounded` with the ÷ brand mark + OneByTwo wordmark on a full-bleed marigold gradient; ink-on-marigold; tagline in Hanken. Depends on **brand kit**. | light + dark hero treatment (dark splash) | M |
+| `auth/presentation/onboarding_screen.dart` (NEW) | 2 ★ | **build** | Net-new in Haldi (PM decision 2026-06-26; design in `Phase3a - Auth.dc.html`): 3 illustrated slides (Track / Split / Settle) in a `PageView` + pagination dots + Skip + ink-on-marigold "Get started" + Terms/Privacy links; first-launch "seen" gating (`shared_preferences`) → phone-entry. Depends on **brand kit**. No FR id yet — flag to `update-srs`. | light + dark; first-launch gate; all 3 slides | M |
 | `auth/presentation/phone_entry_screen.dart` | 3 | reskin | Marigold tokens + Bricolage/Hanken; locked `+91` chip on `surfaceVariant`; field radius → chip/input 12; CTA → primary ink-on-marigold. | — (error + loading present) | S |
 | `auth/presentation/otp_entry_screen.dart` | 4 | reskin | Marigold tokens + type; resend cooldown caption → tertiary text; error microcopy. | — | S |
 | `auth/presentation/widgets/otp_input.dart` | 4 | reskin | Cell radius → chip/input 12; active/filled border → marigold; digit text → Bricolage tabular. (This **is** new-component #11 — already built; reskin only.) | — | S |
@@ -95,6 +96,7 @@ rebuild or hero light+dark bespoke work (multi-day). Hero screens marked ★.
 | `friends/presentation/friend_detail_screen.dart` | 11 | reskin | Marigold tokens + type; `OBTSettleUpCard` reskin; FAB → marigold; skeleton → shimmer. | loading-skeleton (shimmer) | M |
 | `friends/presentation/widgets/friend_detail_header.dart` | 11 | reskin | Large balance pill gains icon + balance-trio tokens; name → Bricolage/Hanken; amount → Bricolage tabular. | — | S |
 | `friends/presentation/widgets/friend_detail_timeline.dart` | 11/12 | reskin | Category icon → Haldi hue bed; amounts → Bricolage tabular; share label → balance tokens; IST dates. | — | M |
+| `friends/presentation/friend_history_screen.dart` (NEW) | 12 | **build** | Net-new in Haldi (PM decision 2026-06-26; FR-FR-04): the dedicated full per-friend log — reverse-chron, **month-grouped**, expenses **+** settlements, **signed amounts** via `formatInrFromPaise()`; shimmer-loading + empty-state + error. Supersedes the top-5 inline preview on Friend detail. | loading-skeleton (shimmer); empty illustration; error | M |
 | `friends/presentation/widgets/friend_detail_states.dart` | 11 | reskin | Skeleton → shimmer; empty `Icon` → empty-state scaffold; tokens. | loading-skeleton (shimmer); empty illustration | S |
 | `friends/presentation/add_friend_screen.dart` | 10 | reskin | Marigold tokens + type; segmented Contacts/Manual reskin; search field radius; contacts `CircularProgressIndicator` → skeleton. | loading-skeleton (replace spinner) | M |
 | `friends/presentation/add_friend_flow.dart` | 10 | **conform** | Pure navigation glue (route push helper); no visual surface. | — | — |
@@ -164,11 +166,13 @@ rebuild or hero light+dark bespoke work (multi-day). Hero screens marked ★.
 | `shell/presentation/add_expense_context_picker_sheet.dart` | 8 | reskin | Sheet radius → 28; section headers → overline; friends loading spinner → skeleton; Groups stub copy → "Coming soon"; add the Haldi search field (additive). | loading-skeleton (replace spinner); search field | M |
 | `shell/presentation/groups_list_placeholder.dart` | — | **delete** | Replaced by the real Haldi 14 Groups list, built fresh in **Sprint 4**. Remove (do not convert). | — | S |
 
-> **Not in scope here.** Haldi 2 (Onboarding), 7 (Search), 13 (Remove friend),
-> 14–20 (Groups: list, create, detail ★, invite, members, leave/delete, history)
-> have **no built file** — `lib/features/groups/` is greenfield. Group detail
-> (Haldi 16 ★) and the rest of the Groups flow are **built fresh in Sprint 4**, not
-> converted in this sprint.
+> **Not in scope here.** Haldi 7 (Search) and 13 (Remove friend) have **no built
+> file** and are built fresh in **Sprint 6** (FR-SR-01/02, FR-FR-05). Haldi 14–20
+> (Groups: list, create, detail ★, invite, members, leave/delete, history) have no
+> built file — `lib/features/groups/` is greenfield — and are **built fresh in
+> Sprint 4**, not converted in this sprint. **(Updated 2026-06-26: Haldi 2 Onboarding
+> and Haldi 12 Friend history were moved IN-scope as net-new builds within DC-04 and
+> DC-06 respectively — see the Auth / Friends rows above.)**
 
 ---
 
@@ -286,22 +290,26 @@ greenfield.
 
 ## D. Roll-up
 
-### Counts by classification (all 56 table rows)
+### Counts by classification (all 58 table rows)
 
 | classification | count |
 |---|---|
 | conform | 3 |
 | reskin | 46 |
 | rebuild | 4 |
+| build | 2 |
 | delete | 3 |
 | blocked | 0 |
-| **total** | **56** |
+| **total** | **58** |
 
 - **conform (3):** `add_friend_flow.dart`, `notifications_lifecycle_host.dart`,
   `authenticated_shell.dart` (logic/nav glue, no visual surface or change).
 - **rebuild (4):** `splash_screen.dart` (brand moment), `match_and_invite_screen.dart`
   (bare guard states), `step_2_split_and_payer.dart` (segmented control + live
   validation), `settle_up_bottom_sheet.dart` (UPI slot + success moment).
+- **build (2):** `onboarding_screen.dart` (Haldi 2, net-new in DC-04),
+  `friend_history_screen.dart` (Haldi 12, net-new in DC-06) — designed-not-yet-built
+  screens promoted in-scope as fresh Haldi builds (PM decision 2026-06-26).
 - **delete (3):** `authenticated_screen.dart`, `profile_placeholder_screen.dart`,
   `groups_list_placeholder.dart`.
 - **blocked (0):** none — the former blocker, `change_phone_screen.dart` (FR-PR-02), now has

--- a/docs/sprint-zero/sprint-3-plan.md
+++ b/docs/sprint-zero/sprint-3-plan.md
@@ -204,35 +204,48 @@ Matching `.github/ISSUE_TEMPLATE/user_story.md`, plus conversion-specific gates:
 
 ### Epic C — Per-Flow Screen Conversion
 
-#### DC-04: Auth flow conversion (Haldi 1, 3, 4, 5)
+#### DC-04: Auth & onboarding flow conversion (Haldi 1, 2, 3, 4, 5)
 
-- **SRS / Source:** FR-AU-01..06; Haldi screens 1, 3, 4, 5; `02-conversion-checklist.md`
-  §B (Auth).
+- **SRS / Source:** FR-AU-01..06; Haldi screens 1, 2, 3, 4, 5; `02-conversion-checklist.md`
+  §B (Auth). **Onboarding (Haldi 2) is a net-new build** (added 2026-06-26): it has no
+  built file today; its design exists in `Phase3a - Auth.dc.html` + the mockup
+  `docs/design/05-mockups/01-splash-and-onboarding.html`, and the SRS §6 first-time
+  journey + §10 (Terms/Privacy linked from onboarding) require it. It has **no dedicated
+  FR id** — flag the FR formalisation to the PM's `update-srs` proposal.
 - **Priority:** P0 — Must have.
-- **User Story:** As a user signing in, I want the splash, phone-entry, OTP, and
-  profile-setup screens in the Haldi visual language so that my first impression of
+- **User Story:** As a user signing in, I want the splash, onboarding, phone-entry, OTP,
+  and profile-setup screens in the Haldi visual language so that my first impression of
   the app is consistent and on-brand.
-- **Preconditions:** DC-01 merged; brand kit (DC-03 #13) available for the splash
-  rebuild.
+- **Preconditions:** DC-01 merged; brand kit (DC-03 #13) — incl. the onboarding
+  illustration holders — available for the splash rebuild and onboarding build.
 - **Acceptance Criteria:**
   1. **Given** the splash screen (Haldi 1, **rebuild**), **When** the app launches,
      **Then** the placeholder icon is replaced by the `÷` brand mark + "OneByTwo"
      wordmark on a full-bleed marigold gradient with **ink** (not white) on marigold,
      in light **and** dark.
-  2. **Given** phone-entry (3), OTP (4) with `otp_input`, and profile-setup (5),
+  2. **Given** onboarding (Haldi 2, **build** — net-new in Haldi), **When** a first-time
+     user launches, **Then** the 3 illustrated slides (Track / Split / Settle) render
+     with pagination dots, a **Skip** affordance, an **ink-on-marigold "Get started"**
+     CTA, and the **Terms of Service / Privacy Policy** links; onboarding shows **once**
+     (first-launch gated by a persisted "seen" flag — Skip and Get started both set it
+     and route to phone-entry), in light **and** dark.
+  3. **Given** phone-entry (3), OTP (4) with `OBTOtpInput`, and profile-setup (5),
      **When** reskinned, **Then** they use marigold tokens + Bricolage/Hanken, the
      `+91` prefix stays **locked**, and the profile-setup camera badge icon is **ink,
      not white**; OTP, validation, and session behaviour are unchanged.
-  3. **Given** `authenticated_screen.dart` (orphaned, no inbound references),
+  4. **Given** `authenticated_screen.dart` (orphaned, no inbound references),
      **When** conversion runs, **Then** it is **deleted, not converted** (negative
      case — if any reference to `AuthenticatedScreen` is found, the deletion is
      blocked until the reference is removed).
-- **Definition of Done:** the standard checklist; one of the three throwaways
-  (`authenticated_screen.dart`) deleted here.
+- **Definition of Done:** the standard checklist; **onboarding (Haldi 2) built fresh**
+  with its first-launch gating; one of the three throwaways (`authenticated_screen.dart`)
+  deleted here.
 - **Invariant Compliance:** No money, balance, share, or project surface changes —
-  all four invariants hold unchanged.
+  all four invariants hold unchanged. The onboarding build adds only its own screen,
+  route, and a local first-launch flag (`shared_preferences`); no second project.
 - **Responsible Agents:** Flutter Dev, Designer, QA.
-- **Story Points:** 5
+- **Story Points:** 8 (was 5; +3 for the net-new onboarding build)
+
 
 #### DC-05: Home dashboard conversion (Haldi 6 ★)
 
@@ -267,16 +280,22 @@ Matching `.github/ISSUE_TEMPLATE/user_story.md`, plus conversion-specific gates:
 - **Responsible Agents:** Flutter Dev, Designer, QA.
 - **Story Points:** 5
 
-#### DC-06: Friends flow conversion (Haldi 9 ★, 10, 11)
+#### DC-06: Friends flow conversion (Haldi 9 ★, 10, 11, 12)
 
-- **SRS / Source:** FR-FR-01..04; Haldi screens 9, 10, 11; `02-conversion-checklist.md`
-  §B (Friends).
+- **SRS / Source:** FR-FR-01..04; Haldi screens 9, 10, 11, 12; `02-conversion-checklist.md`
+  §B (Friends). **Friend history (Haldi 12) is a net-new build** (added 2026-06-26): the
+  Friends feature dev is complete, so the dedicated full per-friend log can now be built.
+  FR-FR-04's full reverse-chron log is today met only by the top-5 inline timeline on
+  Friend detail (11) + the settlements-only history (24); Haldi 12 specifies the dedicated
+  month-grouped expense **+** settlement, signed-amount log, which has no built screen.
 - **Priority:** P0 — Must have.
 - **User Story:** As a user managing friends, I want the friends list, add-friend
-  lookup, and friend-detail screens in the Haldi visual language so that balances and
-  the add-friend branches are clear and on-brand.
+  lookup, friend-detail, and the full friend-history screens in the Haldi visual
+  language so that balances, the add-friend branches, and the complete transaction
+  history are clear and on-brand.
 - **Preconditions:** DC-01 merged; skeleton-loader (#1), empty-state scaffold (#7),
-  balance pill (#2) available (DC-03).
+  balance pill (#2) available (DC-03); the Friends feature (FR-FR-01..04) is built, so
+  the friend-history data/providers exist for Haldi 12.
 - **Acceptance Criteria:**
   1. **Given** the friends list (9 ★), **When** reskinned, **Then** it gains the
      owed/owe summary band, balance-signal rows using the balance pill (colour + icon
@@ -291,13 +310,20 @@ Matching `.github/ISSUE_TEMPLATE/user_story.md`, plus conversion-specific gates:
   4. **Given** friend detail (11), **When** reskinned, **Then** the balance header and
      `OBTSettleUpCard` use the balance trio, amounts render via `formatInrFromPaise()`,
      and balances are **read** from the projection only (Invariants 1 + 2).
+  5. **Given** friend history (12, **build**), **When** the user opens the full log
+     from Friend detail, **Then** a dedicated screen shows the complete reverse-chron,
+     **month-grouped** list of expenses **and** settlements with **signed amounts** via
+     `formatInrFromPaise()` (Invariant 1), shimmer-loading + empty-state + error states,
+     in Haldi — superseding the top-5 inline preview.
 - **Definition of Done:** the standard checklist; `add_friend_flow.dart`
-  **conforms** (pure navigation glue, no visual surface).
+  **conforms** (pure navigation glue, no visual surface); **friend history (Haldi 12)
+  built fresh** with its four states.
 - **Invariant Compliance:** Integer paise via `formatInrFromPaise()` (Invariant 1);
   simplified balances read-only (Invariant 2); invites via OS share sheet only
   (Invariant 3); single project (Invariant 4).
 - **Responsible Agents:** Flutter Dev, Designer, QA.
-- **Story Points:** 5
+- **Story Points:** 8 (was 5; +3 for the net-new friend-history build)
+
 
 #### DC-07: Expenses flow conversion (Haldi 21 ★, 22, and context picker 8)
 
@@ -537,13 +563,13 @@ Matching `.github/ISSUE_TEMPLATE/user_story.md`, plus conversion-specific gates:
 |---|---|---|
 | A — Token + Type Foundation (DC-01) | 1 | 8 |
 | B — Shared Component Library (DC-02, DC-03) | 2 | 16 |
-| C — Per-Flow Screen Conversion (DC-04 … DC-10) | 7 | 31 |
+| C — Per-Flow Screen Conversion (DC-04 … DC-10) | 7 | 37 |
 | D — Dark-Mode Parity (DC-11) | 1 | 5 |
 | E — Accessibility Re-Verification (DC-12) | 1 | 3 |
 | F — Visual-Regression / Golden Harness (DC-13) | 1 | 5 |
-| **Total** | **13** | **68** |
+| **Total** | **13** | **74** |
 
-> **Roll-up note.** This **68 SP** is the additive enabling total that
+> **Roll-up note.** This **74 SP** is the additive enabling total that
 > `docs/design/08-plan/sprint-sequence.md` records as "TBD / set in
 > `sprint-3-plan.md`". It is **enabling** work (like INFRA-01 / FUNC-01 in Sprint 1):
 > it delivers no new functional requirement, carries no P0 FR SP, and is therefore
@@ -557,9 +583,9 @@ Matching `.github/ISSUE_TEMPLATE/user_story.md`, plus conversion-specific gates:
 | DC-01 | 8 | Load-bearing, blocking foundation (ColorScheme + `OBTColors` + Bricolage/Hanken `TextTheme` + radius/shadow/motion + `OBTText` helper); comparable to INFRA-01. |
 | DC-02 | 3 | Six widgets, all classified **reskin** (token/type only); formatter conforms. |
 | DC-03 | 13 | Eleven components, each in four states + light/dark goldens; includes the greenfield segmented split control, offline banner, and brand kit. |
-| DC-04 | 5 | Splash **rebuild** (brand-kit dependency) + three reskins + one delete. |
+| DC-04 | 8 | Splash **rebuild** (brand-kit dependency) + **onboarding build** (net-new: 3-slide PageView, first-launch gating, Terms/Privacy) + three reskins + one delete. |
 | DC-05 | 5 | Home hero ★ + six widgets + donut/skeleton/empty-state + one delete. |
-| DC-06 | 5 | Friends list ★ + add-friend + `match_and_invite` **rebuild** + friend detail (rides on components). |
+| DC-06 | 8 | Friends list ★ + add-friend + `match_and_invite` **rebuild** + friend detail + **friend-history build** (net-new Haldi 12: month-grouped expense+settlement log) (rides on components). |
 | DC-07 | 5 | Add-expense hero ★ (sheet shell + step-2 **rebuild** + step-3 additive) + detail + context picker. |
 | DC-08 | 3 | Settle-up hero ★ **rebuild** (UPI slot + success moment via component) + history. |
 | DC-09 | 3 | Activity hero ★ + shimmer + in-app banner / pre-permission reskins. |


### PR DESCRIPTION
## Scope: Onboarding → DC-04, Friend-history → DC-06

A coverage audit of the 30 designed Haldi screens surfaced two that were
**designed-not-yet-built** with **no concrete Sprint-3/4 home**. PM decision
(2026-06-26): promote both to **net-new builds within the existing flow
conversions**, since both flows are ready.

### Haldi 2 — Onboarding → **DC-04** (Auth & onboarding)
- Designed in `Phase3a - Auth.dc.html` + mockup `05-mockups/01-splash-and-onboarding.html`; required by SRS §6 (first-time journey) and §10 (Terms/Privacy linked from onboarding).
- 3 illustrated slides (Track / Split / Settle) + pagination + Skip + ink-on-marigold "Get started" + Terms/Privacy links; first-launch "seen" gating (`shared_preferences`) → phone-entry. Consumes the DC-03 brand kit.
- **No FR id today** — FR formalisation flagged to the PM's `update-srs` proposal.

### Haldi 12 — Friend history → **DC-06** (Friends)
- The Friends feature dev is complete, so the dedicated full per-friend log can be built: reverse-chron, **month-grouped**, expenses **+** settlements, signed amounts; supersedes the top-5 inline preview. FR-FR-04.

### Reconciliation in this PR (docs only)
- `sprint-3-plan.md`: DC-04 5→**8** SP (+ onboarding build), DC-06 5→**8** SP (+ friend-history build); Epic C 31→**37**; sprint total 68→**74**; new ACs + DoD on both stories.
- `02-conversion-checklist.md` §B: Onboarding (Auth) + Friend-history (Friends) **build** rows; new **build** classification (2); "Not in scope" note updated (Onboarding/12 removed; Search 7 + Remove-friend 13 → Sprint 6 retained).
- `01-coverage-gap.md` §B: matrix rows 2 + 12 → **building (DC-04/DC-06)**; new status in the legend; §C item 7 + §D updated.

The DC-04 prompt `docs/copilot_prompts/sprint_3/5.md` is updated to match (rides untracked with the DC-04 PR per convention). Issues #116 (DC-04) and #118 (DC-06) are commented with the scope addition.

Velocity-excluded (docs/planning only; no `lib/**` or backend change).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
