### PR TITLE
ci(golden): skip golden-a11y-checks compare on workflow_dispatch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -221,8 +221,12 @@ jobs:
     name: Golden & A11y Checks
     runs-on: ubuntu-latest
     needs: [changes]
+    # Compare on every pull request, but never on workflow_dispatch: the manual
+    # golden-refresh job owns that path and regenerates baselines, so a compare
+    # there would only fail against the not-yet-updated committed PNGs.
     if: >-
       !cancelled()
+      && github.event_name != 'workflow_dispatch'
       && (needs.changes.result != 'success'
       || needs.changes.outputs.flutter == 'true'
       || needs.changes.outputs.ci == 'true')

--- a/docs/audits/design-conversion/04-qa-test-strategy.md
+++ b/docs/audits/design-conversion/04-qa-test-strategy.md
@@ -427,11 +427,14 @@ engine-sensitive, whereas `a11y-checks` floats the stable channel and runs no
 byte comparison.
 
 - **Job key / name:** `golden-a11y-checks` / "Golden & A11y Checks".
-- **Trigger:** rides the existing `pull_request → main` (and `workflow_dispatch`)
-  triggers of `pr.yml`. Gated via the existing `changes` detection:
-  runs when `needs.changes.outputs.flutter == 'true'` or `…ci == 'true'`, with
-  the same fail-safe (`needs.changes.result != 'success'` → run anyway). A
-  skipped run reports "skipped", which the ruleset counts as passing.
+- **Trigger:** rides the existing `pull_request → main` trigger of `pr.yml`.
+  Gated via the existing `changes` detection: runs when
+  `needs.changes.outputs.flutter == 'true'` or `…ci == 'true'`, with the same
+  fail-safe (`needs.changes.result != 'success'` → run anyway). It explicitly
+  **skips `workflow_dispatch`** (`github.event_name != 'workflow_dispatch'`) —
+  the `golden-refresh` job owns that path, and a compare there would only fail
+  against the not-yet-updated committed baselines. A skipped run reports
+  "skipped", which the ruleset counts as passing.
 - **Runner / setup:** `ubuntu-latest` (the canonical golden host — see §A.2.2);
   `actions/checkout@v4`; `subosito/flutter-action@v2` **pinned to
   `flutter-version: 3.44.3`** (not just `channel: stable`, §A.2.3 — do not float
@@ -491,6 +494,7 @@ manual-only refresh path:
     needs: [changes]
     if: >-
       !cancelled()
+      && github.event_name != 'workflow_dispatch'
       && (needs.changes.result != 'success'
       || needs.changes.outputs.flutter == 'true'
       || needs.changes.outputs.ci == 'true')


### PR DESCRIPTION
## Follow-up to #140 — keep manual `golden-refresh` runs green

The DC-13 `golden-a11y-checks` compare job ran on **every** `workflow_dispatch`
event because the `changes` job defaults its `flutter` / `ci` outputs to `true`
on non-PR events. So a manual `golden-refresh` dispatch (whose whole purpose is
to regenerate baselines) failed the compare against the not-yet-updated committed
PNGs — e.g. [run 28300551158](https://github.com/avtansh-code/OneByTwo/actions/runs/28300551158)
went red on `Golden & A11y Checks` while `Golden Refresh (manual)` succeeded.

### Fix

Add `&& github.event_name != 'workflow_dispatch'` to the `golden-a11y-checks`
gate. The compare still runs on **every pull request**; the `golden-refresh`
job owns the dispatch path. Documented the gating in `04-qa-test-strategy.md`
§E.2.

Cosmetic only — the dispatch run is not a required check and never blocked #140.
No behaviour change; all four invariants untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
