### PR TITLE
fix(widgets): unify the locked +91 phone field so its halves align

### DIFF
--- a/lib/core/widgets/inputs/obt_locked_phone_field.dart
+++ b/lib/core/widgets/inputs/obt_locked_phone_field.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:onebytwo/app/theme.dart';
+import 'package:onebytwo/core/widgets/india_phone_input_formatter.dart';
+
+/// A locked `+91` Indian mobile-number field.
+///
+/// Renders the handoff's unified phone field (`Phase3a - Auth`): a single
+/// rounded, bordered control whose left segment is the non-editable `+91`
+/// country-code chip (on `surfaceVariant`, separated by a 1px divider) and
+/// whose right segment is a borderless [TextField].
+///
+/// A single outer border wraps both halves so their top and bottom edges
+/// always align — a Material `OutlineInputBorder` cannot stretch to match an
+/// adjacent fixed-height box, so the two-box approach drifts by a few logical
+/// pixels with the real (Hanken) font metrics (#150). Focus is conveyed by the
+/// marigold cursor plus a marigold outer border.
+///
+/// The `+91` prefix is locked because v1.0 supports Indian numbers only
+/// (SRS section 1.3); the caller supplies any extra [inputFormatters]
+/// (`IndianPhoneInputFormatter` is always applied first).
+class OBTLockedPhoneField extends StatefulWidget {
+  /// Creates a locked `+91` phone-number field.
+  const OBTLockedPhoneField({
+    super.key,
+    this.controller,
+    this.onChanged,
+    this.enabled = true,
+    this.hintText = 'Enter mobile number',
+    this.hasError = false,
+    this.autofocus = false,
+    this.inputFormatters = const [],
+  });
+
+  /// Optional controller for the editable portion.
+  final TextEditingController? controller;
+
+  /// Called with the raw editable text whenever it changes.
+  final ValueChanged<String>? onChanged;
+
+  /// Whether the field accepts input.
+  final bool enabled;
+
+  /// Placeholder shown when the field is empty.
+  final String hintText;
+
+  /// When true the outer border uses the error colour.
+  final bool hasError;
+
+  /// Whether the field requests focus on first build.
+  final bool autofocus;
+
+  /// Extra formatters applied after [IndianPhoneInputFormatter].
+  final List<TextInputFormatter> inputFormatters;
+
+  @override
+  State<OBTLockedPhoneField> createState() => _OBTLockedPhoneFieldState();
+}
+
+class _OBTLockedPhoneFieldState extends State<OBTLockedPhoneField> {
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_onFocusChange);
+  }
+
+  void _onFocusChange() => setState(() {});
+
+  @override
+  void dispose() {
+    _focusNode
+      ..removeListener(_onFocusChange)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final borderColor = widget.hasError
+        ? colorScheme.error
+        : _focusNode.hasFocus
+        ? colorScheme.primary
+        : colorScheme.outline;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppTheme.radiusChipInput),
+        border: Border.all(color: borderColor),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppTheme.radiusChipInput),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Locked +91 country-code chip with a divider.
+              Semantics(
+                label: 'Country code, India, plus 91',
+                excludeSemantics: true,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  decoration: BoxDecoration(
+                    color: colorScheme.surfaceContainerHighest,
+                    border: Border(
+                      right: BorderSide(color: colorScheme.outline),
+                    ),
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    '+91',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+              ),
+              // Editable number, borderless inside the shared frame.
+              Expanded(
+                child: TextField(
+                  controller: widget.controller,
+                  focusNode: _focusNode,
+                  enabled: widget.enabled,
+                  autofocus: widget.autofocus,
+                  keyboardType: TextInputType.phone,
+                  inputFormatters: [
+                    IndianPhoneInputFormatter(),
+                    ...widget.inputFormatters,
+                  ],
+                  onChanged: widget.onChanged,
+                  style: theme.textTheme.titleMedium,
+                  decoration: InputDecoration(
+                    hintText: widget.hintText,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 16,
+                    ),
+                    border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
+                    disabledBorder: InputBorder.none,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/phone_entry_screen.dart
+++ b/lib/features/auth/presentation/phone_entry_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:onebytwo/app/theme.dart';
 import 'package:onebytwo/core/widgets/india_phone_input_formatter.dart';
+import 'package:onebytwo/core/widgets/inputs/obt_locked_phone_field.dart';
 import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/auth/application/phone_entry_controller.dart';
 import 'package:onebytwo/features/auth/data/user_repository.dart';
@@ -116,94 +117,11 @@ class _PhoneEntryScreenState extends ConsumerState<PhoneEntryScreen> {
               const SizedBox(height: 32),
 
               // Phone input row.
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Locked +91 prefix.
-                  Semantics(
-                    label: 'Country code, India, plus 91',
-                    excludeSemantics: true,
-                    child: Container(
-                      height: 56,
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      decoration: BoxDecoration(
-                        color: colorScheme.surfaceContainerHighest,
-                        borderRadius: const BorderRadius.only(
-                          topLeft: Radius.circular(AppTheme.radiusChipInput),
-                          bottomLeft: Radius.circular(AppTheme.radiusChipInput),
-                        ),
-                        border: Border.all(color: colorScheme.outline),
-                      ),
-                      alignment: Alignment.center,
-                      child: Text(
-                        '+91',
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          color: colorScheme.onSurface,
-                        ),
-                      ),
-                    ),
-                  ),
-
-                  // Phone number text field.
-                  Expanded(
-                    child: SizedBox(
-                      height: 56,
-                      child: TextField(
-                        enabled: !state.isLoading,
-                        decoration: InputDecoration(
-                          hintText: 'Enter mobile number',
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 16,
-                          ),
-                          border: OutlineInputBorder(
-                            borderRadius: const BorderRadius.only(
-                              topRight: Radius.circular(
-                                AppTheme.radiusChipInput,
-                              ),
-                              bottomRight: Radius.circular(
-                                AppTheme.radiusChipInput,
-                              ),
-                            ),
-                            borderSide: BorderSide(color: colorScheme.outline),
-                          ),
-                          enabledBorder: OutlineInputBorder(
-                            borderRadius: const BorderRadius.only(
-                              topRight: Radius.circular(
-                                AppTheme.radiusChipInput,
-                              ),
-                              bottomRight: Radius.circular(
-                                AppTheme.radiusChipInput,
-                              ),
-                            ),
-                            borderSide: BorderSide(color: colorScheme.outline),
-                          ),
-                          focusedBorder: OutlineInputBorder(
-                            borderRadius: const BorderRadius.only(
-                              topRight: Radius.circular(
-                                AppTheme.radiusChipInput,
-                              ),
-                              bottomRight: Radius.circular(
-                                AppTheme.radiusChipInput,
-                              ),
-                            ),
-                            borderSide: BorderSide(
-                              color: colorScheme.primary,
-                              width: 2,
-                            ),
-                          ),
-                        ),
-                        keyboardType: TextInputType.phone,
-                        inputFormatters: [
-                          IndianPhoneInputFormatter(),
-                          IndianPhoneDisplayFormatter(),
-                        ],
-                        onChanged: controller.updatePhoneNumber,
-                        style: theme.textTheme.titleMedium,
-                      ),
-                    ),
-                  ),
-                ],
+              OBTLockedPhoneField(
+                enabled: !state.isLoading,
+                hasError: state.validationError != null,
+                inputFormatters: [IndianPhoneDisplayFormatter()],
+                onChanged: controller.updatePhoneNumber,
               ),
 
               // Error text.

--- a/lib/features/friends/presentation/widgets/manual_phone_entry_tab.dart
+++ b/lib/features/friends/presentation/widgets/manual_phone_entry_tab.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:onebytwo/app/theme.dart';
 import 'package:onebytwo/core/theme/obt_colors.dart';
 import 'package:onebytwo/core/validators.dart';
-import 'package:onebytwo/core/widgets/india_phone_input_formatter.dart';
+import 'package:onebytwo/core/widgets/inputs/obt_locked_phone_field.dart';
 import 'package:onebytwo/features/auth/application/analytics_provider.dart';
 import 'package:onebytwo/features/friends/domain/selected_contact.dart';
 
@@ -101,84 +100,11 @@ class _ManualPhoneEntryTabState extends State<ManualPhoneEntryTab> {
           const SizedBox(height: 24),
 
           // Phone input row: locked +91 prefix + text field.
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Locked +91 prefix container.
-              Container(
-                height: 56,
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                decoration: BoxDecoration(
-                  color: colorScheme.surfaceContainerHighest,
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(AppTheme.radiusChipInput),
-                    bottomLeft: Radius.circular(AppTheme.radiusChipInput),
-                  ),
-                  border: Border.all(color: colorScheme.outline),
-                ),
-                alignment: Alignment.center,
-                child: Text(
-                  '+91',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    color: colorScheme.onSurface,
-                  ),
-                ),
-              ),
-
-              // Phone number text field.
-              Expanded(
-                child: SizedBox(
-                  height: 56,
-                  child: TextField(
-                    controller: _controller,
-                    keyboardType: TextInputType.phone,
-                    inputFormatters: [
-                      IndianPhoneInputFormatter(),
-                      FilteringTextInputFormatter.digitsOnly,
-                    ],
-                    onChanged: (_) => setState(() {}),
-                    decoration: InputDecoration(
-                      hintText: 'Enter mobile number',
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 16,
-                      ),
-                      border: OutlineInputBorder(
-                        borderRadius: const BorderRadius.only(
-                          topRight: Radius.circular(AppTheme.radiusChipInput),
-                          bottomRight: Radius.circular(
-                            AppTheme.radiusChipInput,
-                          ),
-                        ),
-                        borderSide: BorderSide(color: colorScheme.outline),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: const BorderRadius.only(
-                          topRight: Radius.circular(AppTheme.radiusChipInput),
-                          bottomRight: Radius.circular(
-                            AppTheme.radiusChipInput,
-                          ),
-                        ),
-                        borderSide: BorderSide(color: colorScheme.outline),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: const BorderRadius.only(
-                          topRight: Radius.circular(AppTheme.radiusChipInput),
-                          bottomRight: Radius.circular(
-                            AppTheme.radiusChipInput,
-                          ),
-                        ),
-                        borderSide: BorderSide(
-                          color: colorScheme.primary,
-                          width: 2,
-                        ),
-                      ),
-                    ),
-                    style: theme.textTheme.titleMedium,
-                  ),
-                ),
-              ),
-            ],
+          OBTLockedPhoneField(
+            controller: _controller,
+            hasError: _validationError != null,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            onChanged: (_) => setState(() {}),
           ),
 
           // Validation error text.

--- a/lib/features/profile/presentation/change_phone_screen.dart
+++ b/lib/features/profile/presentation/change_phone_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:onebytwo/app/theme.dart';
 import 'package:onebytwo/core/theme/obt_colors.dart';
-import 'package:onebytwo/core/widgets/india_phone_input_formatter.dart';
+import 'package:onebytwo/core/widgets/inputs/obt_locked_phone_field.dart';
 import 'package:onebytwo/features/auth/presentation/widgets/otp_input.dart';
 import 'package:onebytwo/features/profile/application/change_phone_controller.dart';
 
@@ -224,63 +224,11 @@ class _ChangePhoneScreenState extends ConsumerState<ChangePhoneScreen> {
     ChangePhoneState state,
     ChangePhoneController controller,
   ) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Semantics(
-          label: 'Country code, India, plus 91',
-          excludeSemantics: true,
-          child: Container(
-            height: 56,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            decoration: BoxDecoration(
-              color: colorScheme.surfaceContainerHighest,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(AppTheme.radiusChipInput),
-                bottomLeft: Radius.circular(AppTheme.radiusChipInput),
-              ),
-              border: Border.all(color: colorScheme.outline),
-            ),
-            alignment: Alignment.center,
-            child: Text(
-              '+91',
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: colorScheme.onSurface,
-              ),
-            ),
-          ),
-        ),
-        Expanded(
-          child: SizedBox(
-            height: 56,
-            child: TextField(
-              enabled: !state.isLoading,
-              decoration: const InputDecoration(
-                hintText: 'Enter new mobile number',
-                contentPadding: EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 16,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.only(
-                    topRight: Radius.circular(AppTheme.radiusChipInput),
-                    bottomRight: Radius.circular(AppTheme.radiusChipInput),
-                  ),
-                ),
-              ),
-              keyboardType: TextInputType.phone,
-              inputFormatters: [
-                IndianPhoneInputFormatter(),
-                FilteringTextInputFormatter.digitsOnly,
-              ],
-              onChanged: controller.updateNewPhone,
-              style: theme.textTheme.titleMedium,
-            ),
-          ),
-        ),
-      ],
+    return OBTLockedPhoneField(
+      enabled: !state.isLoading,
+      hintText: 'Enter new mobile number',
+      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+      onChanged: controller.updateNewPhone,
     );
   }
 

--- a/test/core/widgets/inputs/obt_locked_phone_field_test.dart
+++ b/test/core/widgets/inputs/obt_locked_phone_field_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:onebytwo/core/widgets/inputs/obt_locked_phone_field.dart';
+
+void main() {
+  Widget host(Widget child) => MaterialApp(
+    home: Scaffold(
+      body: Padding(padding: const EdgeInsets.all(16), child: child),
+    ),
+  );
+
+  group('OBTLockedPhoneField', () {
+    testWidgets('renders +91 and an editable field as one bordered control', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(const OBTLockedPhoneField()));
+      expect(find.text('+91'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+
+      // The inner TextField carries no border of its own: a single outer
+      // frame wraps both halves so their edges stay aligned (#150).
+      final tf = tester.widget<TextField>(find.byType(TextField));
+      expect(tf.decoration!.border, InputBorder.none);
+      expect(tf.decoration!.enabledBorder, InputBorder.none);
+      expect(tf.decoration!.focusedBorder, InputBorder.none);
+    });
+
+    testWidgets('the +91 chip and the input share top and bottom edges', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(const OBTLockedPhoneField()));
+      final prefixRect = tester.getRect(
+        find.ancestor(of: find.text('+91'), matching: find.byType(Container)),
+      );
+      final fieldRect = tester.getRect(find.byType(TextField));
+      expect(prefixRect.top, moreOrLessEquals(fieldRect.top, epsilon: 0.5));
+      expect(
+        prefixRect.bottom,
+        moreOrLessEquals(fieldRect.bottom, epsilon: 0.5),
+      );
+    });
+
+    testWidgets('applies the Indian formatter plus caller formatters', (
+      tester,
+    ) async {
+      final controller = TextEditingController();
+      String? last;
+      await tester.pumpWidget(
+        host(
+          OBTLockedPhoneField(
+            controller: controller,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            onChanged: (value) => last = value,
+          ),
+        ),
+      );
+      await tester.enterText(find.byType(TextField), '98abc7654321099');
+      final digits = controller.text.replaceAll(RegExp(r'\D'), '');
+      expect(digits.length, lessThanOrEqualTo(10));
+      expect(last, isNotNull);
+      controller.dispose();
+    });
+
+    testWidgets('hasError tints the outer frame with the error colour', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(const OBTLockedPhoneField(hasError: true)));
+      final context = tester.element(find.byType(OBTLockedPhoneField));
+      final errorColor = Theme.of(context).colorScheme.error;
+      final borders = tester
+          .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+          .map((d) => d.decoration)
+          .whereType<BoxDecoration>()
+          .where((b) => b.border is Border)
+          .map((b) => (b.border! as Border).top.color);
+      expect(borders, contains(errorColor));
+    });
+  });
+}


### PR DESCRIPTION
Closes #150.

## What
Extracts a shared **`OBTLockedPhoneField`** and migrates the three copies of
the locked-`+91` phone field (auth phone entry, add-friend manual tab,
change-phone) to it, so the `+91` prefix and the number input always render as
**one unified, equal-height control** per the `Phase3a - Auth` handoff.

## Why (the bug, #150)
The `+91` box (a `Container` with `Border.all`, fills 56px) sat next to a
Material `TextField` whose `OutlineInputBorder` **cannot stretch** to match an
adjacent fixed-height box. With the real Hanken font metrics the painted
outline drifted a few logical pixels, so the two halves had mismatched
heights/edges. This only shows on device / in goldens — widget tests use a
fallback font and measured aligned, which is why it slipped through.

## How
One outer rounded border wraps a tinted `+91` segment (1px divider) and a
**borderless** `TextField`; `IntrinsicHeight` + `stretch` keeps both halves at
one shared height. Focus = marigold cursor + marigold outer border.

Verified on an iPhone 17 Pro simulator: prefix and input now measure identical
top/bottom (0px delta), where they previously drifted ~4px.

## Invariants
Display/layout only — all four hold. Locked `+91` (India-only, SRS 1.3) and the
`IndianPhoneInputFormatter` pipeline are preserved. No money, projection,
share-sheet, or Firebase-project change.

## Tests / goldens
- New `test/core/widgets/inputs/obt_locked_phone_field_test.dart` pins the
  single-frame structure (TextField has `InputBorder.none`), edge alignment,
  the formatter pipeline, and the error tint.
- auth (227), friends (330), profile (200) suites pass locally.
- Goldens (**dc04** auth, **dc10** profile, friends add-friend) are being
  regenerated on **ubuntu** via the `golden-refresh` workflow; the reviewed
  PNGs will be committed to this branch.

Found during the Sprint-3 manual-validation pass.
